### PR TITLE
add sqlite model base

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -28,3 +28,6 @@ Provide small, cross-platform helpers for creating directories and files safely 
 
 ## Non-goals
 - No changes to `.env`, Docker, or dependency installation.
+
+## Follow-up
+- Reconcile `ModelSQLite` with the upstream `develation` SQLite fixes after the dependency update lands in BlueCore so duplicated local behavior can be reduced or removed intentionally.

--- a/SPEC.md
+++ b/SPEC.md
@@ -7,12 +7,15 @@ Provide small, cross-platform helpers for creating directories and files safely 
 - `BlueFission\Utils\Path::ensureDir($path, $mode = 0775, $recursive = true)` creates a directory when missing and returns a normalized path.
 - `BlueFission\Utils\File::ensureFile($path, $contents = '', $overwrite = false)` creates a file and its parent directories when needed.
 - `BlueFission\Utils\File::writeAtomic($path, $contents)` writes via a temp file and renames into place.
+- `BlueFission\BlueCore\Model\ModelSQLite` provides a first-party SQLite-backed BlueCore model base analogous to `ModelSql`.
 - Tests for directory creation, file creation, overwrite behavior, and atomic writes.
+- Tests for SQLite-backed model write/read and materialized result sets.
 
 ## User Stories
 - As a CLI tool, I can ensure a cache directory exists without duplicating mkdir logic.
 - As a generator, I can write a file once and avoid accidental overwrites unless I opt in.
 - As a service, I can write files atomically to reduce partial-write risk.
+- As an app using local agent memory or planning state, I can inherit from a BlueCore SQLite model base instead of wiring raw SQLite storage in each model.
 
 ## Acceptance Criteria
 - `ensureDir` returns a normalized path and creates the directory if missing.
@@ -20,6 +23,8 @@ Provide small, cross-platform helpers for creating directories and files safely 
 - `ensureFile` creates parent directories and writes contents when missing.
 - `ensureFile` does not overwrite existing files unless `$overwrite` is true.
 - `writeAtomic` results in the target file containing the requested contents.
+- `ModelSQLite` can create a table, write a row, read it back, and expose a `query()` string.
+- `ModelSQLite::result()` returns a materialized collection of rows rather than a raw `SQLite3Result`.
 
 ## Non-goals
 - No changes to `.env`, Docker, or dependency installation.

--- a/src/BlueCore/Model/BaseModel.php
+++ b/src/BlueCore/Model/BaseModel.php
@@ -66,6 +66,7 @@ class BaseModel extends Obj implements IData, JsonSerializable {
 		$this->assign($values);
         // $this->_elasticsearchClient = ClientBuilder::fromConfig(\App::instance()->configuration('database')['elasticsearch'];
 		return $this;
+	}
 
 	/**
 	 * Generates a timestamp for the data.
@@ -77,7 +78,7 @@ class BaseModel extends Obj implements IData, JsonSerializable {
 	{
 		$id = $this->_idField;
 
-		if (!$this->_dataObject->$id) {
+		if (!$this->_dataObject->field($id)) {
 			$this->created = date($this->_timestampFormat);
 		}
 		$this->updated = date($this->_timestampFormat);
@@ -230,7 +231,7 @@ class BaseModel extends Obj implements IData, JsonSerializable {
 	 */
 	public function id() {
 		if($this->_idField) {
-			return $this->data()[$this->_idField];
+			return $this->data()[$this->_idField] ?? null;
 		}
 		return 0;
 	}

