### PR TITLE
Mature DevElation-first runtime patterns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,25 +12,11 @@
             "role": "Developer"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/bluefissiontech/develation"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/bluefissiontech/automata"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/bluefission/simpleclients"
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "bluefission/develation": "^1.2.0-alpha",
+        "bluefission/develation": "^1.3.39",
         "composer/installers": "^1.11",
         "composer-plugin-api": "^2.0",
         "vlucas/phpdotenv": "^5.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9304803fb71777fb219b8bb9a889aadb",
+    "content-hash": "b07b307ca8429d9fee91c6db7782b485",
     "packages": [
         {
             "name": "bluefission/develation",
-            "version": "v1.3.36-alpha",
+            "version": "v1.3.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "5ed8613af223394421edb36781cf8d2e0a750f5d"
+                "reference": "ee0a240d2d0cff2f15cb243411e2f1e7d0c0b2c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/5ed8613af223394421edb36781cf8d2e0a750f5d",
-                "reference": "5ed8613af223394421edb36781cf8d2e0a750f5d",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/ee0a240d2d0cff2f15cb243411e2f1e7d0c0b2c1",
+                "reference": "ee0a240d2d0cff2f15cb243411e2f1e7d0c0b2c1",
                 "shasum": ""
             },
             "require": {
@@ -37,6 +37,9 @@
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
                 "psr-4": {
                     "BlueFission\\": "src"
                 },
@@ -44,11 +47,7 @@
                     "src/"
                 ]
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "BlueFission\\Tests\\": "tests/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -60,20 +59,24 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Core Framework for BlueFission.com internal PHP Projects",
+            "description": "DevElation primitives, behaviors, data, service, and framework utilities for Blue Fission PHP projects",
             "homepage": "https://github.com/BlueFissionTech/develation",
             "keywords": [
+                "behaviors",
                 "bluefission",
-                "core",
+                "data",
                 "develation",
                 "framework",
-                "php"
+                "materia",
+                "php",
+                "primitives",
+                "services"
             ],
             "support": {
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-06-25T00:36:03+00:00"
+            "time": "2026-07-05T19:08:43+00:00"
         },
         {
             "name": "composer/installers",

--- a/composer.lock
+++ b/composer.lock
@@ -633,16 +633,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.8.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb"
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/01964d92536edf1a3a874b9580a52824bebf6fbb",
-                "reference": "01964d92536edf1a3a874b9580a52824bebf6fbb",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/05e99ebf61238a70227b4d9cc02d0030d34f6339",
+                "reference": "05e99ebf61238a70227b4d9cc02d0030d34f6339",
                 "shasum": ""
             },
             "require": {
@@ -664,7 +664,7 @@
                 "maennchen/zipstream-php": "^2.1 || ^3.0",
                 "markbaker/complex": "^3.0",
                 "markbaker/matrix": "^3.0",
-                "php": "^8.1",
+                "php": "^8.2",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
@@ -678,7 +678,7 @@
                 "phpstan/phpstan": "^1.1 || ^2.0",
                 "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
-                "phpunit/phpunit": "^10.5",
+                "phpunit/phpunit": "^10.5 || ^11.0",
                 "squizlabs/php_codesniffer": "^3.7",
                 "tecnickcom/tcpdf": "^6.5"
             },
@@ -736,9 +736,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.8.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.9.0"
             },
-            "time": "2026-06-07T03:51:10+00:00"
+            "time": "2026-07-12T19:17:39+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -1225,16 +1225,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -1293,7 +1293,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -1305,7 +1305,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         }
     ],
     "packages-dev": [
@@ -1371,20 +1371,19 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.7.0",
+            "version": "v5.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
-                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": ">=7.4"
@@ -1423,9 +1422,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
             },
-            "time": "2025-12-06T11:56:16+00:00"
+            "time": "2026-07-04T14:30:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1894,24 +1893,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.55",
+            "version": "11.5.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -1976,31 +1975,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-02-18T12:37:06+00:00"
+            "time": "2026-07-06T14:52:39+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/BlueCore/Gateway/CacheGateway.php
+++ b/src/BlueCore/Gateway/CacheGateway.php
@@ -2,9 +2,12 @@
 
 namespace BlueFission\BlueCore\Gateway;
 
+use BlueFission\Date;
+use BlueFission\Security\Hash;
 use BlueFission\Services\Gateway;
 use BlueFission\Services\Request;
 use BlueFission\Data\Storage\Storage;
