### PR TITLE
Mature DevElation helper adoption across core surfaces

### DIFF
--- a/docs/sqlite-model-boundary.md
+++ b/docs/sqlite-model-boundary.md
@@ -1,0 +1,32 @@
+# SQLite Model Boundary
+
+BlueCore uses `BlueFission\BlueCore\Model\ModelSQLite` as a model-level projection over local SQLite storage.
+
+The upstream DevElation storage adapter is `BlueFission\Data\Storage\SQLite`. That adapter remains the canonical storage contract for direct SQLite data access, status vocabulary, query diagnostics, and broad storage behavior. BlueCore should rely on that contract when it needs generic SQLite storage.
+
+`SQLiteModelStore` remains in BlueCore for the model-specific layer that is not a direct replacement for the upstream adapter:
+
+- explicit model field projection from `ModelSQLite::$_fields`
+- optional `column_types` for model-local schema shape
+- materialized `Group` results for model query reads
+- single-table model query diagnostics
+- predictable `created` and `updated` timestamp behavior from `ModelSQLite`
+
+The boundary is intentionally narrow. New storage primitives should go upstream to DevElation first. BlueCore should keep only the model-facing behavior that binds storage to the framework model contract.
+
+## Diagnostics
+
+`SQLiteModelStore::diagnostics()` returns a compact trace shape:
+
+```php
+[
+    'upstreamStorage' => BlueFission\Data\Storage\SQLite::class,
+    'table' => 'records',
+    'key' => 'record_id',
+    'query' => 'SELECT * FROM `records`',
+    'status' => BlueFission\Data\Storage\Storage::STATUS_SUCCESS,
+    'rowCount' => 1,
+]
+```
+
+Use the diagnostics for tests, trace output, and operational inspection. Do not parse SQL strings for application decisions.

--- a/src/BlueCore/Auth.php
+++ b/src/BlueCore/Auth.php
@@ -1,6 +1,7 @@
 <?php
 namespace BlueFission\BlueCore;
 
+use BlueFission\Arr;
 use BlueFission\Services\Authenticator;
 use BlueFission\Data\Storage\Storage;
 use BlueFission\BlueCore\Security;
@@ -42,7 +43,8 @@ class Auth extends Authenticator
 
 	public function hasPermission(string $permission): bool
 	{
-	    // Assuming $this->_data['permissions'] is an array of permissions
-	    return in_array($permission, $this->_data['permissions']);
+	    $permissions = Arr::toArray($this->_data['permissions'] ?? [], true);
+
+	    return Arr::has($permissions, $permission, true);
 	}
 }

--- a/src/BlueCore/Business/Managers/NavMenuManager.php
+++ b/src/BlueCore/Business/Managers/NavMenuManager.php
@@ -1,9 +1,11 @@
 <?php
 namespace BlueFission\BlueCore\Business\Managers;
 
+use BlueFission\Arr;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Services\Service;
 use BlueFission\BlueCore\Auth as Authenticator;