--- a/src/BlueCore/Model/ModelSQLite.php
+++ b/src/BlueCore/Model/ModelSQLite.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace BlueFission\BlueCore\Model;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+
+class ModelSQLite extends BaseModel
+{
+    protected $_database = '';
+    protected $_table = '';
+    protected $_fields = [];
+    protected $_columnTypes = [];
+    protected $_ignore_null = true;
+    protected $_save_related_tables = false;
+    protected $_key = '';
+
+    public function __construct($database = null)
+    {
+        if ($database !== null) {
+            $this->_database = $database;
+        }
+
+        $this->_type = get_class($this);
+        $this->_dataObject = new SQLiteModelStore([
+            'location' => $this->_database,
+            'name' => $this->_table,
+            'fields' => $this->_fields,
+            'key' => $this->resolvePrimaryKey(),
+            'column_types' => $this->_columnTypes,
+        ]);
+        $this->_dataObject->activate();
+        $this->init();
+        $this->_idField = $this->_dataObject->primary();
+        $this->clear();
+    }
+
+    protected function init()
+    {
+    }
+
+    protected function resolvePrimaryKey(): string
+    {
+        if ($this->_key) {
+            return $this->_key;
+        }
+
+        foreach ($this->_fields as $field) {
+            if (strtolower(substr($field, -2)) === 'id') {
+                return $field;
+            }
+        }
+
+        return $this->_idField;
+    }
+
+    public function field(string $field, $value = null): mixed
+    {
+        if (!Arr::hasKey($this->_dataObject->data(), $field) && !Arr::has($this->_fields, $field)) {
+            return null;
+        }
+
+        if (func_num_args() > 1) {
+            return $this->_dataObject->field($field, $value);
+        }
+
+        return $this->_dataObject->field($field);
+    }
+
+    public function write($values = null): Obj
+    {
+        $forceCreatedTimestamp = false;
+        $forceUpdatedTimestamp = false;
+        $id = $this->_idField;
+
+        if (
+            !in_array('created', $this->_fields, true) &&
+            !$this->_save_related_tables &&
+            (
+                !$this->_dataObject->field($id) ||
+                (
+                    isset($values) &&
+                    !(is_array($values) && isset($values[$id])) &&
+                    !(is_object($values) && isset($values->$id))
+                )
+            )
+        ) {
+            $this->_fields[] = 'created';
+            $forceCreatedTimestamp = true;
+        }
+
+        if (!in_array('updated', $this->_fields, true) && !$this->_save_related_tables) {
+            $this->_fields[] = 'updated';
+            $forceUpdatedTimestamp = true;
+        }
+
+        $this->_dataObject->config('fields', $this->_fields);
+        $result = parent::write($values);
+
+        if ($forceCreatedTimestamp) {
+            $key = array_search('created', $this->_fields, true);
+            if ($key !== false) {
+                unset($this->_fields[$key]);
+            }
+        }
+
+        if ($forceUpdatedTimestamp) {
+            $key = array_search('updated', $this->_fields, true);
+            if ($key !== false) {
+                unset($this->_fields[$key]);
+            }
+        }
+
+        $this->_fields = array_values($this->_fields);
+        $this->_dataObject->config('fields', $this->_fields);
+
+        return $result;
+    }
+
+    public function condition($field, $condition = '', $value = '')
+    {
+        $this->_dataObject->condition($field, $condition, $value);
+
+        return $this;
+    }
+
+    public function result()
+    {
+        return $this->_dataObject->result();
+    }
+
+    public function query()
+    {
+        return $this->_dataObject->query();
+    }
+}

