### PR TITLE
Define extension registration contracts

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -1,0 +1,39 @@
+# Extension Registration Contracts
+
+BlueCore extension registration is package-level framework behavior. It should stay generic enough for any BlueCore consumer while remaining prescriptive about the lifecycle shape.
+
+## Registration Lifecycle
+
+An extension can describe its contribution through a `RegistrationPlan`:
+
+- services: reusable service names and definitions
+- delegates: callable or class-backed delegation entries
+- bindings: symbolic binding names mapped to implementation definitions
+- themes: named theme locations
+- addons: add-on metadata and lifecycle entries
+
+Registrars implement `BlueFission\BlueCore\Contracts\IApplicationRegistrar` and receive both the application instance and a mutable `RegistrationPlan`.
+
+## Add-on Lifecycle
+
+Add-on lifecycle managers implement `IAddOnLifecycleManager`:
+
+- `install($name, bool $installDependencies = false): array`
+- `uninstall($addOnId, bool $removeDependencies = false): array`
+- `activate($addOnId): array`
+- `deactivate($addOnId): array`
+
+Lifecycle methods return structured arrays so callers can compose results, log decisions, and avoid process termination.
+
+## Theme Registry
+
+Theme registries implement `IThemeRegistry`:
+
+- `registerTheme(string $name, string $location = null): mixed`
+- `theme(string $name): mixed`
+
+The interface intentionally avoids prescribing a concrete theme storage backend. BlueCore owns the contract, while applications decide how registered themes are stored and exposed.
+
+## Ownership Boundary
+
+BlueCore owns the registration vocabulary, lifecycle result shape, and generic plan object. Applications own concrete service definitions, concrete bindings, route surfaces, and deployment-specific activation policy.

--- a/src/BlueCore/Contracts/IAddOnLifecycleManager.php
+++ b/src/BlueCore/Contracts/IAddOnLifecycleManager.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BlueFission\BlueCore\Contracts;
+
+interface IAddOnLifecycleManager
+{
+    public function install($name, bool $installDependencies = false): array;
+    public function uninstall($addOnId, bool $removeDependencies = false): array;
+    public function activate($addOnId): array;
+    public function deactivate($addOnId): array;
+}

--- a/src/BlueCore/Contracts/IApplicationRegistrar.php
+++ b/src/BlueCore/Contracts/IApplicationRegistrar.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BlueFission\BlueCore\Contracts;
+
+use BlueFission\BlueCore\Registration\RegistrationPlan;
+use BlueFission\Services\Application;
+
+interface IApplicationRegistrar
+{
+    public function register(Application $app, RegistrationPlan $plan): void;
+}

--- a/src/BlueCore/Contracts/IThemeRegistry.php
+++ b/src/BlueCore/Contracts/IThemeRegistry.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BlueFission\BlueCore\Contracts;
+
+interface IThemeRegistry
+{
+    public function registerTheme(string $name, ?string $location = null): mixed;
+    public function theme(string $name): mixed;
+}

--- a/src/BlueCore/Registration/RegistrationPlan.php
+++ b/src/BlueCore/Registration/RegistrationPlan.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace BlueFission\BlueCore\Registration;
+
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+use BlueFission\Val;
+
+class RegistrationPlan
+{
+    private array $services = [];
+    private array $delegates = [];
+    private array $bindings = [];
+    private array $themes = [];
+    private array $addons = [];
+
+    public function service(string $name, mixed $definition): self
+    {
+        return $this->put('services', $name, $definition);
+    }
+
+    public function delegate(string $name, mixed $definition): self
+    {
+        return $this->put('delegates', $name, $definition);
+    }
+
+    public function binding(string $name, mixed $definition): self
+    {
+        return $this->put('bindings', $name, $definition);
+    }
+
+    public function theme(string $name, string $location = null): self
+    {
+        return $this->put('themes', $name, [
+            'name' => $name,
+            'location' => $location,
+        ]);
+    }
+
+    public function addon(string $name, array $definition = []): self
+    {
+        return $this->put('addons', $name, Arr::make(['name' => $name])->merge($definition)->toArray());
+    }
+
+    public function entries(string $section): array
+    {
+        if (!Arr::hasKey($this->sections(), $section)) {
+            throw new \InvalidArgumentException("Unknown registration section '{$section}'.");
+        }
+
+        return (new Collection($this->{$section}))->toArray();
+    }
+
+    public function toArray(): array
+    {
+        return Arr::make($this->sections())->toArray();
+    }
+
+    private function put(string $section, string $name, mixed $definition): self
+    {
+        if (Val::isEmpty($name)) {
+            throw new \InvalidArgumentException('Registration names cannot be empty.');
+        }
+
+        $this->{$section}[$name] = $definition;
+
+        return $this;
+    }
+
+    private function sections(): array
+    {
+        return [
+            'services' => $this->services,
+            'delegates' => $this->delegates,
+            'bindings' => $this->bindings,
+            'themes' => $this->themes,
+            'addons' => $this->addons,
+        ];
+    }
+}

