### PR TITLE
Add file and directory readiness diagnostics

### DIFF
--- a/src/Utils/File.php
+++ b/src/Utils/File.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Utils;
 
 use BlueFission\Data\File as BaseFile;
+use BlueFission\Arr;
 use BlueFission\Flag;
 use BlueFission\Val;
 
@@ -81,5 +82,67 @@ class File extends BaseFile
         }
 
         return $contents;
+    }
+
+    public static function readiness($path, bool $includeHash = false): array
+    {
+        $normalized = Path::normalize($path);
+        $exists = Val::isNotEmpty($normalized) && is_file($normalized);
+        $readable = $exists && is_readable($normalized);
+        $writable = $exists
+            ? is_writable($normalized)
+            : self::parentIsWritable($normalized);
+
+        $result = [
+            'normalizedPath' => $normalized,
+            'expectedType' => 'file',
+            'exists' => Flag::parseBool($exists),
+            'readable' => Flag::parseBool($readable),
+            'writable' => Flag::parseBool($writable),
+            'reason' => self::readinessReason($normalized, $exists, $readable, $writable),
+            'hash' => null,
+        ];
+
+        if (Flag::parseBool($includeHash) && Flag::parseBool($readable)) {
+            $result['hash'] = hash_file('sha256', $normalized) ?: null;
+        }
+
+        return Arr::make($result)->toArray();
+    }
+
+    private static function parentIsWritable(string $path): bool
+    {
+        if (Val::isEmpty($path)) {
+            return false;
+        }
+
+        $dir = Path::parentPath($path);
+
+        return Val::isNotEmpty($dir) && is_dir($dir) && is_writable($dir);
+    }
+
+    private static function readinessReason(string $path, bool $exists, bool $readable, bool $writable): ?string
+    {
+        if (Val::isEmpty($path)) {
+            return 'invalid_path';
+        }
+
+        if (file_exists($path) && !$exists) {
+            return 'not_file';
+        }
+
+        if (!$exists) {
+            return self::parentIsWritable($path) ? 'missing' : 'parent_unavailable';
+        }
+
+        if (!$readable) {
+            return 'unreadable';
+        }
+
+        if (!$writable) {
+            return 'unwritable';
+        }
+
+        return null;
     }
 }

--- a/src/Utils/Path.php
+++ b/src/Utils/Path.php
@@ -2,7 +2,9 @@
 
 namespace BlueFission\Utils;
 
+use BlueFission\Arr;
 use BlueFission\Data\Directory;
+use BlueFission\Flag;
 use BlueFission\Str;
 use BlueFission\Val;
 
@@ -38,6 +40,24 @@ class Path extends Directory
         return dirname(self::normalize($path));
     }
 
+    public static function readiness($path): array
+    {
+        $normalized = self::normalize($path);
+        $exists = Val::isNotEmpty($normalized) && is_dir($normalized);
+        $readable = $exists && is_readable($normalized);
+        $writable = $exists && is_writable($normalized);
+
+        return Arr::make([
+            'normalizedPath' => $normalized,
+            'expectedType' => 'directory',
+            'exists' => Flag::parseBool($exists),
+            'readable' => Flag::parseBool($readable),
+            'writable' => Flag::parseBool($writable),
+            'reason' => self::readinessReason($normalized, $exists, $readable, $writable),
+            'hash' => null,
+        ])->toArray();
+    }
+
     public static function ensureDir($path, $mode = 0775, $recursive = true)
     {
         $normalized = self::normalize($path);
@@ -58,5 +78,30 @@ class Path extends Directory
         }
 
         return $normalized;
+    }
+
+    private static function readinessReason(string $path, bool $exists, bool $readable, bool $writable): ?string
+    {
+        if (Val::isEmpty($path)) {
+            return 'invalid_path';
+        }
+
+        if (file_exists($path) && !$exists) {
+            return 'not_directory';
+        }
+
+        if (!$exists) {
+            return 'missing';
+        }
+
+        if (!$readable) {
+            return 'unreadable';
+        }
+
+        if (!$writable) {
+            return 'unwritable';
+        }
+
+        return null;
     }
 }

--- a/tests/Utils/FileTest.php
+++ b/tests/Utils/FileTest.php
@@ -51,6 +51,46 @@ class FileTest extends TestCase
         $this->assertSame('world', File::readContents($path));
     }
 