--- a/src/BlueCore/Model/SQLiteModelStore.php
+++ b/src/BlueCore/Model/SQLiteModelStore.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace BlueFission\BlueCore\Model;
+
+use BlueFission\Collections\Group;
+
+class SQLiteModelStore
+{
+    protected $_config = [
+        'location' => '',
+        'name' => '',
+        'fields' => [],
+        'key' => 'id',
+        'column_types' => [],
+    ];
+
+    protected $_data = [];
+    protected $_rows = [];
+    protected $_query = '';
+    protected $_status = null;
+    protected $_conditions = [];
+    protected $_order = [];
+
+    public function __construct(array $config = [])
+    {
+        $this->config($config);
+
+        foreach ((array)$this->config('fields') as $field) {
+            $this->_data[$field] = null;
+        }
+    }
+
+    public function activate()
+    {
+        return $this;
+    }
+
+    public function config($config = null, $value = null)
+    {
+        if ($config === null) {
+            return $this->_config;
+        }
+
+        if (is_array($config)) {
+            foreach ($config as $key => $item) {
+                if (array_key_exists($key, $this->_config)) {
+                    $this->_config[$key] = $item;
+                }
+            }
+
+            return $this;
+        }
+
+        if (func_num_args() === 1) {
+            return $this->_config[$config] ?? null;
+        }
+
+        if (array_key_exists($config, $this->_config)) {
+            $this->_config[$config] = $value;
+        }
+
+        return $this;
+    }
+
+    public function field(string $field, $value = null): mixed
+    {
+        if (func_num_args() > 1) {
+            $this->_data[$field] = $value;
+
+            return $this;
+        }
+
+        return $this->_data[$field] ?? null;
+    }
+
+    public function data(): array
+    {
+        return $this->_data;
+    }
+
+    public function clear()
+    {
+        foreach (array_keys($this->_data) as $field) {
+            $this->_data[$field] = null;
+        }
+
+        return $this;
+    }
+
+    public function condition($field, $condition = '', $value = '')
+    {
+        $condition = $condition ?: '=';
+        $this->_conditions[$field] = $condition;
+
+        if (func_num_args() > 2) {
+            $this->_data[$field] = $value;
+        }
+
+        return $this;
+    }
+
+    public function order($field, $direction = 'ASC')
+    {
+        $this->_order[$field] = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
+
+        return $this;
+    }
+
+    public function write()
+    {
+        $db = $this->open();
+        $this->ensureSchema($db);
+
+        $key = $this->primary();
+        $identifier = $key ? ($this->_data[$key] ?? null) : null;
+        $record = $this->writableData();
+
+        if ($identifier !== null && $this->exists($db, $identifier)) {
+            $assignments = [];
+            foreach (array_keys($record) as $field) {
+                if ($field === $key) {
+                    continue;
+                }
+                $assignments[] = sprintf('`%s` = :%s', $field, $field);
+            }
+
+            $this->_query = sprintf(
+                'UPDATE `%s` SET %s WHERE `%s` = :__key',
+                $this->config('name'),
+                implode(', ', $assignments),
+                $key
+            );
+
+            $statement = $db->prepare($this->_query);
+            foreach ($record as $field => $value) {
+                if ($field === $key) {
+                    continue;
+                }
+                $statement->bindValue(':' . $field, $value, $this->sqliteType($value));
+            }
+            $statement->bindValue(':__key', $identifier, SQLITE3_INTEGER);
+            $result = $statement->execute();
+        } else {
+            $columns = [];
+            $placeholders = [];
+
+            foreach ($record as $field => $value) {
+                if ($field === $key && $value === null) {
+                    continue;
+                }
+
+                $columns[] = sprintf('`%s`', $field);
+                $placeholders[] = ':' . $field;
+            }
+
+            $this->_query = sprintf(
+                'INSERT INTO `%s` (%s) VALUES (%s)',
+                $this->config('name'),
+                implode(', ', $columns),
+                implode(', ', $placeholders)
+            );
+
+            $statement = $db->prepare($this->_query);
+            foreach ($record as $field => $value) {
+                if ($field === $key && $value === null) {
+                    continue;
+                }
+                $statement->bindValue(':' . $field, $value, $this->sqliteType($value));
+            }
+            $result = $statement->execute();
+
+            if ($result && $key && $identifier === null) {
+                $this->_data[$key] = $db->lastInsertRowID();
+            }
+        }
+
+        $this->_status = $result ? 'Success.' : 'Failed.';
+        if ($result instanceof \SQLite3Result) {
+            $result->finalize();
+        }
+
+        $db->close();
+
+        return $this;
+    }
+
+    public function read()
+    {
+        $db = $this->open();
+        $this->ensureSchema($db);
+
+        $where = [];
+        foreach ($this->_data as $field => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $operator = $this->_conditions[$field] ?? '=';
+            $where[] = sprintf('`%s` %s :%s', $field, $operator, $field);
+        }
+
+        $this->_query = sprintf('SELECT * FROM `%s`', $this->config('name'));
+        if ($where) {
+            $this->_query .= ' WHERE ' . implode(' AND ', $where);
+        }
+        if ($this->_order) {
+            $sort = [];
+            foreach ($this->_order as $field => $direction) {
+                $sort[] = sprintf('`%s` %s', $field, $direction);
+            }
+            $this->_query .= ' ORDER BY ' . implode(', ', $sort);
+        }
+
+        $statement = $db->prepare($this->_query);
+        foreach ($this->_data as $field => $value) {
+            if ($value === null) {
+                continue;
+            }
+            $statement->bindValue(':' . $field, $value, $this->sqliteType($value));
+        }
+
+        $result = $statement->execute();
+        $rows = [];
+        while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+            $rows[] = $row;
+        }
+
+        $this->_rows = $rows;
+        $this->_status = 'Success.';
+
+        if ($rows) {
+            foreach ($rows[0] as $field => $value) {
+                $this->_data[$field] = $value;
+            }
+        }
+
+        $result->finalize();
+        $db->close();
+
+        return $this;
+    }
+
+    public function delete()
+    {
+        $db = $this->open();
+        $key = $this->primary();
+        $identifier = $key ? ($this->_data[$key] ?? null) : null;
+
+        if ($key && $identifier !== null) {
+            $this->_query = sprintf('DELETE FROM `%s` WHERE `%s` = :__key', $this->config('name'), $key);
+            $statement = $db->prepare($this->_query);
+            $statement->bindValue(':__key', $identifier, SQLITE3_INTEGER);
+            $result = $statement->execute();
+            $this->_status = $result ? 'Success.' : 'Failed.';
+            if ($result instanceof \SQLite3Result) {
+                $result->finalize();
+            }
+        }
+
+        $db->close();
+
+        return $this;
+    }
+
+    public function result()
+    {
+        return new Group($this->_rows);
+    }
+
+    public function contents(): mixed
+    {
+        return $this->_rows ?: $this->_data;
+    }
+
+    public function query(): string
+    {
+        return $this->_query;
+    }
+
+    public function status($message = null): mixed
+    {
+        if (func_num_args() === 0) {
+            return $this->_status;
+        }
+
+        $this->_status = $message;
+
+        return $this;
+    }
+
+    public function primary(): string
+    {
+        return $this->config('key');
+    }
+
+    protected function open(): \SQLite3
+    {
+        $database = $this->config('location') ?: ':memory:';
+
+        return new \SQLite3($database);
+    }
+
+    protected function ensureSchema(\SQLite3 $db): void
+    {
+        $columns = [];
+        $key = $this->primary();
+        $types = (array)$this->config('column_types');
+
+        foreach ((array)$this->config('fields') as $field) {
+            $type = $types[$field] ?? null;
+            if (!$type) {
+                $type = $field === $key
+                    ? 'INTEGER PRIMARY KEY AUTOINCREMENT'
+                    : (in_array($field, ['created', 'updated', 'date'], true) ? 'DATETIME' : 'TEXT');
+            }
+            $columns[] = sprintf('`%s` %s', $field, $type);
+        }
+
+        $query = sprintf(
+            'CREATE TABLE IF NOT EXISTS `%s` (%s)',
+            $this->config('name'),
+            implode(', ', $columns)
+        );
+
+        $this->_query = $query;
+        $db->exec($query);
+    }
+
+    protected function exists(\SQLite3 $db, $identifier): bool
+    {
+        $query = sprintf('SELECT 1 FROM `%s` WHERE `%s` = :__key LIMIT 1', $this->config('name'), $this->primary());
+        $statement = $db->prepare($query);
+        $statement->bindValue(':__key', $identifier, SQLITE3_INTEGER);
+        $result = $statement->execute();
+        $row = $result ? $result->fetchArray(SQLITE3_ASSOC) : false;
+        if ($result instanceof \SQLite3Result) {
+            $result->finalize();
+        }
+
+        return (bool)$row;
+    }
+
+    protected function writableData(): array
+    {
+        $record = [];
+
+        foreach ((array)$this->config('fields') as $field) {
+            $record[$field] = $this->_data[$field] ?? null;
+        }
+
+        return $record;
+    }
+
+    protected function sqliteType($value): int
+    {
+        if (is_int($value)) {
+            return SQLITE3_INTEGER;
+        }
+
+        if (is_float($value)) {
+            return SQLITE3_FLOAT;
+        }
+
+        if ($value === null) {
+            return SQLITE3_NULL;
+        }
+
+        return SQLITE3_TEXT;
+    }
+}