--- a/tests/BlueCore/Contracts/RegistrationPlanTest.php
+++ b/tests/BlueCore/Contracts/RegistrationPlanTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Contracts;
+
+use BlueFission\BlueCore\Contracts\IAddOnLifecycleManager;
+use BlueFission\BlueCore\Contracts\IApplicationRegistrar;
+use BlueFission\BlueCore\Contracts\IThemeRegistry;
+use BlueFission\BlueCore\Registration\RegistrationPlan;
+use PHPUnit\Framework\TestCase;
+
+class RegistrationPlanTest extends TestCase
+{
+    public function testRegistrationPlanCollectsFrameworkContributions(): void
+    {
+        $plan = (new RegistrationPlan())
+            ->service('cache', 'CacheService')
+            ->delegate('boot', 'BootDelegate')
+            ->binding('repository.users', 'UserRepository')
+            ->theme('admin', 'resource/markup/admin')
+            ->addon('reports', ['version' => '1.0.0']);
+
+        $this->assertSame('CacheService', $plan->entries('services')['cache']);
+        $this->assertSame('BootDelegate', $plan->entries('delegates')['boot']);
+        $this->assertSame('UserRepository', $plan->entries('bindings')['repository.users']);
+        $this->assertSame('resource/markup/admin', $plan->entries('themes')['admin']['location']);
+        $this->assertSame('1.0.0', $plan->entries('addons')['reports']['version']);
+    }
+
+    public function testRegistrationPlanRejectsUnknownSectionsAndEmptyNames(): void
+    {
+        $plan = new RegistrationPlan();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $plan->entries('missing');
+    }
+
+    public function testRegistrationContractsAreDefined(): void
+    {
+        $this->assertTrue(interface_exists(IApplicationRegistrar::class));
+        $this->assertTrue(interface_exists(IAddOnLifecycleManager::class));
+        $this->assertTrue(interface_exists(IThemeRegistry::class));
+    }
+}


### PR DESCRIPTION
## Intent Summary

Formalize BlueCore extension, add-on, theme, and application registration contracts.

This PR adds package-owned interfaces for application registrars, add-on lifecycle managers, and theme registries, plus a `RegistrationPlan` object that collects services, delegates, bindings, themes, and add-ons with DevElation helper-backed structure.

Closes #9.

## User Stories / Acceptance Criteria

- As a BlueCore extension author, I can describe services, delegates, bindings, themes, and add-ons through one plan object.
- As a framework maintainer, I can type against stable registrar, add-on lifecycle, and theme registry contracts.
- As a contributor, I can inspect the lifecycle and ownership boundary in package documentation.
- As a reviewer, registration plan behavior is covered by focused tests.

## Key Files Changed

- `src/BlueCore/Contracts/IApplicationRegistrar.php`
- `src/BlueCore/Contracts/IAddOnLifecycleManager.php`
- `src/BlueCore/Contracts/IThemeRegistry.php`
- `src/BlueCore/Registration/RegistrationPlan.php`
- `docs/extension-registration-contracts.md`
- `tests/BlueCore/Contracts/RegistrationPlanTest.php`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\BlueCore\Contracts\RegistrationPlanTest.php
composer ci
```

## QA Checklist

- [x] Registration interfaces are package-owned and generic.
- [x] `RegistrationPlan` captures services, delegates, bindings, themes, and add-ons.
- [x] Documentation identifies BlueCore versus application ownership.
- [x] Tests cover plan collection and interface presence.
- [x] `composer ci` passes.

## Approval Conditions

- PR #11 remains mergeable into `main`, or this branch is retargeted to `main` after PR #11 lands.
- Review confirms the interface names and plan sections match the desired BlueCore registration vocabulary.
