### PR TITLE
Add maintained package examples

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "bluefission/develation",
-            "version": "v1.3.31-alpha",
+            "version": "v1.3.34-alpha",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "4afc6d5713f35ab46e790e39a9f0a23902f1de82"
+                "reference": "1bd1b9518b713b200288efa205a4f7d54347c066"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/4afc6d5713f35ab46e790e39a9f0a23902f1de82",
-                "reference": "4afc6d5713f35ab46e790e39a9f0a23902f1de82",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/1bd1b9518b713b200288efa205a4f7d54347c066",
+                "reference": "1bd1b9518b713b200288efa205a4f7d54347c066",
                 "shasum": ""
             },
             "require": {
@@ -70,7 +70,7 @@
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-05-20T18:21:05+00:00"
+            "time": "2026-06-22T02:15:04+00:00"
         },
         {
             "name": "cboden/ratchet",
@@ -288,28 +288,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -347,7 +348,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -357,13 +358,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -476,23 +473,25 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.1",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -573,7 +572,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -589,7 +588,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T09:27:36+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -857,16 +856,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.7.0",
+            "version": "5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8"
+                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
-                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/01964d92536edf1a3a874b9580a52824bebf6fbb",
+                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb",
                 "shasum": ""
             },
             "require": {
@@ -960,9 +959,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.7.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.8.0"
             },
