### PR TITLE
Reconcile SQLite model boundary with DevElation storage

### DIFF
--- a/docs/sqlite-model-boundary.md
+++ b/docs/sqlite-model-boundary.md
@@ -1,0 +1,32 @@
+# SQLite Model Boundary
+
+BlueCore uses `BlueFission\BlueCore\Model\ModelSQLite` as a model-level projection over local SQLite storage.
+
+The upstream DevElation storage adapter is `BlueFission\Data\Storage\SQLite`. That adapter remains the canonical storage contract for direct SQLite data access, status vocabulary, query diagnostics, and broad storage behavior. BlueCore should rely on that contract when it needs generic SQLite storage.
+
+`SQLiteModelStore` remains in BlueCore for the model-specific layer that is not a direct replacement for the upstream adapter:
+
+- explicit model field projection from `ModelSQLite::$_fields`
+- optional `column_types` for model-local schema shape
+- materialized `Group` results for model query reads
+- single-table model query diagnostics
+- predictable `created` and `updated` timestamp behavior from `ModelSQLite`
+
+The boundary is intentionally narrow. New storage primitives should go upstream to DevElation first. BlueCore should keep only the model-facing behavior that binds storage to the framework model contract.
+
+## Diagnostics
+
+`SQLiteModelStore::diagnostics()` returns a compact trace shape:
+
+```php
+[
+    'upstreamStorage' => BlueFission\Data\Storage\SQLite::class,
+    'table' => 'records',
+    'key' => 'record_id',
+    'query' => 'SELECT * FROM `records`',
+    'status' => BlueFission\Data\Storage\Storage::STATUS_SUCCESS,
+    'rowCount' => 1,
+]
+```
+
+Use the diagnostics for tests, trace output, and operational inspection. Do not parse SQL strings for application decisions.

--- a/src/BlueCore/Model/SQLiteModelStore.php
+++ b/src/BlueCore/Model/SQLiteModelStore.php
@@ -4,10 +4,14 @@ namespace BlueFission\BlueCore\Model;
 
 use BlueFission\Arr;
 use BlueFission\Collections\Group;
+use BlueFission\Data\Storage\SQLite as DevElationSQLite;
+use BlueFission\Data\Storage\Storage;
 use BlueFission\Str;
 
 class SQLiteModelStore
 {
+    public const UPSTREAM_STORAGE = DevElationSQLite::class;
+
     protected $_config = [
         'location' => '',
         'name' => '',
@@ -176,7 +180,7 @@ class SQLiteModelStore
             }
         }
 
-        $this->_status = $result ? 'Success.' : 'Failed.';
+        $this->_status = $result ? Storage::STATUS_SUCCESS : Storage::STATUS_FAILED;
         if ($result instanceof \SQLite3Result) {
             $result->finalize();
         }
@@ -228,7 +232,7 @@ class SQLiteModelStore
         }
 
         $this->_rows = $rows;
-        $this->_status = 'Success.';
+        $this->_status = Storage::STATUS_SUCCESS;
 
         if ($rows) {
             foreach ($rows[0] as $field => $value) {
@@ -253,7 +257,7 @@ class SQLiteModelStore
             $statement = $db->prepare($this->_query);
             $statement->bindValue(':__key', $identifier, SQLITE3_INTEGER);
             $result = $statement->execute();
-            $this->_status = $result ? 'Success.' : 'Failed.';
+            $this->_status = $result ? Storage::STATUS_SUCCESS : Storage::STATUS_FAILED;
             if ($result instanceof \SQLite3Result) {
                 $result->finalize();
             }
@@ -288,6 +292,36 @@ class SQLiteModelStore
         $this->_status = $message;
 
         return $this;
+    }
+
+    public function diagnostics(): array
+    {
+        return Arr::make([
+            'upstreamStorage' => self::UPSTREAM_STORAGE,
+            'table' => $this->config('name'),
+            'key' => $this->primary(),
+            'query' => $this->_query,
+            'status' => $this->_status,
+            'rowCount' => Arr::count($this->_rows),
+        ])->toArray();
+    }
+
+    public static function boundary(): array
+    {
+        return Arr::make([
+            'upstreamStorage' => self::UPSTREAM_STORAGE,
+            'blueCoreRole' => 'model_projection_store',
+            'delegatesToUpstreamFor' => [
+                'status_constants',
+                'sqlite_storage_contract',
+            ],
+            'retainsLocally' => [
+                'explicit_column_types',
+                'model_field_projection',
+                'materialized_group_results',
+                'single_table_model_query_diagnostics',
+            ],
+        ])->toArray();
     }
 
     public function primary(): string

--- a/tests/BlueCore/Model/ModelSQLiteTest.php
+++ b/tests/BlueCore/Model/ModelSQLiteTest.php
@@ -3,6 +3,9 @@
 namespace BlueFission\Tests\BlueCore\Model;
 
 use BlueFission\BlueCore\Model\ModelSQLite;
+use BlueFission\BlueCore\Model\SQLiteModelStore;
+use BlueFission\Data\Storage\SQLite as DevElationSQLite;
+use BlueFission\Data\Storage\Storage;
 use PHPUnit\Framework\TestCase;
 
 class ModelSQLiteTest extends TestCase
@@ -54,6 +57,34 @@ class ModelSQLiteTest extends TestCase
         $this->assertSame('first', $rows[0]['name']);
         $this->assertSame('second', $rows[1]['name']);
     }