+    public function testReadinessReportsExistingFileWithHash(): void
+    {
+        $path = File::ensureFile($this->tmpDir . DIRECTORY_SEPARATOR . 'ready.txt', 'ready', true);
+
+        $readiness = File::readiness($path, true);
+
+        $this->assertSame($path, $readiness['normalizedPath']);
+        $this->assertSame('file', $readiness['expectedType']);
+        $this->assertTrue($readiness['exists']);
+        $this->assertTrue($readiness['readable']);
+        $this->assertTrue($readiness['writable']);
+        $this->assertNull($readiness['reason']);
+        $this->assertSame(hash('sha256', 'ready'), $readiness['hash']);
+    }
+
+    public function testReadinessReportsMissingFileAgainstWritableParent(): void
+    {
+        $dir = $this->tmpDir . DIRECTORY_SEPARATOR . 'target';
+        $path = $dir . DIRECTORY_SEPARATOR . 'missing.txt';
+        \BlueFission\Utils\Path::ensureDir($dir);
+
+        $readiness = File::readiness($path);
+
+        $this->assertFalse($readiness['exists']);
+        $this->assertFalse($readiness['readable']);
+        $this->assertTrue($readiness['writable']);
+        $this->assertSame('missing', $readiness['reason']);
+    }
+
+    public function testReadinessRejectsInvalidAndDirectoryPaths(): void
+    {
+        $this->assertSame('invalid_path', File::readiness('')['reason']);
+
+        $dir = \BlueFission\Utils\Path::ensureDir($this->tmpDir . DIRECTORY_SEPARATOR . 'folder');
+        $readiness = File::readiness($dir);
+
+        $this->assertFalse($readiness['exists']);
+        $this->assertSame('not_file', $readiness['reason']);
+    }
+
     private function removeDir($dir): void
     {
         if (!$dir || !is_dir($dir)) {

--- a/tests/Utils/PathTest.php
+++ b/tests/Utils/PathTest.php
@@ -43,6 +43,42 @@ class PathTest extends TestCase
         Path::ensureDir($filePath);
     }
 
+    public function testReadinessReportsExistingDirectory(): void
+    {
+        $dir = Path::ensureDir($this->tmpDir . DIRECTORY_SEPARATOR . 'ready');
+
+        $readiness = Path::readiness($dir);
+
+        $this->assertSame($dir, $readiness['normalizedPath']);
+        $this->assertSame('directory', $readiness['expectedType']);
+        $this->assertTrue($readiness['exists']);
+        $this->assertTrue($readiness['readable']);
+        $this->assertTrue($readiness['writable']);
+        $this->assertNull($readiness['reason']);
+        $this->assertNull($readiness['hash']);
+    }
+
+    public function testReadinessReportsMissingAndInvalidDirectories(): void
+    {
+        $missing = Path::readiness($this->tmpDir . DIRECTORY_SEPARATOR . 'missing');
+
+        $this->assertFalse($missing['exists']);
+        $this->assertSame('missing', $missing['reason']);
+        $this->assertSame('invalid_path', Path::readiness('')['reason']);
+    }
+
+    public function testReadinessReportsFileAtDirectoryPath(): void
+    {
+        $filePath = File::ensureFile($this->tmpDir . DIRECTORY_SEPARATOR . 'file.txt', 'data', true);
+
+        $readiness = Path::readiness($filePath);
+
+        $this->assertFalse($readiness['exists']);
+        $this->assertFalse($readiness['readable']);
+        $this->assertFalse($readiness['writable']);
+        $this->assertSame('not_directory', $readiness['reason']);
+    }
+
     private function removeDir($dir): void
     {
         if (!$dir || !is_dir($dir)) {


### PR DESCRIPTION
## Intent Summary

Add reusable file and directory readiness diagnostics to BlueCore's utility layer.

This keeps the diagnostic surface on the existing `File` and `Path` utilities, which already inherit from DevElation file and directory primitives on the package-readiness branch. The implementation uses DevElation `Arr`, `Val`, and `Flag` helpers where they fit cleanly, while leaving filesystem checks to PHP's filesystem API.

Closes #12.

## User Stories / Acceptance Criteria

- As a generator or runtime caller, I can ask whether a file path is valid, present, readable, writable, or missing before writing.
- As a package maintainer, I can inspect a directory path with the same compact diagnostic shape.
- As a reviewer, I can see actionable reason codes for invalid paths, type mismatches, missing targets, unreadable paths, and unwritable paths.
- As a contributor, I can request a deterministic SHA-256 hash for readable files.

## Key Files Changed

- `src/Utils/File.php`
- `src/Utils/Path.php`
- `tests/Utils/FileTest.php`
- `tests/Utils/PathTest.php`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\Utils
composer ci
```

## QA Checklist

- [x] File readiness reports normalized path, expected type, existence, readability, writability, reason, and optional hash.
- [x] Directory readiness reports the same bounded result shape.
- [x] Diagnostics stay on the existing BlueCore utility layer and remain compatible with DevElation inheritance.
- [x] Tests cover existing files, existing directories, missing paths, invalid paths, and file/directory type mismatches.
- [x] `composer ci` passes.

## Approval Conditions

- PR #11 remains mergeable into `main`, or this branch is retargeted to `main` after PR #11 lands.
- Review confirms the reason-code vocabulary is sufficient for the next generator/config readiness callers.
