### PR TITLE
Stabilize generator subsystem contracts

### DIFF
--- a/src/BlueCore/Generation/BaseGenerator.php
+++ b/src/BlueCore/Generation/BaseGenerator.php
@@ -73,7 +73,7 @@ abstract class BaseGenerator implements IGenerator
 
     protected function getOutputFile(string $name): string
     {
-        return $this->outputPath . '/' . $name . '.php';
+        return Path::normalize($this->outputPath . DIRECTORY_SEPARATOR . $name . '.php');
     }
 
     abstract public function getType(): string;

--- a/src/BlueCore/Generation/GeneratorFactory.php
+++ b/src/BlueCore/Generation/GeneratorFactory.php
@@ -3,9 +3,31 @@ namespace BlueFission\BlueCore\Generation;
 
 use BlueFission\Arr;
 use BlueFission\Str;
+use BlueFission\Val;
 
 class GeneratorFactory
 {
+    private const SUPPORTED_TYPES = [
+        'controller',
+        'module',
+        'query',
+        'repository',
+        'scaffold',
+        'valueobject',
+        'content',
+        'admin_module',
+        'css',
+        'template',
+    ];
+
+    private const TYPE_ALIASES = [
+        'adminmodule' => 'admin_module',
+        'admin-module' => 'admin_module',
+        'html' => 'template',
+        'value_object' => 'valueobject',
+        'value-object' => 'valueobject',
+    ];
+
     private $aiCodeGenerator;
     private $aiCopyGenerator;
 
@@ -19,7 +41,7 @@ class GeneratorFactory
     {
         $aiCodeGenerator = $this->aiCodeGenerator;
         $aiCopyGenerator = $this->aiCopyGenerator;
-        $type = Str::lower($name);
+        $type = $this->normalizeType($name);
         $templatePath = $this->configValue($config, 'templatePath', $this->configValue($config, 'template_path', ''));
         $resolvedOutputPath = $outputPath ?? $this->configValue($config, 'outputPath', $this->configValue($config, 'output_path', ''));
 
@@ -49,6 +71,23 @@ class GeneratorFactory
         }
     }
 
+    public function createOrFail(string $name, array|object $config, string $outputPath = null): IGenerator
+    {
+        $generator = $this->create($name, $config, $outputPath);
+        if (Val::isNotNull($generator)) {
+            return $generator;
+        }
+
+        throw new \InvalidArgumentException(
+            "Unsupported generator type '{$name}'. Supported types: " . implode(', ', $this->supportedTypes())
+        );
+    }
+
+    public function supportedTypes(): array
+    {
+        return self::SUPPORTED_TYPES;
+    }
+
     private function configValue(array|object $config, string $key, mixed $default = null): mixed
     {
         $values = Arr::toArray((array)$config, true);
@@ -58,5 +97,13 @@ class GeneratorFactory
         }
 
         return Arr::make($values)->get($key) ?? $default;
+    }
+
+    private function normalizeType(string $name): string
+    {
+        $type = Str::lower(Str::trim($name));
+        $type = Str::replace($type, ' ', '_');
+
+        return self::TYPE_ALIASES[$type] ?? $type;
     }
 }

--- a/src/BlueCore/Generation/GeneratorFactory.php
+++ b/src/BlueCore/Generation/GeneratorFactory.php
@@ -101,9 +101,12 @@ class GeneratorFactory
 
     private function normalizeType(string $name): string
     {
-        $type = Str::lower(Str::trim($name));
-        $type = Str::replace($type, ' ', '_');
-
+        $type = Str::make($name)
+            ->trim()
+            ->lower()
+            ->replace(' ', '_')
+            ->val();
+        
         return self::TYPE_ALIASES[$type] ?? $type;
     }
 }