+
+    public function testSQLiteStoreBoundaryNamesDevElationStorageAndLocalResponsibilities(): void
+    {
+        $boundary = SQLiteModelStore::boundary();
+
+        $this->assertSame(DevElationSQLite::class, $boundary['upstreamStorage']);
+        $this->assertSame('model_projection_store', $boundary['blueCoreRole']);
+        $this->assertContains('sqlite_storage_contract', $boundary['delegatesToUpstreamFor']);
+        $this->assertContains('materialized_group_results', $boundary['retainsLocally']);
+    }
+
+    public function testSQLiteStoreDiagnosticsExposeQueryStatusAndRows(): void
+    {
+        $writer = new TestSQLiteModel($this->database);
+        $writer->write(['name' => 'first', 'status' => 'active']);
+
+        $reader = new TestSQLiteModel($this->database);
+        $reader->read();
+
+        $diagnostics = $reader->storeDiagnostics();
+
+        $this->assertSame(DevElationSQLite::class, $diagnostics['upstreamStorage']);
+        $this->assertSame('test_records', $diagnostics['table']);
+        $this->assertSame('record_id', $diagnostics['key']);
+        $this->assertStringContainsString('SELECT', $diagnostics['query']);
+        $this->assertSame(Storage::STATUS_SUCCESS, $diagnostics['status']);
+        $this->assertSame(1, $diagnostics['rowCount']);
+    }
 }
 
 class TestSQLiteModel extends ModelSQLite
@@ -64,4 +95,9 @@ class TestSQLiteModel extends ModelSQLite
         'name',
         'status',
     ];
+
+    public function storeDiagnostics(): array
+    {
+        return $this->_dataObject->diagnostics();
+    }
 }


### PR DESCRIPTION
## Intent Summary

Reconcile BlueCore's SQLite model layer with the upstream DevElation SQLite storage contract by making the ownership boundary explicit and test-covered.

This PR does not force a risky replacement of `SQLiteModelStore` with `BlueFission\Data\Storage\SQLite`, because the upstream class is the generic storage adapter while BlueCore's local store is a model projection layer with explicit field lists, optional column types, materialized `Group` results, and model query diagnostics. The PR instead names the upstream adapter, reuses DevElation storage status constants, exposes diagnostics, and documents what should stay local versus upstream.

Closes #7.

## User Stories / Acceptance Criteria

- As a maintainer, I can see which DevElation SQLite storage adapter BlueCore aligns with.
- As a reviewer, I can inspect the model-local responsibilities retained by BlueCore.
- As a model caller, I can read query/status/row-count diagnostics without parsing internal state.
- As a contributor, future SQLite primitive work has a clear upstream-first boundary.

## Key Files Changed

- `src/BlueCore/Model/SQLiteModelStore.php`
- `tests/BlueCore/Model/ModelSQLiteTest.php`
- `docs/sqlite-model-boundary.md`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\BlueCore\Model\ModelSQLiteTest.php
composer ci
```

## QA Checklist

- [x] Local SQLite model store names `BlueFission\Data\Storage\SQLite` as the upstream adapter.
- [x] Store status values use DevElation storage constants.
- [x] Diagnostics expose upstream storage, table, key, query, status, and row count.
- [x] Boundary documentation explains retained BlueCore responsibilities.
- [x] `composer ci` passes.

## Approval Conditions

- PR #16 remains mergeable into its base, or this branch is retargeted after #16 lands.
- Review confirms the local store should remain as the model projection layer for now.
