### PR TITLE
Persist portable add-on paths

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -31,6 +31,7 @@ class AddOnManager extends Service
 
     public function install($name, bool $installDependencies = false): array
     {
+        $addOnPath = $this->addOnPath((string)$name);
         $data = $this->getAddOnData($name);
         $result = $this->lifecycleResult('install', $data->name);
         $dependencyCommands = $this->dependencyCommands($data->libraries, 'require');
@@ -46,7 +47,7 @@ class AddOnManager extends Service
 
         $addon = new AddOn;
         $addon->assign($data);
-        $addon->path = resolve_path('addons' . DIRECTORY_SEPARATOR . $name);
+        $addon->path = $addOnPath;
 
         $datasource = instance('datasource');
         $datasource->setDeltaDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR);
@@ -161,7 +162,7 @@ class AddOnManager extends Service
             $model = new AddOn;
             $model->name = $data->name ?? $addOn;
             $model->description = Str::truncate($data->description ?? "");
-            $model->path = resolve_path('addons' . DIRECTORY_SEPARATOR . $addOn);
+            $model->path = $this->addOnPath($addOn);
             $model->primary_file = 'main.php';
             // $addOn = $model;
             $list[$data->name] = $model;
@@ -264,6 +265,28 @@ class AddOnManager extends Service
         $data->primary_file = $data->primary_file ?? 'main.php';
 
         return $data;
+    }
+
+    protected function addOnPath(string $name): string
+    {
+        $root = realpath(resolve_path('addons'));
+        $path = realpath(resolve_path('addons' . DIRECTORY_SEPARATOR . $name));
+
+        if (Val::isEmpty($root) || Val::isEmpty($path)) {
+            throw new \InvalidArgumentException("Add-on path not found for {$name}.");
+        }
+
+        $root = Path::normalize($root);
+        $path = Path::normalize($path);
+        $rootPrefix = Str::endsWith($root, DIRECTORY_SEPARATOR)
+            ? $root
+            : $root . DIRECTORY_SEPARATOR;
+
+        if ($path !== $root && !Str::startsWith($path, $rootPrefix)) {
+            throw new \InvalidArgumentException("Add-on path escapes the configured root for {$name}.");
+        }
+
+        return Str::replace($path, '\\', '/');
     }
 
     protected function dependencyCommands(array $libraries, string $operation): array

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -84,6 +84,23 @@ class AddOnManagerTest extends TestCase
         $manager->definition('missing');
     }
 
+    public function testAddOnPathsArePortableAndRemainWithinTheConfiguredRoot(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $definitionDir = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'demo';
+        Path::ensureDir($definitionDir);
+
+        $path = $manager->path('demo');
+
+        $this->assertStringNotContainsString('\\', $path);
+        $this->assertStringEndsWith('/addons/demo', $path);
+
+        Path::ensureDir(self::$root . DIRECTORY_SEPARATOR . 'outside');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $manager->path('../outside');
+    }
+
     public function testActivateAndActivateAllReturnStructuredStatuses(): void
     {
         $model = new FakeAddOnModel([
@@ -143,6 +160,11 @@ class TestableAddOnManager extends AddOnManager
     public function definition(string $name): object
     {
         return $this->getAddOnData($name);
+    }
+
+    public function path(string $name): string
+    {
+        return $this->addOnPath($name);
     }
 }
 


### PR DESCRIPTION
## Intent

Persist installed add-on paths in a portable form while rejecting paths that resolve outside the configured add-on root.

Closes #33.

## User stories and acceptance criteria

- Installed add-on paths use stable forward-slash separators in storage.
- Runtime filesystem access remains compatible on Windows and POSIX.
- Traversal and symlink escapes are rejected before definition loading or dependency work.
- Existing add-on discovery and lifecycle behavior remains compatible.

## Key files changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## How to test

```shell
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php
composer ci
```

## QA checklist

- [x] Canonical paths are checked against the configured add-on root.
- [x] Persisted paths contain no Windows backslash separators.
- [x] Traversal outside the add-on root is covered.
- [x] Full CI passes: 45 tests, 132 assertions.
- [x] No external services or environment changes are required.

## Approval conditions

- Confirm canonical root containment is the expected pre-lifecycle boundary.
- Confirm forward slashes are the stable persisted representation.
- GitHub CI remains green on supported PHP versions.