--- a/src/BlueCore/Generation/Gpt4CodeGenerator.php
+++ b/src/BlueCore/Generation/Gpt4CodeGenerator.php
@@ -11,19 +11,17 @@ class Gpt4CodeGenerator implements IAICodeGenerator
 {
     private $apiKey;
     private $apiUrl = 'https://api.openai.com/v1/engines/davinci-codex/completions';
+    private $client;
 
-    public function __construct(string $apiKey)
+    public function __construct(string $apiKey, object $client = null)
     {
         $this->apiKey = $apiKey;
+        $this->client = $client;
     }
 
     public function generateCode(string $template, string $userPrompt): ?string
     {
-        if (!class_exists(Client::class)) {
-            throw new \RuntimeException('Guzzle HTTP client is required to use Gpt4CodeGenerator.');
-        }
-
-        $client = new Client();
+        $client = $this->client();
 
         $prompt = "Generate PHP code for the following description:\n{$userPrompt}\n\nTemplate:\n{$template}\n\nGenerated Code:";
 
@@ -58,11 +56,7 @@ class Gpt4CodeGenerator implements IAICodeGenerator
 
     public function generateClassName(string $userPrompt): ?string
     {
-        if (!class_exists(Client::class)) {
-            throw new \RuntimeException('Guzzle HTTP client is required to use Gpt4CodeGenerator.');
-        }
-
-        $client = new Client();
+        $client = $this->client();
 
         $prompt = "Generate a class name for the following description:\n{$userPrompt}\n\nClass Name:";
 
@@ -93,5 +87,22 @@ class Gpt4CodeGenerator implements IAICodeGenerator
         }
 
         return null;
+    }
+
+    private function client(): object
+    {
+        if (Val::isNotNull($this->client)) {
+            if (!method_exists($this->client, 'post')) {
+                throw new \RuntimeException('Injected code-generation client must expose a post method.');
+            }
+
+            return $this->client;
+        }
+
+        if (!class_exists(Client::class)) {
+            throw new \RuntimeException('A Guzzle-compatible HTTP client is required to use Gpt4CodeGenerator.');
+        }
+
+        return new Client();
     }
 }

--- a/tests/BlueCore/Generation/GeneratorFactoryTest.php
+++ b/tests/BlueCore/Generation/GeneratorFactoryTest.php
@@ -6,6 +6,7 @@ use BlueFission\BlueCore\Generation\ContentGenerator;
 use BlueFission\BlueCore\Generation\ControllerGenerator;
 use BlueFission\BlueCore\Generation\CSSGenerator;
 use BlueFission\BlueCore\Generation\GeneratorFactory;
+use BlueFission\BlueCore\Generation\Gpt4CodeGenerator;
 use BlueFission\BlueCore\Generation\HTMLGenerator;
 use BlueFission\BlueCore\Generation\IAICodeGenerator;
 use BlueFission\BlueCore\Generation\IAICopyGenerator;
@@ -13,6 +14,8 @@ use BlueFission\BlueCore\Generation\QueryGenerator;
 use BlueFission\BlueCore\Generation\RepositoryGenerator;
 use BlueFission\BlueCore\Generation\ScaffoldGenerator;
 use BlueFission\BlueCore\Generation\ValueObjectGenerator;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
 use PHPUnit\Framework\TestCase;
 
 class GeneratorFactoryTest extends TestCase
@@ -37,6 +40,72 @@ class GeneratorFactoryTest extends TestCase
         $factory = new GeneratorFactory(new FakeCodeGenerator(), new FakeCopyGenerator());
 
         $this->assertNull($factory->create('missing', []));