+use BlueFission\BlueCore\MenuItem;
 
 class NavMenuManager extends Service
 {
@@ -19,7 +21,7 @@ class NavMenuManager extends Service
     public function registerMenu($menu)
     {
         // Ensure menu is not already registered
-        if (!array_key_exists($menu->getId(), $this->_menus)) {
+        if (!Arr::hasKey($this->_menus, $menu->getId())) {
             $this->_menus[$menu->getId()] = $menu;
         }
         // $this->_menus[$menu->getName()] = $menu;
@@ -27,7 +29,7 @@ class NavMenuManager extends Service
 
     public function getMenu($menuId)
     {
-        if (array_key_exists($menuId, $this->_menus)) {
+        if (Arr::hasKey($this->_menus, $menuId)) {
             return $this->_menus[$menuId];
         }
         return null;
@@ -35,7 +37,7 @@ class NavMenuManager extends Service
 
     public function addMenuItem($menuId, $menuItem)
     {
-        if (array_key_exists($menuId, $this->_menus)) {
+        if (Arr::hasKey($this->_menus, $menuId)) {
             $this->_menus[$menuId]->addItem($menuItem);
         }
     }
@@ -43,7 +45,7 @@ class NavMenuManager extends Service
     public function renderMenu(string $menuName)
     {
         $renderedItems = [];
-        if (isset($this->_menus[$menuName])) {
+        if (Arr::hasKey($this->_menus, $menuName)) {
             $menu = $this->_menus[$menuName];
             $menuItems = $menu->getItems();
 
@@ -73,7 +75,7 @@ class NavMenuManager extends Service
 
     public function displayMenuItemBasedOnRole($menuId, $itemId, $role)
     {
-        if (array_key_exists($menuId, $this->_menus)) {
+        if (Arr::hasKey($this->_menus, $menuId)) {
             $menuItem = $this->_menus[$menuId]->getItem($itemId);
             if ($menuItem->getRole() === $role) {
                 return $menuItem->render();
@@ -84,7 +86,7 @@ class NavMenuManager extends Service
 
     public function displayMenuItemBasedOnGroup($menuId, $itemId, $group)
     {
-        if (array_key_exists($menuId, $this->_menus)) {
+        if (Arr::hasKey($this->_menus, $menuId)) {
             $menuItem = $this->_menus[$menuId]->getItem($itemId);
             if ($menuItem && $menuItem->getGroup() === $group) {
                 return $menuItem->render();
@@ -95,7 +97,7 @@ class NavMenuManager extends Service
 
     public function displayMenuItemBasedOnPermission($menuId, $itemId, $permission)
     {
-        if (array_key_exists($menuId, $this->_menus)) {
+        if (Arr::hasKey($this->_menus, $menuId)) {
             $menuItem = $this->_menus[$menuId]->getItem($itemId);
             if ($menuItem && $menuItem->getPermission() === $permission) {
                 return $menuItem->render();

--- a/src/BlueCore/Menu.php
+++ b/src/BlueCore/Menu.php
@@ -1,7 +1,10 @@
 <?php
 namespace BlueFission\BlueCore;
 
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
 use BlueFission\HTML\Template;
+use BlueFission\Str;
 
 class Menu
 {
@@ -48,7 +51,7 @@ class Menu
 
     public function getItem($itemId)
     {
-        if (array_key_exists($itemId, $this->_items)) {
+        if (Arr::hasKey($this->_items, $itemId)) {
             return $this->_items[$itemId];
         }
         return null;
@@ -63,9 +66,10 @@ class Menu
     {
 
         // Implement your rendering logic here
-        $renderedItems = [];
-        $renderedItems = array_map(function($item) { return $item->render(); }, $this->_items);
-        $renderedItems = implode('', $renderedItems);
+        $renderedItems = (new Collection($this->_items))
+            ->map(function($item) { return $item->render(); })
+            ->toArray();
+        $renderedItems = Str::concat('', ...$renderedItems);
 
         $app = instance();
         $theme = $app->theme($this->_theme);

--- a/src/BlueCore/Model/ModelSQLite.php
+++ b/src/BlueCore/Model/ModelSQLite.php
@@ -4,6 +4,8 @@ namespace BlueFission\BlueCore\Model;
 
 use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
 
 class ModelSQLite extends BaseModel
 {
@@ -41,12 +43,12 @@ class ModelSQLite extends BaseModel
 
     protected function resolvePrimaryKey(): string
     {
-        if ($this->_key) {
+        if (Val::isNotEmpty($this->_key)) {
             return $this->_key;
         }
 
         foreach ($this->_fields as $field) {
-            if (strtolower(substr($field, -2)) === 'id') {
+            if (Str::endsWith($field, 'id', Str::IGNORE_CASE)) {
                 return $field;
             }
         }
@@ -74,14 +76,13 @@ class ModelSQLite extends BaseModel
         $id = $this->_idField;
 
         if (
-            !in_array('created', $this->_fields, true) &&
+            !Arr::has($this->_fields, 'created', true) &&
             !$this->_save_related_tables &&
             (
                 !$this->_dataObject->field($id) ||
                 (
-                    isset($values) &&
-                    !(is_array($values) && isset($values[$id])) &&
-                    !(is_object($values) && isset($values->$id))
+                    Val::isNotNull($values) &&
+                    !Arr::hasKey(Arr::toArray((array)$values, true), $id)
                 )
             )
         ) {
@@ -89,7 +90,7 @@ class ModelSQLite extends BaseModel
             $forceCreatedTimestamp = true;
         }
 
-        if (!in_array('updated', $this->_fields, true) && !$this->_save_related_tables) {
+        if (!Arr::has($this->_fields, 'updated', true) && !$this->_save_related_tables) {
             $this->_fields[] = 'updated';
             $forceUpdatedTimestamp = true;
         }
@@ -98,20 +99,13 @@ class ModelSQLite extends BaseModel
         $result = parent::write($values);
 
         if ($forceCreatedTimestamp) {
-            $key = array_search('created', $this->_fields, true);
-            if ($key !== false) {
-                unset($this->_fields[$key]);
-            }
+            $this->removeField('created');
         }
 
         if ($forceUpdatedTimestamp) {
-            $key = array_search('updated', $this->_fields, true);
-            if ($key !== false) {
-                unset($this->_fields[$key]);
-            }
+            $this->removeField('updated');
         }
 
-        $this->_fields = array_values($this->_fields);
         $this->_dataObject->config('fields', $this->_fields);
 
         return $result;
@@ -132,5 +126,12 @@ class ModelSQLite extends BaseModel
     public function query()
     {
         return $this->_dataObject->query();
+    }
+
+    private function removeField(string $field): void
+    {
+        $this->_fields = Arr::make($this->_fields)
+            ->filter(static fn ($value) => $value !== $field)
+            ->toArray();
     }
 }

--- a/src/BlueCore/Model/ModelSql.php
+++ b/src/BlueCore/Model/ModelSql.php
@@ -3,6 +3,7 @@ namespace BlueFission\BlueCore\Model;
 
 use BlueFission\Arr;
 use BlueFission\Obj;
+use BlueFission\Val;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\BlueCore\Model\BaseModel;
 use BlueFission\Data\Storage\MySQLBulk;
@@ -60,7 +61,7 @@ class ModelSql extends BaseModel {
 	 */
 	public function __construct( MySQLLink $link = null )
 	{
-		if ($link) {
+		if (Val::isNotNull($link)) {
 			$link->when(Event::ACTION_FAILED, function($event) {
 				// Handle the event when the link fails
 				throw new \Exception("Database connection failed: " . $event->context->info);
@@ -124,43 +125,38 @@ class ModelSql extends BaseModel {
 	 */
 	public function write($values = null) :Obj
 	{
-		$force_created_timestamp = false;
-		$force_updated_timestamp = false;
+		$forceCreatedTimestamp = false;
+		$forceUpdatedTimestamp = false;
 		$id = $this->_idField;
 
 		if (
-			!in_array('created', $this->_fields) && 
+			!Arr::has($this->_fields, 'created', true) &&
 			!$this->_save_related_tables && 
-			(!$this->_dataObject->$id || 
-				(isset($values) && 
-					!(is_array($values) && isset($values[$id])) && 
-					!(is_object($values) && isset($values->$id))
+			(!$this->_dataObject->$id ||
+				(Val::isNotNull($values) &&
+					!Arr::hasKey(Arr::toArray((array)$values, true), $id)
 				)
 			)
 		) {
 			$this->_fields[] = 'created';
-			$force_created_timestamp = true;
+			$forceCreatedTimestamp = true;
 		}
-		if (!in_array('updated', $this->_fields) && !$this->_save_related_tables) {
+		if (!Arr::has($this->_fields, 'updated', true) && !$this->_save_related_tables) {
 			$this->_fields[] = 'updated';
-			$force_updated_timestamp = true;
+			$forceUpdatedTimestamp = true;
 		}
 		$this->_dataObject->config('fields', $this->_fields);
 		// Do the work
 		$result = parent::write($values);
-		if ($force_created_timestamp) {
-			if (($key = array_search("created", $this->_fields)) !== false) {
-			    unset($this->_fields[$key]);
-			}
+		if ($forceCreatedTimestamp) {
+			$this->removeField('created');
 		}
-		if ($force_updated_timestamp) {
-			if (($key = array_search("updated", $this->_fields)) !== false) {
-			    unset($this->_fields[$key]);
-			}
+		if ($forceUpdatedTimestamp) {
+			$this->removeField('updated');
 		}
 		$this->_dataObject->config('fields', $this->_fields);
 
-		return $this;
+		return $result;
 	}
 
 	/**
@@ -193,6 +189,13 @@ class ModelSql extends BaseModel {
 	public function query()
 	{
 		return $this->_dataObject->query();
+	}
+
+	private function removeField(string $field): void
+	{
+		$this->_fields = Arr::make($this->_fields)
+			->filter(static fn ($value) => $value !== $field)
+			->toArray();
 	}
 
 }

--- a/src/BlueCore/Model/SQLiteModelStore.php
+++ b/src/BlueCore/Model/SQLiteModelStore.php
@@ -4,10 +4,14 @@ namespace BlueFission\BlueCore\Model;
 
 use BlueFission\Arr;
 use BlueFission\Collections\Group;
+use BlueFission\Data\Storage\SQLite as DevElationSQLite;
+use BlueFission\Data\Storage\Storage;
 use BlueFission\Str;
 
 class SQLiteModelStore
 {
+    public const UPSTREAM_STORAGE = DevElationSQLite::class;
+
     protected $_config = [
         'location' => '',
         'name' => '',
@@ -176,7 +180,7 @@ class SQLiteModelStore
             }
         }
 
-        $this->_status = $result ? 'Success.' : 'Failed.';
+        $this->_status = $result ? Storage::STATUS_SUCCESS : Storage::STATUS_FAILED;
         if ($result instanceof \SQLite3Result) {
             $result->finalize();
         }
@@ -228,7 +232,7 @@ class SQLiteModelStore
         }
 
         $this->_rows = $rows;
-        $this->_status = 'Success.';
+        $this->_status = Storage::STATUS_SUCCESS;
 
         if ($rows) {
             foreach ($rows[0] as $field => $value) {
@@ -253,7 +257,7 @@ class SQLiteModelStore
             $statement = $db->prepare($this->_query);
             $statement->bindValue(':__key', $identifier, SQLITE3_INTEGER);
             $result = $statement->execute();
-            $this->_status = $result ? 'Success.' : 'Failed.';
+            $this->_status = $result ? Storage::STATUS_SUCCESS : Storage::STATUS_FAILED;
             if ($result instanceof \SQLite3Result) {
                 $result->finalize();
             }
@@ -288,6 +292,36 @@ class SQLiteModelStore
         $this->_status = $message;
 
         return $this;
+    }
+
+    public function diagnostics(): array
+    {
+        return Arr::make([
+            'upstreamStorage' => self::UPSTREAM_STORAGE,
+            'table' => $this->config('name'),
+            'key' => $this->primary(),
+            'query' => $this->_query,
+            'status' => $this->_status,
+            'rowCount' => Arr::count($this->_rows),
+        ])->toArray();
+    }
+
+    public static function boundary(): array
+    {
+        return Arr::make([
+            'upstreamStorage' => self::UPSTREAM_STORAGE,
+            'blueCoreRole' => 'model_projection_store',
+            'delegatesToUpstreamFor' => [
+                'status_constants',
+                'sqlite_storage_contract',
+            ],
+            'retainsLocally' => [
+                'explicit_column_types',
+                'model_field_projection',
+                'materialized_group_results',
+                'single_table_model_query_diagnostics',
+            ],
+        ])->toArray();
     }
 
     public function primary(): string

--- a/src/BlueCore/Model/SQLiteModelStore.php
+++ b/src/BlueCore/Model/SQLiteModelStore.php
@@ -2,7 +2,9 @@
 
 namespace BlueFission\BlueCore\Model;
 
+use BlueFission\Arr;
 use BlueFission\Collections\Group;
+use BlueFission\Str;
 
 class SQLiteModelStore
 {
@@ -41,9 +43,9 @@ class SQLiteModelStore
             return $this->_config;
         }
 
-        if (is_array($config)) {
+        if (Arr::is($config)) {
             foreach ($config as $key => $item) {
-                if (array_key_exists($key, $this->_config)) {
+                if (Arr::hasKey($this->_config, $key)) {
                     $this->_config[$key] = $item;
                 }
             }
@@ -55,7 +57,7 @@ class SQLiteModelStore
             return $this->_config[$config] ?? null;
         }
 
-        if (array_key_exists($config, $this->_config)) {
+        if (Arr::hasKey($this->_config, $config)) {
             $this->_config[$config] = $value;
         }
 
@@ -101,7 +103,7 @@ class SQLiteModelStore
 
     public function order($field, $direction = 'ASC')
     {
-        $this->_order[$field] = strtoupper($direction) === 'DESC' ? 'DESC' : 'ASC';
+        $this->_order[$field] = Str::match($direction, 'DESC', Str::IGNORE_CASE) ? 'DESC' : 'ASC';
 
         return $this;
     }
@@ -311,7 +313,7 @@ class SQLiteModelStore
             if (!$type) {
                 $type = $field === $key
                     ? 'INTEGER PRIMARY KEY AUTOINCREMENT'
-                    : (in_array($field, ['created', 'updated', 'date'], true) ? 'DATETIME' : 'TEXT');
+                    : (Arr::has(['created', 'updated', 'date'], $field, true) ? 'DATETIME' : 'TEXT');
             }
             $columns[] = sprintf('`%s` %s', $field, $type);
         }

--- a/src/BlueCore/Theme.php
+++ b/src/BlueCore/Theme.php
@@ -1,6 +1,9 @@
 <?php
 namespace BlueFission\BlueCore;
 
+use BlueFission\Arr;
+use BlueFission\Str;
+
 class Theme 
 {
 	public $name;
@@ -11,13 +14,13 @@ class Theme
 	{
 		$this->name = $name;
 
-		$directory = explode('/', $name)[0] ?? "";
-		$theme = explode('/', $name)[1] ?? "";
+		$nameParts = Arr::toArray(Str::split($name, '/'), true);
+		$directory = $nameParts[0] ?? "";
 		$appThemeDir = resolve_path('resource'.DIRECTORY_SEPARATOR.'markup'.DIRECTORY_SEPARATOR);
 
 		$addonThemeDir = resolve_path('addons'.DIRECTORY_SEPARATOR.$directory.DIRECTORY_SEPARATOR.'resource'.DIRECTORY_SEPARATOR.'markup'.DIRECTORY_SEPARATOR);
 
-		$path = $appThemeDir.strtolower($name).DIRECTORY_SEPARATOR;
+		$path = $appThemeDir.Str::lower($name).DIRECTORY_SEPARATOR;
 
 		if ( $location && $directory == 'app' ) {
 			$location = $appThemeDir.$location.DIRECTORY_SEPARATOR;

--- a/src/BlueCore/ValueObject.php
+++ b/src/BlueCore/ValueObject.php
@@ -1,6 +1,9 @@
 <?php
 namespace BlueFission\BlueCore;
 
+use BlueFission\Arr;
+use BlueFission\Val;
+
 /**
  * Class ValueObject implements IValueObject
  *
@@ -14,7 +17,7 @@ class ValueObject implements IValueObject {
 	 * @param mixed|null $values An array or object with values to be assigned to the properties
 	 */
 	public function __construct($values = null) {
-		if ($values) {
+		if (Val::isNotEmpty($values)) {
 			$this->assign($values);
 		}
 	}
@@ -25,8 +28,10 @@ class ValueObject implements IValueObject {
 	 * @param mixed $values An array or object with values to be assigned to the properties
 	 */
 	public function assign($values) {
-		foreach ( get_object_vars($this) as $property=>$value ) {
-			$this->$property = is_object($values) ? ( $values->$property ?? $value ) : ( $values[$property] ?? $value );
+		$incoming = Arr::toArray((array)$values, true);
+
+		foreach (Arr::toArray(get_object_vars($this), true) as $property=>$value) {
+			$this->$property = Arr::hasKey($incoming, $property) ? $incoming[$property] : $value;
 		}
 	}
 }

--- a/tests/BlueCore/AuthTest.php
+++ b/tests/BlueCore/AuthTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore;
+
+use BlueFission\BlueCore\Auth;
+use PHPUnit\Framework\TestCase;
+
+class AuthTest extends TestCase
+{
+    public function testHasPermissionUsesArrayBackedPermissions(): void
+    {
+        $auth = $this->authWithPermissions(['reports.view', 'tasks.manage']);
+
+        $this->assertTrue($auth->hasPermission('reports.view'));
+        $this->assertFalse($auth->hasPermission('users.manage'));
+    }
+
+    private function authWithPermissions(array $permissions): Auth
+    {
+        return new class($permissions) extends Auth {
+            public function __construct(private array $permissions)
+            {
+            }
+
+            public function hasPermission(string $permission): bool
+            {
+                $this->_data['permissions'] = $this->permissions;
+
+                return parent::hasPermission($permission);
+            }
+        };
+    }
+}

--- a/tests/BlueCore/Model/ModelSQLiteTest.php
+++ b/tests/BlueCore/Model/ModelSQLiteTest.php
@@ -3,6 +3,9 @@
 namespace BlueFission\Tests\BlueCore\Model;
 
 use BlueFission\BlueCore\Model\ModelSQLite;
+use BlueFission\BlueCore\Model\SQLiteModelStore;
+use BlueFission\Data\Storage\SQLite as DevElationSQLite;
+use BlueFission\Data\Storage\Storage;
 use PHPUnit\Framework\TestCase;
 
 class ModelSQLiteTest extends TestCase
@@ -54,6 +57,34 @@ class ModelSQLiteTest extends TestCase
         $this->assertSame('first', $rows[0]['name']);
         $this->assertSame('second', $rows[1]['name']);
     }
+
+    public function testSQLiteStoreBoundaryNamesDevElationStorageAndLocalResponsibilities(): void
+    {
+        $boundary = SQLiteModelStore::boundary();
+
+        $this->assertSame(DevElationSQLite::class, $boundary['upstreamStorage']);
+        $this->assertSame('model_projection_store', $boundary['blueCoreRole']);
+        $this->assertContains('sqlite_storage_contract', $boundary['delegatesToUpstreamFor']);
+        $this->assertContains('materialized_group_results', $boundary['retainsLocally']);
+    }
+
+    public function testSQLiteStoreDiagnosticsExposeQueryStatusAndRows(): void
+    {
+        $writer = new TestSQLiteModel($this->database);
+        $writer->write(['name' => 'first', 'status' => 'active']);
+
+        $reader = new TestSQLiteModel($this->database);
+        $reader->read();
+
+        $diagnostics = $reader->storeDiagnostics();
+
+        $this->assertSame(DevElationSQLite::class, $diagnostics['upstreamStorage']);
+        $this->assertSame('test_records', $diagnostics['table']);
+        $this->assertSame('record_id', $diagnostics['key']);
+        $this->assertStringContainsString('SELECT', $diagnostics['query']);
+        $this->assertSame(Storage::STATUS_SUCCESS, $diagnostics['status']);
+        $this->assertSame(1, $diagnostics['rowCount']);
+    }
 }
 
 class TestSQLiteModel extends ModelSQLite
@@ -64,4 +95,9 @@ class TestSQLiteModel extends ModelSQLite
         'name',
         'status',
     ];
+
+    public function storeDiagnostics(): array
+    {
+        return $this->_dataObject->diagnostics();
+    }
 }

--- a/tests/BlueCore/ValueObjectTest.php
+++ b/tests/BlueCore/ValueObjectTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore;
+
+use BlueFission\BlueCore\ValueObject;
+use PHPUnit\Framework\TestCase;
+
+class ValueObjectTest extends TestCase
+{
+    public function testAssignKeepsDefaultsForMissingFields(): void
+    {
+        $value = new TestValueObject(['name' => 'alpha']);
+
+        $this->assertSame('alpha', $value->name);
+        $this->assertSame('draft', $value->status);
+    }
+
+    public function testAssignAcceptsObjects(): void
+    {
+        $payload = (object)[
+            'name' => 'beta',
+            'status' => 'active',
+        ];
+
+        $value = new TestValueObject($payload);
+
+        $this->assertSame('beta', $value->name);
+        $this->assertSame('active', $value->status);
+    }
+}
+
+class TestValueObject extends ValueObject
+{
+    public string $name = '';
+    public string $status = 'draft';
+}


### PR DESCRIPTION
## Intent Summary

Mature BlueCore's direct use of DevElation helper APIs across existing core surfaces while preserving the package's current public behavior.

This PR keeps the work package-owned and reusable: permissions, value assignment, menu rendering, theme parsing, and SQL/SQLite model timestamp handling now lean on DevElation value, array, string, and collection helpers instead of nearby vanilla PHP equivalents.

Closes #15.

## User Stories / Acceptance Criteria

- As a BlueCore maintainer, common value, array, string, and collection operations should use DevElation helpers where the helper semantics fit cleanly.
- As a contributor, helper usage should be represented in production code and backed by focused tests for behavior-sensitive paths.
- As a package consumer, permission checks and value-object assignment should preserve current behavior while using Blue Fission primitives internally.
- As a reviewer, the SQL and SQLite model timestamp-field handling should remain aligned and easy to compare.

## Key Files Changed

- `src/BlueCore/Auth.php`
- `src/BlueCore/ValueObject.php`
- `src/BlueCore/Menu.php`
- `src/BlueCore/Theme.php`
- `src/BlueCore/Business/Managers/NavMenuManager.php`
- `src/BlueCore/Model/ModelSql.php`
- `src/BlueCore/Model/ModelSQLite.php`
- `src/BlueCore/Model/SQLiteModelStore.php`
- `tests/BlueCore/AuthTest.php`
- `tests/BlueCore/ValueObjectTest.php`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\BlueCore
vendor\bin\phpunit.bat --do-not-cache-result tests\Utils
composer ci
```

## QA Checklist

- [x] Uses DevElation `Arr`, `Str`, `Val`, and `Collection` helpers in the updated paths.
- [x] Keeps the implementation generic to BlueCore and DevElation, with no downstream-specific behavior.
- [x] Adds focused tests for permission lookup and value-object assignment.
- [x] Verifies package validation, lint, and the full PHPUnit suite with `composer ci`.
- [x] Stacks on the package-readiness branch so this can be retargeted to `main` cleanly after that PR lands.

## Approval Conditions

- PR #11 remains mergeable into `main` or this branch is retargeted to `main` after PR #11 lands.
- GitHub CI passes on the supported PHP matrix.
- Review confirms the helper substitutions remain readable and do not broaden behavior beyond the existing BlueCore contracts.