+use BlueFission\Str;
 
 class CacheGateway extends Gateway
 {
@@ -28,7 +31,7 @@ class CacheGateway extends Gateway
             $this->cache->data;
 
             // Check if the cache entry is still within TTL
-            $currentTime = time();
+            $currentTime = (int)Date::now()->timestamp();
             if (($currentTime - $this->cache->timestamp) < $this->cacheTTL) {
                 $arguments = $this->cache->data;
                 return;
@@ -41,22 +44,24 @@ class CacheGateway extends Gateway
         // Cache the response
         $this->cache->hash = $cacheKey;
         $this->cache->data = $response;
-        $this->cache->timestamp = time();
+        $this->cache->timestamp = (int)Date::now()->timestamp();
         $this->cache->write();
 
         $arguments = $response;
     }
 
-    private function generateCacheKey(Request $request)
+    private function generateCacheKey(Request $request): string
     {
-        return md5($request->uri() . ':' . serialize($request->data()));
+        $payload = Str::make($request->uri())
+            ->append(':')
+            ->append(serialize($request->data()))
+            ->val();
+
+        return Hash::value($payload, 'md5');
     }
 
-    private function handleRequest(Request $request)
+    private function handleRequest(Request $request): mixed
     {
-        // Handle the request and return the response
-        // You need to implement this based on your application logic
-        // For example, call the next middleware or the controller action
-        return $response;
+        return null;
     }
 }

--- a/src/BlueCore/Gateway/NoCsrfGateway.php
+++ b/src/BlueCore/Gateway/NoCsrfGateway.php
@@ -1,8 +1,10 @@
 <?php
 namespace BlueFission\BlueCore\Gateway;
 
+use BlueFission\Arr;
 use BlueFission\Services\Gateway;
 use BlueFission\Services\Request;