+    }
+
+    public function testFactorySupportsAliasesAndFailFastCreation(): void
+    {
+        $factory = new GeneratorFactory(new FakeCodeGenerator(), new FakeCopyGenerator());
+        $config = ['templatePath' => __FILE__, 'outputPath' => sys_get_temp_dir(), 'tableName' => 'users'];
+
+        $this->assertContains('controller', $factory->supportedTypes());
+        $this->assertInstanceOf(HTMLGenerator::class, $factory->create('html', $config));
+        $this->assertInstanceOf(ValueObjectGenerator::class, $factory->create('value object', $config));
+        $this->assertInstanceOf(\BlueFission\BlueCore\Generation\AdminModuleGenerator::class, $factory->createOrFail('admin-module', $config));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $factory->createOrFail('missing', $config);
+    }
+
+    public function testBaseGeneratorWritesGeneratedCodeToNormalizedOutputPath(): void
+    {
+        $tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-generator-' . uniqid('', true);
+        $template = File::ensureFile($tmpDir . DIRECTORY_SEPARATOR . 'template.php', '<?php // template', true);
+
+        try {
+            $generator = new ControllerGenerator($template, $tmpDir . '/output', new FakeCodeGenerator());
+
+            $this->assertTrue($generator->generate('GeneratedController', 'create a controller generated'));
+            $this->assertSame('<?php', File::readContents($tmpDir . DIRECTORY_SEPARATOR . 'output' . DIRECTORY_SEPARATOR . 'GeneratedController.php'));
+        } finally {
+            $this->removeDir($tmpDir);
+        }
+    }
+
+    public function testGpt4CodeGeneratorUsesInjectedClient(): void
+    {
+        $generator = new Gpt4CodeGenerator('token', new FakeCompletionClient(' class Demo {} '));
+
+        $this->assertSame('class Demo {}', $generator->generateCode('<?php', 'create demo'));
+    }
+
+    public function testGpt4CodeGeneratorRejectsInvalidInjectedClient(): void
+    {
+        $generator = new Gpt4CodeGenerator('token', new \stdClass());
+
+        $this->expectException(\RuntimeException::class);
+        $generator->generateCode('<?php', 'create demo');
+    }
+
+    private function removeDir($dir): void
+    {
+        if (!$dir || !is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($dir);
     }
 }
 
@@ -63,5 +132,33 @@ class FakeCopyGenerator implements IAICopyGenerator
     public function generateImage(string $prompt): ?string
     {
         return 'image';
+    }
+}
+
+class FakeCompletionClient
+{
+    public function __construct(private string $text)
+    {
+    }
+
+    public function post(string $url, array $options): FakeCompletionResponse
+    {
+        return new FakeCompletionResponse($this->text);
+    }
+}
+
+class FakeCompletionResponse
+{
+    public function __construct(private string $text)
+    {
+    }
+
+    public function getBody(): string
+    {
+        return json_encode([
+            'choices' => [
+                ['text' => $this->text],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
## Intent Summary

Stabilize BlueCore's generator subsystem contracts beyond the baseline parse and factory fixes in the package-readiness branch.

This PR keeps the generator namespace package-owned, adds a clear supported-type list and aliases, introduces fail-fast generator creation for callers that need strict behavior, normalizes generated output paths through the BlueCore path utility, and makes the optional GPT code generator accept an injected HTTP client so tests and local code do not require network or secrets.

Closes #6.

## User Stories / Acceptance Criteria

- As a maintainer, I can inspect the supported generator types directly from the factory.
- As a caller, I can use `createOrFail()` when an unknown generator type should be treated as a contract error.
- As a contributor, factory aliases such as `html`, `value object`, and `admin-module` resolve predictably.
- As a test author, GPT code generation can be exercised with an injected client instead of a real HTTP dependency.
- As a package consumer, missing optional HTTP support fails with a clear exception rather than a fatal class error.

## Key Files Changed

- `src/BlueCore/Generation/GeneratorFactory.php`
- `src/BlueCore/Generation/BaseGenerator.php`
- `src/BlueCore/Generation/Gpt4CodeGenerator.php`
- `tests/BlueCore/Generation/GeneratorFactoryTest.php`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\BlueCore\Generation\GeneratorFactoryTest.php
composer ci
```

## QA Checklist

- [x] Factory dispatch covers supported generator types and aliases.
- [x] Unknown strict creation throws a clear exception.
- [x] Generator output paths use the BlueCore `Path` utility.
- [x] GPT code generation can use an injected client in tests.
- [x] `composer ci` passes without network calls or secrets.

## Approval Conditions

- PR #11 remains mergeable into `main`, or this branch is retargeted to `main` after PR #11 lands.
- Review confirms the alias list and fail-fast behavior are the expected package contract.
