### PR TITLE
Activate migration storage before first use

### DIFF
--- a/src/BlueCore/Business/Managers/DatasourceManager.php
+++ b/src/BlueCore/Business/Managers/DatasourceManager.php
@@ -20,6 +20,7 @@ class DatasourceManager extends Service {
 		$this->_generatorDir = resolve_path('datasources/generator/');
 		$this->_db = $storage;
 		$this->_db->config('name', 'migrations');
+		$this->_db->activate();
 	}
 
 	public function setDeltaDirectory( $directory )

--- a/tests/BlueCore/Business/Managers/DatasourceManagerTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Business\Managers;
+
+use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use BlueFission\Connections\Database\MySQLLink;
+use BlueFission\Data\Storage\Storage;
+use BlueFission\IObj;
+use PHPUnit\Framework\TestCase;
+
+class DatasourceManagerTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('APP_ROOT')) {
+            define('APP_ROOT', sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-datasource-manager-tests');
+        }
+
+        if (!defined('PROJECT_ROOT')) {
+            define('PROJECT_ROOT', APP_ROOT);
+        }
+    }
+
+    public function testMigrationStorageIsConfiguredBeforeActivation(): void
+    {
+        $link = new TrackingMySQLLink();
+        $storage = new TrackingMigrationStorage();
+
+        new DatasourceManager($link, $storage);
+
+        $this->assertSame(1, $link->openCount);
+        $this->assertSame(1, $storage->activationCount);
+        $this->assertSame('migrations', $storage->nameAtActivation);
+    }
+}
+
+class TrackingMySQLLink extends MySQLLink
+{
+    public int $openCount = 0;
+
+    public function open(): IObj
+    {
+        $this->openCount++;
+
+        return $this;
+    }
+}
+
+class TrackingMigrationStorage extends Storage
+{
+    public int $activationCount = 0;
+    public mixed $nameAtActivation = null;
+
+    public function activate(): IObj
+    {
+        $this->activationCount++;
+        $this->nameAtActivation = $this->config('name');
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Intent

Ensure migration storage is configured and activated as part of `DatasourceManager` initialization so first-run migration writes have a ready storage source.

Closes #28.

## User stories and acceptance criteria

- A fresh application can initialize migration storage before the first migration record is written.
- The migration storage name is configured before activation.
- Existing manager construction continues to open the injected database connection once.
- The behavior is covered without requiring an external database service.

## Key files changed

- `src/BlueCore/Business/Managers/DatasourceManager.php`
- `tests/BlueCore/Business/Managers/DatasourceManagerTest.php`

## How to test

```shell
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/DatasourceManagerTest.php
composer ci
```

## QA checklist

- [x] Composer metadata validates strictly.
- [x] PHP lint passes for source, tests, and examples.
- [x] Focused regression test passes.
- [x] Full test suite passes: 45 tests, 132 assertions.
- [x] No external service or environment configuration is required.

## Approval conditions

- Confirm constructor-time activation is the intended lifecycle boundary for injected migration storage.
- Confirm the focused test captures configuration-before-activation ordering.
- CI remains green on PHP 8.2 and supported dependency versions.
