### PR TITLE
Characterize menu manager behavior

### DIFF
--- a/src/BlueCore/Business/Managers/NavMenuManager.php
+++ b/src/BlueCore/Business/Managers/NavMenuManager.php
@@ -6,6 +6,7 @@ use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Services\Service;
 use BlueFission\BlueCore\Auth as Authenticator;
 use BlueFission\BlueCore\MenuItem;
+use BlueFission\Val;
 
 class NavMenuManager extends Service
 {
@@ -57,9 +58,9 @@ class NavMenuManager extends Service
 
                     // Check role, group, and permission against current user
                     if (
-                        ($requiredRole && !$this->_authenticator->hasRole($requiredRole)) ||
-                        ($requiredGroup && !$this->_authenticator->isInGroup($requiredGroup)) ||
-                        ($requiredPermission && !$this->_authenticator->hasPermission($requiredPermission))
+                        (Val::isNotEmpty($requiredRole) && !$this->_authenticator->hasRole($requiredRole)) ||
+                        (Val::isNotEmpty($requiredGroup) && !$this->_authenticator->isInGroup($requiredGroup)) ||
+                        (Val::isNotEmpty($requiredPermission) && !$this->_authenticator->hasPermission($requiredPermission))
                     ) {
                         continue; // Skip this item if user does not meet requirements
                     }
@@ -70,7 +71,7 @@ class NavMenuManager extends Service
             }
         }
 
-        return implode("\n", $renderedItems);
+        return Arr::make($renderedItems)->join("\n")->val();
     }
 
     public function displayMenuItemBasedOnRole($menuId, $itemId, $role)

--- a/src/BlueCore/Business/Managers/NavMenuManager.php
+++ b/src/BlueCore/Business/Managers/NavMenuManager.php
@@ -71,7 +71,7 @@ class NavMenuManager extends Service
             }
         }
 
-        return Arr::make($renderedItems)->join("\n")->val();
+        return Arr::isNotEmpty($renderedItems) ? implode("\n", $renderedItems) : '';
     }
 
     public function displayMenuItemBasedOnRole($menuId, $itemId, $role)