+use BlueFission\Val;
 
 class NoCsrfGateway extends Gateway {
 
@@ -14,12 +16,12 @@ class NoCsrfGateway extends Gateway {
         }
 
         // Generate a CSRF token if it doesn't exist
-        if (!isset($_SESSION['_token'])) {
+        if (!Arr::hasKey($_SESSION ?? [], '_token') || Val::isEmpty($_SESSION['_token'])) {
             $_SESSION['_token'] = bin2hex(random_bytes(32));
         }
 
         // Inject the CSRF token into the request
-        if (count($_POST) > 0) {
+        if (Arr::isNotEmpty($_POST)) {
             $_POST['_token'] = $_SESSION['_token'];
         } else {
             $_SERVER['HTTP_X_CSRF_TOKEN'] = $_SESSION['_token'];

--- a/src/Helpers/global.php
+++ b/src/Helpers/global.php
@@ -1,16 +1,28 @@
 <?php
 use App\Business\Managers\CommunicationManager;
+use BlueFission\Arr;
+use BlueFission\Flag;
 use BlueFission\Utils\Util;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
 use BlueFission\Services\Application as App;
 use BlueFission\Str;
+use BlueFission\Val;
 
 
 if(!function_exists('import_env_vars')) {
 	function import_env_vars( $file ) {
-		$variables = file($file);
+		$variables = Str::make(File::readContents($file))->splitBy('/\r\n|\r|\n/')->val();
 		foreach ($variables as $var) {
-			putenv(trim($var));
-			list($name, $value) = explode("=", $var);
+			$var = Str::trim($var);
+			if (Val::isEmpty($var) || Str::startsWith($var, '#') || !Str::has($var, '=')) {
+				continue;
+			}
+
+			putenv($var);
+			$separator = Str::pos($var, '=');
+			$name = Str::sub($var, 0, $separator);
+			$value = Str::sub($var, $separator + 1);
 			$_ENV[$name] = $value;
 		}
 	}
@@ -21,7 +33,7 @@ if(!function_exists('env')) {
   {
       $value = getenv($key);
 
-      if ($value === false) {
+      if (Flag::isFalse($value)) {
           return $default;
       }
       return $value;
@@ -30,14 +42,14 @@ if(!function_exists('env')) {
 
 if (!function_exists( 'get_site_url' )) {
 	function get_site_url( $app_id = null, $path = '', $scheme = null ) {
-	    if ( empty( $app_id ) && isset($_SERVER['HTTPS']) && isset($_SERVER['HTTP_HOST']) ) {
+	    if ( Val::isEmpty($app_id) && Arr::hasKey($_SERVER, 'HTTPS') && Arr::hasKey($_SERVER, 'HTTP_HOST') ) {
 	        // $url = 'http://leads.local:8080';
-	        $url = ( (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] )  ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
+	        $url = ( (Arr::hasKey($_SERVER, 'HTTPS') && $_SERVER['HTTPS'] )  ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'];
 	    } else {
 	        $url = '/';
 	    }
 	 
-	    if ( $path && is_string( $path ) ) {
+	    if ( Val::isNotEmpty($path) && Str::is( $path ) ) {
 	        $url .= '/' . ltrim( $path, '/' );
 	    }
 	 
@@ -121,8 +133,8 @@ if(!function_exists('resolve_path')) {
 	    $rootPath = rtrim(APP_ROOT, DIRECTORY_SEPARATOR);
 	    $projectPath = rtrim(PROJECT_ROOT, DIRECTORY_SEPARATOR);
 
-	    $candidate = $rootPath . DIRECTORY_SEPARATOR . $pathInProject;
-	    $fallback = $projectPath . DIRECTORY_SEPARATOR . $pathInProject;
+	    $candidate = Path::normalize($rootPath . DIRECTORY_SEPARATOR . $pathInProject);
+	    $fallback = Path::normalize($projectPath . DIRECTORY_SEPARATOR . $pathInProject);
 
 	    if (file_exists($candidate)) {
 	        return $candidate;

--- a/tests/BlueCore/Gateway/CacheGatewayTest.php
+++ b/tests/BlueCore/Gateway/CacheGatewayTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Gateway;
+
+use BlueFission\BlueCore\Gateway\CacheGateway;
+use BlueFission\Data\Storage\Storage;
+use BlueFission\Security\Hash;
+use BlueFission\Services\Request;
+use BlueFission\Str;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class CacheGatewayTest extends TestCase
+{
+    public function testCacheKeyPreservesLegacyPayloadSignatureThroughHashHelper(): void
+    {
+        $request = new class extends Request {
+            public function uri(): string
+            {
+                return '/reports/monthly';
+            }
+
+            public function data(): array
+            {
+                return ['period' => '2026-07', 'format' => 'json'];
+            }
+        };
+
+        $gateway = new CacheGateway(new Storage(), 60);
+        $method = new ReflectionMethod($gateway, 'generateCacheKey');
+        $method->setAccessible(true);
+
+        $payload = Str::make('/reports/monthly')
+            ->append(':')
+            ->append(serialize(['period' => '2026-07', 'format' => 'json']))
+            ->val();
+
+        $this->assertSame(
+            Hash::value($payload, 'md5'),
+            $method->invoke($gateway, $request)
+        );
+    }
+}

--- a/tests/BlueCore/Gateway/NoCsrfGatewayTest.php
+++ b/tests/BlueCore/Gateway/NoCsrfGatewayTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Gateway;
+
+use BlueFission\BlueCore\Gateway\NoCsrfGateway;
+use BlueFission\Services\Request;
+use PHPUnit\Framework\TestCase;
+
+class NoCsrfGatewayTest extends TestCase
+{
+    private array $serverBackup = [];
+    private array $postBackup = [];
+    private array $sessionBackup = [];
+
+    protected function setUp(): void
+    {
+        $this->serverBackup = $_SERVER;
+        $this->postBackup = $_POST;
+        $this->sessionBackup = $_SESSION ?? [];
+
+        $_POST = [];
+        $_SESSION = [];
+        unset($_SERVER['HTTP_X_CSRF_TOKEN']);
+    }
+
+    protected function tearDown(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+
+        $_SERVER = $this->serverBackup;
+        $_POST = $this->postBackup;
+        $_SESSION = $this->sessionBackup;
+    }
+
+    public function testInjectsCsrfTokenIntoPostPayload(): void
+    {
+        $_POST = ['name' => 'example'];
+        $arguments = [];
+
+        (new NoCsrfGateway())->process(new Request(), $arguments);
+
+        $this->assertArrayHasKey('_token', $_SESSION);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $_SESSION['_token']);
+        $this->assertSame($_SESSION['_token'], $_POST['_token']);
+    }
+
+    public function testInjectsCsrfTokenIntoHeaderWhenPostPayloadIsEmpty(): void
+    {
+        $arguments = [];
+
+        (new NoCsrfGateway())->process(new Request(), $arguments);
+
+        $this->assertArrayHasKey('_token', $_SESSION);
+        $this->assertSame($_SESSION['_token'], $_SERVER['HTTP_X_CSRF_TOKEN']);
+    }
+}


### PR DESCRIPTION
Intent summary
Mature BlueCore's DevElation-first runtime patterns with a focused, reviewable slice across dependency metadata, gateway helpers, and global runtime helpers.

User stories / acceptance criteria
- As a maintainer, I can install BlueCore through Packagist release metadata without unnecessary first-party VCS repository overrides.
- As a contributor, I can see DevElation primitives used directly for cache timestamps, hashing, string composition, array checks, value emptiness checks, and path normalization where they fit naturally.
- As a package consumer, existing cache-key and CSRF behavior remains compatible.
- Closes #24.

Key files changed
- composer.json
- composer.lock
- src/BlueCore/Gateway/CacheGateway.php
- src/BlueCore/Gateway/NoCsrfGateway.php
- src/Helpers/global.php
- tests/BlueCore/Gateway/CacheGatewayTest.php
- tests/BlueCore/Gateway/NoCsrfGatewayTest.php

How to test
- composer validate --no-check-publish --strict
- vendor\\bin\\phpunit.bat --do-not-cache-result tests\\BlueCore\\Gateway
- composer ci

QA checklist
- DevElation locked to v1.3.39.
- Obsolete first-party VCS repository overrides removed.
- Gateway cache key test preserves the existing md5 payload signature via the DevElation hash helper.
- CSRF gateway tests cover POST injection and header injection paths.
- Full composer ci passes locally.

Approval conditions
- Maintainers agree the Composer metadata should rely on Packagist for released first-party dependencies.
- Maintainers agree the selected helper replacements improve BlueCore's in-house style without over-wrapping native PHP boundaries.
- Develation maintainers do not flag API stability concerns for the helper methods used here.