--- a/tests/BlueCore/Model/ModelSQLiteTest.php
+++ b/tests/BlueCore/Model/ModelSQLiteTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Model;
+
+use BlueFission\BlueCore\Model\ModelSQLite;
+use PHPUnit\Framework\TestCase;
+
+class ModelSQLiteTest extends TestCase
+{
+    private $database;
+
+    protected function setUp(): void
+    {
+        $this->database = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-model-' . uniqid('', true) . '.sqlite';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->database)) {
+            unlink($this->database);
+        }
+    }
+
+    public function testWriteAndReadUsingSQLiteModelBase(): void
+    {
+        $model = new TestSQLiteModel($this->database);
+        $model->write(['name' => 'alpha', 'status' => 'active']);
+
+        $this->assertGreaterThan(0, $model->id());
+        $this->assertStringContainsString('INSERT', strtoupper($model->query()));
+
+        $reader = new TestSQLiteModel($this->database);
+        $reader->field('name', 'alpha');
+        $reader->read();
+
+        $this->assertSame('alpha', $reader->field('name'));
+        $this->assertSame('active', $reader->field('status'));
+        $this->assertNotEmpty($reader->field('created'));
+        $this->assertNotEmpty($reader->field('updated'));
+    }
+
+    public function testResultReturnsMaterializedRows(): void
+    {
+        $writer = new TestSQLiteModel($this->database);
+        $writer->write(['name' => 'first', 'status' => 'active']);
+        $writer->clear();
+        $writer->write(['name' => 'second', 'status' => 'draft']);
+
+        $reader = new TestSQLiteModel($this->database);
+        $reader->read();
+        $rows = $reader->result()->toArray();
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('first', $rows[0]['name']);
+        $this->assertSame('second', $rows[1]['name']);
+    }
+}
+
+class TestSQLiteModel extends ModelSQLite
+{
+    protected $_table = 'test_records';
+    protected $_fields = [
+        'record_id',
+        'name',
+        'status',
+    ];
+}


### PR DESCRIPTION
## Intent summary
- add a first-party SQLite-backed BlueCore model base for local planning and memory use cases
- keep the model surface close to ModelSql while avoiding current upstream SQLite storage defects

## User stories / acceptance criteria
- as an app using local SQLite persistence, i can inherit from a BlueCore model base instead of wiring storage manually
- ModelSQLite can create a table, write a row, read it back, and expose query/result helpers
- ModelSQLite::result returns a materialized collection of rows

## Key files changed
- src/BlueCore/Model/ModelSQLite.php
- src/BlueCore/Model/SQLiteModelStore.php
- src/BlueCore/Model/BaseModel.php
- tests/BlueCore/Model/ModelSQLiteTest.php
- SPEC.md

## How to test
- vendor/bin/phpunit --do-not-cache-result tests
- vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Model/ModelSQLiteTest.php

## QA checklist
- [x] tests passing locally
- [x] no .env changes
- [x] no dependency installation performed
- [x] upstream SQLite defects reported to develation through Keryx

## Approval conditions
- maintainer agrees with the BlueCore-owned SQLite store approach
- dependency bump to develation can be handled separately
- reconcile BlueCore ModelSQLite with the newer develation SQLite fixes after the dependency update lands here