--- a/tests/BlueCore/Business/Managers/NavMenuManagerTest.php
+++ b/tests/BlueCore/Business/Managers/NavMenuManagerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Business\Managers;
+
+use BlueFission\BlueCore\Auth;
+use BlueFission\BlueCore\Business\Managers\NavMenuManager;
+use BlueFission\BlueCore\MenuItem;
+use PHPUnit\Framework\TestCase;
+
+class NavMenuManagerTest extends TestCase
+{
+    public function testRenderMenuJoinsAllowedItemsAndSkipsUnauthorizedItems(): void
+    {
+        $manager = new NavMenuManager(new FakeMenuAuthenticator(
+            roles: ['admin'],
+            groups: ['staff'],
+            permissions: ['reports.view']
+        ));
+
+        $menu = new FakeMenu('main');
+        $menu->addItem(new FakeMenuItem('Allowed', '/allowed', role: 'admin'));
+        $menu->addItem(new FakeMenuItem('Denied Role', '/denied-role', role: 'owner'));
+        $menu->addItem(new FakeMenuItem('Allowed Permission', '/allowed-permission', permission: 'reports.view'));
+        $menu->addItem(new FakeMenuItem('Denied Permission', '/denied-permission', permission: 'reports.edit'));
+
+        $manager->registerMenu($menu);
+
+        $this->assertSame(
+            '<item>Allowed</item>' . "\n" . '<item>Allowed Permission</item>',
+            $manager->renderMenu('main')
+        );
+    }
+
+    public function testConditionalDisplayHelpersRenderMatchingItems(): void
+    {
+        $manager = new NavMenuManager(new FakeMenuAuthenticator());
+        $menu = new FakeMenu('settings');
+        $menu->addItem(new FakeMenuItem('Users', '/users', role: 'admin', group: 'staff', permission: 'users.manage'));
+        $manager->registerMenu($menu);
+
+        $this->assertSame('<item>Users</item>', $manager->displayMenuItemBasedOnRole('settings', 'users', 'admin'));
+        $this->assertSame('<item>Users</item>', $manager->displayMenuItemBasedOnGroup('settings', 'users', 'staff'));
+        $this->assertSame('<item>Users</item>', $manager->displayMenuItemBasedOnPermission('settings', 'users', 'users.manage'));
+        $this->assertSame('', $manager->displayMenuItemBasedOnRole('settings', 'users', 'operator'));
+    }
+}
+
+class FakeMenu
+{
+    private array $items = [];
+
+    public function __construct(private string $id)
+    {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function addItem(MenuItem $item): void
+    {
+        $this->items[$item->getId()] = $item;
+    }
+
+    public function getItem(string $itemId): ?MenuItem
+    {
+        return $this->items[$itemId] ?? null;
+    }
+
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}
+
+class FakeMenuItem extends MenuItem
+{
+    public function render(): string
+    {
+        return '<item>' . $this->getLabel() . '</item>';
+    }
+}
+
+class FakeMenuAuthenticator extends Auth
+{
+    public function __construct(
+        private array $roles = [],
+        private array $groups = [],
+        private array $permissions = []
+    ) {
+    }
+
+    public function hasRole(string $role): bool
+    {
+        return in_array($role, $this->roles, true);
+    }
+
+    public function isInGroup(string $group): bool
+    {
+        return in_array($group, $this->groups, true);
+    }
+
+    public function hasPermission(string $permission): bool
+    {
+        return in_array($permission, $this->permissions, true);
+    }
+}

--- a/tests/BlueCore/Business/Managers/NavMenuManagerTest.php
+++ b/tests/BlueCore/Business/Managers/NavMenuManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Tests\BlueCore\Business\Managers;
 
+use BlueFission\Arr;
 use BlueFission\BlueCore\Auth;
 use BlueFission\BlueCore\Business\Managers\NavMenuManager;
 use BlueFission\BlueCore\MenuItem;
@@ -93,16 +94,16 @@ class FakeMenuAuthenticator extends Auth
 
     public function hasRole(string $role): bool
     {
-        return in_array($role, $this->roles, true);
+        return Arr::has($this->roles, $role, true);
     }
 
     public function isInGroup(string $group): bool
     {
-        return in_array($group, $this->groups, true);
+        return Arr::has($this->groups, $group, true);
     }
 
     public function hasPermission(string $permission): bool
     {
-        return in_array($permission, $this->permissions, true);
+        return Arr::has($this->permissions, $permission, true);
     }
 }


### PR DESCRIPTION
Intent summary
Add characterization coverage for BlueCore manager/service behavior before broader DevElation-first lifecycle refactors.

User stories / acceptance criteria
- As a maintainer, I can review menu manager behavior through focused tests before additional service/delegate lifecycle changes.
- As a contributor, I can see DevElation helpers used where they preserve existing manager behavior.
- As a package consumer, menu registration, authorization filtering, and conditional display return values stay compatible.
- Closes #26.

Key files changed
- src/BlueCore/Business/Managers/NavMenuManager.php
- tests/BlueCore/Business/Managers/NavMenuManagerTest.php

How to test
- php -l src\BlueCore\Business\Managers\NavMenuManager.php
- php -l tests\BlueCore\Business\Managers\NavMenuManagerTest.php
- vendor\bin\phpunit.bat --do-not-cache-result tests\BlueCore\Business\Managers\NavMenuManagerTest.php
- composer ci

QA checklist
- Menu manager rendering is covered for allowed and unauthorized items.
- Conditional role, group, and permission display helpers have focused coverage.
- Role/group/permission presence checks use Val::isNotEmpty.
- Test fakes use Arr::has for membership checks.
- Final menu assembly remains compatible with the currently locked DevElation release while the newer Arr::join dependency remains isolated to the dependency-alignment slice.
- Full composer ci passes locally and GitHub Actions is green.

Approval conditions
- Maintainers agree this PR should remain a characterization/helper-alignment slice.
- Broader manager lifecycle, service/delegate wiring, generator integration, and dependency-release alignment remain separate follow-up work.