-            "time": "2026-04-20T02:42:17+00:00"
+            "time": "2026-06-07T03:51:10+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -1875,16 +1874,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.35",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "cffffd0a2c037117b742b4f8b379a22a2a33f6d2"
+                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/cffffd0a2c037117b742b4f8b379a22a2a33f6d2",
-                "reference": "cffffd0a2c037117b742b4f8b379a22a2a33f6d2",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/48d76c29a67a301e0f7779a512bf76417395ffef",
+                "reference": "48d76c29a67a301e0f7779a512bf76417395ffef",
                 "shasum": ""
             },
             "require": {
@@ -1932,7 +1931,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.35"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -1952,7 +1951,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T11:15:58+00:00"
+            "time": "2026-05-24T10:54:17+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2039,16 +2038,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -2100,7 +2099,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2120,7 +2119,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -2208,16 +2207,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -2264,7 +2263,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2284,20 +2283,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.40",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "0cd0d2fb05382c95dff6b33c51a7c96cbdbc136d"
+                "reference": "af04c79671fd8df0805a44c83fa2b0ba56c8329e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/0cd0d2fb05382c95dff6b33c51a7c96cbdbc136d",
-                "reference": "0cd0d2fb05382c95dff6b33c51a7c96cbdbc136d",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/af04c79671fd8df0805a44c83fa2b0ba56c8329e",
+                "reference": "af04c79671fd8df0805a44c83fa2b0ba56c8329e",
                 "shasum": ""
             },
             "require": {
@@ -2351,7 +2350,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.40"
+                "source": "https://github.com/symfony/routing/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -2371,7 +2370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-19T20:33:22+00:00"
+            "time": "2026-05-24T11:18:16+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# BlueCore Examples
+
+These examples are small, runnable scripts that demonstrate the current package APIs without optional services or application boot state. They are intended to show package-owned patterns for contributors and integrators while keeping runtime side effects isolated to the system temporary directory.
+
+Run an example from the package root after installing dependencies:
+
+```bash
+php examples/file-path-utilities.php
+php examples/sqlite-model.php
+php examples/generator-factory.php
+php examples/menu-composition.php
+```
+
+The normal CI lint command also parses the examples:
+
+```bash
+composer lint
+```
+
+## Coverage
+
+- `file-path-utilities.php` shows path normalization, directory creation, safe file creation, and atomic writes through the BlueCore utility facades backed by DevElation primitives.
+- `sqlite-model.php` shows a minimal `ModelSQLite` aggregate with deterministic temporary storage.
+- `generator-factory.php` shows how to inject generation dependencies and request concrete generator types without requiring network-backed AI services.
+- `menu-composition.php` shows menu and nested menu-item composition without requiring theme rendering.

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+use BlueFission\Utils\Path;
+
+function bluecore_example_runtime_path(string $name): string
+{
+    $base = Path::ensureDir(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-examples');
+
+    return Path::ensureDir($base . DIRECTORY_SEPARATOR . $name);
+}
+
+function bluecore_example_json(array $payload): void
+{
+    echo json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+}

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 
+use BlueFission\Arr;
 use BlueFission\Utils\Path;
 
 function bluecore_example_runtime_path(string $name): string
@@ -15,5 +16,5 @@ function bluecore_example_runtime_path(string $name): string
 
 function bluecore_example_json(array $payload): void
 {
-    echo json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    echo Arr::make($payload)->toJson() . PHP_EOL;
 }

--- a/examples/file-path-utilities.php
+++ b/examples/file-path-utilities.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+
+$runtime = bluecore_example_runtime_path('file-path');
+$notesPath = $runtime . DIRECTORY_SEPARATOR . 'notes' . DIRECTORY_SEPARATOR . 'readme.txt';
+
+$createdPath = File::ensureFile($notesPath, "created\n");
+$keptPath = File::ensureFile($notesPath, "ignored\n");
+$keptContents = trim((string)file_get_contents($keptPath));
+
+$writtenPath = File::writeAtomic($notesPath, "updated\n");
+$writtenContents = trim((string)file_get_contents($writtenPath));
+
+bluecore_example_json([
+    'runtime' => Path::normalize($runtime),
+    'file' => Path::normalize($writtenPath),
+    'created' => file_exists($createdPath),
+    'ensure_file_kept_existing_contents' => $keptContents === 'created',
+    'atomic_write_contents' => $writtenContents,
+]);

--- a/examples/file-path-utilities.php
+++ b/examples/file-path-utilities.php
@@ -6,21 +6,22 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
+use BlueFission\Str;
 
 $runtime = bluecore_example_runtime_path('file-path');
-$notesPath = $runtime . DIRECTORY_SEPARATOR . 'notes' . DIRECTORY_SEPARATOR . 'readme.txt';
+$notesPath = $runtime . DIRECTORY_SEPARATOR . 'notes' . DIRECTORY_SEPARATOR . Str::rand('', 10) . '.txt';
 
 $createdPath = File::ensureFile($notesPath, "created\n");
 $keptPath = File::ensureFile($notesPath, "ignored\n");
-$keptContents = trim((string)file_get_contents($keptPath));
+$keptContents = Str::trim(File::readContents($keptPath));
 
 $writtenPath = File::writeAtomic($notesPath, "updated\n");
-$writtenContents = trim((string)file_get_contents($writtenPath));
+$writtenContents = Str::trim(File::readContents($writtenPath));
 
 bluecore_example_json([
     'runtime' => Path::normalize($runtime),
     'file' => Path::normalize($writtenPath),
-    'created' => file_exists($createdPath),
+    'created' => (new File())->exists($createdPath),
     'ensure_file_kept_existing_contents' => $keptContents === 'created',
     'atomic_write_contents' => $writtenContents,
 ]);

--- a/examples/generator-factory.php
+++ b/examples/generator-factory.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+use BlueFission\BlueCore\Generation\GeneratorFactory;
+use BlueFission\BlueCore\Generation\IAICodeGenerator;
+use BlueFission\BlueCore\Generation\IAICopyGenerator;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+
+final class ExampleCodeGenerator implements IAICodeGenerator
+{
+    public function generateCode(string $template, string $userPrompt): ?string
+    {
+        $className = $this->generateClassName($userPrompt) ?? 'GeneratedExample';
+
+        return str_replace('ExampleClass', $className, $template);
+    }
+
+    public function generateClassName(string $userPrompt): ?string
+    {
+        return 'GeneratedReportController';
+    }
+}
+
+final class ExampleCopyGenerator implements IAICopyGenerator
+{
+    public function generateText(string $prompt): ?string
+    {
+        return 'Generated copy for: ' . $prompt;
+    }
+
+    public function generateImage(string $prompt): ?string
+    {
+        return 'image-placeholder:' . sha1($prompt);
+    }
+}
+
+$runtime = bluecore_example_runtime_path('generator-factory');
+$outputPath = Path::ensureDir($runtime . DIRECTORY_SEPARATOR . 'generated');
+$templatePath = File::writeAtomic(
+    $runtime . DIRECTORY_SEPARATOR . 'controller-template.php',
+    "<?php\n\nfinal class ExampleClass\n{\n}\n"
+);
+
+$factory = new GeneratorFactory(new ExampleCodeGenerator(), new ExampleCopyGenerator());
+$config = (object)[
+    'templatePath' => $templatePath,
+    'outputPath' => $outputPath,
+];
+
+$created = [];
+foreach (['controller', 'query', 'repository', 'scaffold', 'valueobject', 'content', 'css', 'template', 'missing'] as $name) {
+    $generator = $factory->create($name, $config);
+    $created[$name] = $generator ? [
+        'class' => get_class($generator),
+        'type' => $generator->getType(),
+    ] : null;
+}
+
+$controller = $factory->create('controller', $config);
+$controllerGenerated = $controller?->generate('ReportController', 'Create a controller for reporting');
+$generatedFile = $outputPath . DIRECTORY_SEPARATOR . 'ReportController.php';
+
+$copy = $factory->create('content', $config)?->generate('copy', 'Report on monthly account activity');
+
+bluecore_example_json([
+    'runtime' => Path::normalize($runtime),
+    'generators' => $created,
+    'controller_generated' => $controllerGenerated === true && file_exists($generatedFile),
+    'controller_file' => Path::normalize($generatedFile),
+    'copy_preview' => $copy,
+]);

--- a/examples/generator-factory.php
+++ b/examples/generator-factory.php
@@ -7,6 +7,8 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
 use BlueFission\BlueCore\Generation\GeneratorFactory;
 use BlueFission\BlueCore\Generation\IAICodeGenerator;
 use BlueFission\BlueCore\Generation\IAICopyGenerator;
+use BlueFission\Str;
+use BlueFission\Val;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 
@@ -16,7 +18,7 @@ final class ExampleCodeGenerator implements IAICodeGenerator
     {
         $className = $this->generateClassName($userPrompt) ?? 'GeneratedExample';
 
-        return str_replace('ExampleClass', $className, $template);
+        return Str::replace($template, 'ExampleClass', $className);
     }
 
     public function generateClassName(string $userPrompt): ?string
@@ -34,7 +36,7 @@ final class ExampleCopyGenerator implements IAICopyGenerator
 
     public function generateImage(string $prompt): ?string
     {
-        return 'image-placeholder:' . sha1($prompt);
+        return 'image-placeholder:' . Str::encrypt($prompt, Str::SHA);
     }
 }
 
@@ -54,7 +56,7 @@ $config = (object)[
 $created = [];
 foreach (['controller', 'query', 'repository', 'scaffold', 'valueobject', 'content', 'css', 'template', 'missing'] as $name) {
     $generator = $factory->create($name, $config);
-    $created[$name] = $generator ? [
+    $created[$name] = Val::isNotNull($generator) ? [
         'class' => get_class($generator),
         'type' => $generator->getType(),
     ] : null;
@@ -69,7 +71,7 @@ $copy = $factory->create('content', $config)?->generate('copy', 'Report on month
 bluecore_example_json([
     'runtime' => Path::normalize($runtime),
     'generators' => $created,
-    'controller_generated' => $controllerGenerated === true && file_exists($generatedFile),
+    'controller_generated' => $controllerGenerated === true && (new File())->exists($generatedFile),
     'controller_file' => Path::normalize($generatedFile),
     'copy_preview' => $copy,
 ]);

--- a/examples/menu-composition.php
+++ b/examples/menu-composition.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+use BlueFission\BlueCore\Menu;
+use BlueFission\BlueCore\MenuItem;
+
+function bluecore_example_menu_payload(Menu $menu): array
+{
+    $items = [];
+
+    foreach ($menu->getItems() as $item) {
+        if ($item instanceof Menu) {
+            $items[] = bluecore_example_menu_payload($item);
+            continue;
+        }
+
+        $items[] = [
+            'type' => 'item',
+            'id' => $item->getId(),
+            'label' => $item->getLabel(),
+            'action' => $item->getAction(),
+            'role' => $item->getRole(),
+            'group' => $item->getGroup(),
+            'permission' => $item->getPermission(),
+        ];
+    }
+
+    return [
+        'type' => 'menu',
+        'id' => $menu->getId(),
+        'label' => $menu->getLabel(),
+        'items' => $items,
+    ];
+}
+
+$workspace = new Menu('Workspace');
+$workspace->addItem(new MenuItem('Dashboard', '/dashboard', 'operator', 'workspace', 'dashboard.view'));
+$workspace->addItem(new MenuItem('Tasks', '/tasks', 'operator', 'workspace', 'tasks.manage'));
+
+$reports = new Menu('Reports');
+$reports->addItem(new MenuItem('Activity', '/reports/activity', 'analyst', 'reports', 'reports.view'));
+$reports->addItem(new MenuItem('Exports', '/reports/exports', 'analyst', 'reports', 'reports.export'));
+
+$workspace->addItem($reports);
+
+bluecore_example_json(bluecore_example_menu_payload($workspace));

--- a/examples/sqlite-model.php
+++ b/examples/sqlite-model.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use BlueFission\BlueCore\Model\ModelSQLite;
+use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Utils\Path;
 
 final class ExampleTaskModel extends ModelSQLite
@@ -18,11 +20,7 @@ final class ExampleTaskModel extends ModelSQLite
 }
 
 $runtime = bluecore_example_runtime_path('sqlite-model');
-$database = $runtime . DIRECTORY_SEPARATOR . 'tasks.sqlite';
-
-if (file_exists($database)) {
-    unlink($database);
-}
+$database = $runtime . DIRECTORY_SEPARATOR . 'tasks-' . Str::rand('', 10) . '.sqlite';
 
 $tasks = new ExampleTaskModel($database);
 $tasks->write([
@@ -39,13 +37,13 @@ $tasks->write([
 $reader = new ExampleTaskModel($database);
 $reader->read();
 
-$rows = array_map(static function (array $row): array {
+$rows = Arr::make($reader->result()->toArray())->map(static function (array $row): array {
     return [
         'task_id' => (int)$row['task_id'],
         'title' => $row['title'],
         'status' => $row['status'],
     ];
-}, $reader->result()->toArray());
+})->toArray();
 
 bluecore_example_json([
     'database' => Path::normalize($database),

--- a/examples/sqlite-model.php
+++ b/examples/sqlite-model.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+use BlueFission\BlueCore\Model\ModelSQLite;
+use BlueFission\Utils\Path;
+
+final class ExampleTaskModel extends ModelSQLite
+{
+    protected $_table = 'example_tasks';
+    protected $_fields = [
+        'task_id',
+        'title',
+        'status',
+    ];
+}
+
+$runtime = bluecore_example_runtime_path('sqlite-model');
+$database = $runtime . DIRECTORY_SEPARATOR . 'tasks.sqlite';
+
+if (file_exists($database)) {
+    unlink($database);
+}
+
+$tasks = new ExampleTaskModel($database);
+$tasks->write([
+    'title' => 'Review package examples',
+    'status' => 'active',
+]);
+
+$tasks->clear();
+$tasks->write([
+    'title' => 'Confirm CI coverage',
+    'status' => 'queued',
+]);
+
+$reader = new ExampleTaskModel($database);
+$reader->read();
+
+$rows = array_map(static function (array $row): array {
+    return [
+        'task_id' => (int)$row['task_id'],
+        'title' => $row['title'],
+        'status' => $row['status'],
+    ];
+}, $reader->result()->toArray());
+
+bluecore_example_json([
+    'database' => Path::normalize($database),
+    'table' => 'example_tasks',
+    'rows' => $rows,
+]);

--- a/scripts/lint.php
+++ b/scripts/lint.php
@@ -1,6 +1,6 @@
 <?php
 
-$roots = ['src', 'tests'];
+$roots = ['src', 'tests', 'examples'];
 $failures = [];
 
 foreach ($roots as $root) {


### PR DESCRIPTION
## Intent summary

Add maintained, runnable examples that demonstrate current BlueCore package APIs and refresh the dependency lockfile so the examples align with the latest available DevElation-backed utility surface.

This PR is stacked on the package readiness branch because it relies on the current CI scripts and utility contracts introduced there. It should be retargeted after that branch lands.

Closes #13.

## User stories / acceptance criteria

- As a contributor, I can run focused examples for file/path utilities, SQLite models, generator factory wiring, and menu composition.
- As a package maintainer, I can rely on `composer lint` and `composer ci` to parse example code.
- Examples avoid optional services, network-backed generation, local app boot state, and repository-local runtime writes.
- Dependency metadata is current enough to exercise the latest DevElation primitive-backed API behavior available to this package.

## Key files changed

- `examples/README.md`
- `examples/bootstrap.php`
- `examples/file-path-utilities.php`
- `examples/sqlite-model.php`
- `examples/generator-factory.php`
- `examples/menu-composition.php`
- `scripts/lint.php`
- `composer.lock`

## How to test

```bash
php examples/file-path-utilities.php
php examples/sqlite-model.php
php examples/generator-factory.php
php examples/menu-composition.php
composer ci
composer audit
```

## QA checklist

- [x] Example scripts run successfully with temporary runtime storage.
- [x] `composer ci` passes and now lints `examples/`.
- [x] `composer audit` reports no security advisories.
- [x] Public wording stays package-owned and does not target a downstream package.

## Approval conditions

- Confirm the example set covers the package APIs expected for the next readiness slice.
- Confirm the dependency lock refresh is acceptable on this stacked branch.
- After the package-readiness branch lands, retarget this PR if needed and re-run CI.