### PR TITLE
Make add-on lifecycle recoverable

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -5,6 +5,7 @@ namespace BlueFission\BlueCore\Business\Managers;
 use BlueFission\Arr;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\FileSystem;
+use BlueFission\Data\Storage\Storage;
 use BlueFission\Services\Service;
 use BlueFission\Utils\Loader;
 use BlueFission\Utils\File;
@@ -33,6 +34,16 @@ class AddOnManager extends Service
     {
         $data = $this->getAddOnData($name);
         $result = $this->lifecycleResult('install', $data->name);
+
+        if ($this->isInstalled($data->name)) {
+            $result['stage'] = 'complete';
+            $result['messages'][] = 'Add-on is already installed.';
+            $result['modelStatus'] = $this->_model->status();
+            $result['query'] = $this->_model->query();
+
+            return $result;
+        }
+
         $dependencyCommands = $this->dependencyCommands($data->libraries, 'require');
         $result['dependencies'] = $dependencyCommands;
 
@@ -48,7 +59,7 @@ class AddOnManager extends Service
         $addon->assign($data);
         $addon->path = resolve_path('addons' . DIRECTORY_SEPARATOR . $name);
 
-        $datasource = instance('datasource');
+        $datasource = $this->datasourceManager();
         $datasource->setDeltaDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR);
         $datasource->setGeneratorDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'generator' . DIRECTORY_SEPARATOR);
         ob_start();
@@ -59,6 +70,8 @@ class AddOnManager extends Service
 
         $this->callHook($addon, 'install');
         $this->_model->write($addon);
+        $result['changed'] = true;
+        $result['stage'] = 'complete';
         $result['modelStatus'] = $this->_model->status();
         $result['query'] = $this->_model->query();
 
@@ -70,9 +83,7 @@ class AddOnManager extends Service
         $addOns = $this->showAllAddOns();
         $results = [];
         foreach ($addOns as $addOn) {
-            if (!$this->_model->exists(['name' => $addOn->name])) {
-                $results[] = $this->install($addOn->name, $installDependencies);
-            }
+            $results[] = $this->install($addOn->name, $installDependencies);
         }
         return $results;
     }
@@ -82,31 +93,44 @@ class AddOnManager extends Service
         $addon = $this->getAddOnById($addOnId);
         $result = $this->lifecycleResult('uninstall', $addon->name);
 
-        // Check for and call the `uninstall` function hook
-        $this->callHook($addon, 'uninstall');
+        try {
+            $result['stage'] = 'hook';
+            $this->callHook($addon, 'uninstall');
 
-        $this->_model->delete(['addon_id' => $addOnId]);
+            $result['stage'] = 'definition';
+            $data = $this->getAddOnData($addon->name);
+            $dependencyCommands = $this->dependencyCommands($data->libraries, 'remove');
+            $result['dependencies'] = $dependencyCommands;
 
-        $data = $this->getAddOnData($addon->name);
-        $dependencyCommands = $this->dependencyCommands($data->libraries, 'remove');
-        $result['dependencies'] = $dependencyCommands;
-
-        if (Arr::isNotEmpty($dependencyCommands)) {
-            if ($removeDependencies) {
-                $result['messages'][] = $this->runDependencyCommands($dependencyCommands);
-            } else {
-                $result['messages'][] = 'Dependency removal skipped; run the listed commands explicitly if required.';
+            if (Arr::isNotEmpty($dependencyCommands)) {
+                if ($removeDependencies) {
+                    $result['stage'] = 'dependencies';
+                    $result['messages'][] = $this->runDependencyCommands($dependencyCommands);
+                } else {
+                    $result['messages'][] = 'Dependency removal skipped; run the listed commands explicitly if required.';
+                }
             }
-        }
 
-        $datasource = instance('datasource');
-        $datasource->setDeltaDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR);
-        $datasource->setGeneratorDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'generator' . DIRECTORY_SEPARATOR);
-        ob_start();
-        // $datasource->revertMigrations();
-        $datasource->revertBatch($addon->name);
-        $result['messages'][] = ob_get_contents();
-        ob_end_clean();
+            $result['stage'] = 'datasource';
+            $datasource = $this->datasourceManager();
+            $datasource->setDeltaDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR);
+            $datasource->setGeneratorDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'generator' . DIRECTORY_SEPARATOR);
+            $result['messages'][] = $this->captureOutput(fn() => $datasource->revertBatch($addon->name));
+
+            $result['stage'] = 'registration';
+            $this->_model->delete(['addon_id' => $addOnId]);
+            if ($this->_model->status() !== Storage::STATUS_SUCCESS) {
+                throw new \RuntimeException('Add-on registration could not be removed.');
+            }
+
+            $result['changed'] = true;
+            $result['stage'] = 'complete';
+        } catch (\Throwable $exception) {
+            $result['ok'] = false;
+            $result['nextAction'] = 'retry_uninstall';
+            $result['error'] = $exception->getMessage();
+            $result['messages'][] = $exception->getMessage();
+        }
 
         $result['modelStatus'] = $this->_model->status();
 
@@ -122,7 +146,7 @@ class AddOnManager extends Service
 
     public function activateAll(): array
     {
-        $addOns = $this->_model->getAllAddOns();
+        $addOns = $this->installedAddOns();
         $results = [];
         foreach ($addOns as $addOn) {
             if (!$addOn->is_active) {
@@ -290,7 +314,43 @@ class AddOnManager extends Service
         return $library;
     }
 
-    private function runDependencyCommands(array $commands): string
+    protected function isInstalled(string $name): bool
+    {
+        $this->_model->clear();
+        $this->_model->read(['name' => $name]);
+
+        return Val::isNotEmpty($this->_model->id());
+    }
+
+    protected function installedAddOns(): mixed
+    {
+        $this->_model->clear();
+        $this->_model->read();
+
+        return $this->_model->all();
+    }
+
+    protected function datasourceManager(): mixed
+    {
+        return instance('datasource');
+    }
+
+    protected function captureOutput(callable $operation): string
+    {
+        ob_start();
+
+        try {
+            $operation();
+
+            return (string)ob_get_clean();
+        } catch (\Throwable $exception) {
+            ob_end_clean();
+
+            throw $exception;
+        }
+    }
+
+    protected function runDependencyCommands(array $commands): string
     {
         $system = new System();
         $system->cwd(APP_ROOT);
@@ -310,6 +370,10 @@ class AddOnManager extends Service
             'ok' => true,
             'action' => $action,
             'addon' => $addOn,
+            'changed' => false,
+            'stage' => 'pending',
+            'nextAction' => null,
+            'error' => null,
             'messages' => [],
             'dependencies' => [],
             'modelStatus' => $modelStatus,

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -105,6 +105,86 @@ class AddOnManagerTest extends TestCase
         $this->assertSame('1', $all[0]['addon']);
     }
 
+    public function testRepeatedInstallUsesSupportedModelOperationsAndDoesNotDuplicateRegistration(): void
+    {
+        $this->writeDefinition('demo');
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $manager = new TestableAddOnManager($model, $datasource);
+
+        $first = $manager->install('demo');
+        $second = $manager->install('demo');
+
+        $this->assertTrue($first['changed']);
+        $this->assertFalse($second['changed']);
+        $this->assertSame('complete', $second['stage']);
+        $this->assertCount(1, $model->records);
+        $this->assertSame(1, $datasource->migrationRuns);
+    }
+
+    public function testFailedTeardownPreservesRegistrationForRetry(): void
+    {
+        $this->writeDefinition('demo');
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'demo';
+        $model = new FakeAddOnModel([
+            (object)[
+                'addon_id' => 7,
+                'name' => 'demo',
+                'path' => $path,
+                'primary_file' => 'main.php',
+                'is_active' => 1,
+            ],
+        ]);
+        $datasource = new FakeDatasourceManager(failRollback: true);
+        $manager = new TestableAddOnManager($model, $datasource);
+
+        $result = $manager->uninstall(7);
+
+        $this->assertFalse($result['ok']);
+        $this->assertFalse($result['changed']);
+        $this->assertSame('datasource', $result['stage']);
+        $this->assertSame('retry_uninstall', $result['nextAction']);
+        $this->assertCount(1, $model->records);
+        $this->assertSame([], $model->deletes);
+    }
+
+    public function testSuccessfulTeardownRemovesRegistrationLast(): void
+    {
+        $this->writeDefinition('demo');
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'demo';
+        $model = new FakeAddOnModel([
+            (object)[
+                'addon_id' => 8,
+                'name' => 'demo',
+                'path' => $path,
+                'primary_file' => 'main.php',
+                'is_active' => 1,
+            ],
+        ]);
+        $manager = new TestableAddOnManager($model, new FakeDatasourceManager());
+
+        $result = $manager->uninstall(8);
+
+        $this->assertTrue($result['ok']);
+        $this->assertTrue($result['changed']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertSame([['addon_id' => 8]], $model->deletes);
+        $this->assertSame([], $model->records);
+    }
+
+    private function writeDefinition(string $name): void
+    {
+        File::ensureFile(
+            self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . $name . DIRECTORY_SEPARATOR . 'definition.json',
+            json_encode([
+                'name' => $name,
+                'libraries' => [],
+                'primary_file' => 'main.php',
+            ]),
+            true
+        );
+    }
+
     private function removeDir($dir): void
     {
         if (!$dir || !is_dir($dir)) {
@@ -130,9 +210,13 @@ class AddOnManagerTest extends TestCase
 
 class TestableAddOnManager extends AddOnManager
 {
-    public function __construct(FakeAddOnModel $model)
+    public function __construct(
+        FakeAddOnModel $model,
+        private ?FakeDatasourceManager $datasource = null
+    )
     {
         $this->_model = $model;
+        $this->datasource ??= new FakeDatasourceManager();
     }
 
     public function commands(array $libraries, string $operation): array
@@ -144,19 +228,103 @@ class TestableAddOnManager extends AddOnManager
     {
         return $this->getAddOnData($name);
     }
+
+    protected function datasourceManager(): mixed
+    {
+        return $this->datasource;
+    }
+
+    protected function callHook(\BlueFission\BlueCore\Domain\AddOn\AddOn $addOn, $hook): void
+    {
+    }
 }
 
 class FakeAddOnModel
 {
     public array $writes = [];
+    public array $deletes = [];
+    public array $records = [];
+    private array $current = [];
 
-    public function __construct(private array $addons = [])
+    public function __construct(array $addons = [])
     {
+        $this->records = array_map(static fn($addon) => (array)$addon, $addons);
     }
 
     public function write($values): void
     {
-        $this->writes[] = (array)$values;
+        $record = (array)$values;
+        $this->writes[] = $record;
+        $id = $record['addon_id'] ?? count($this->records) + 1;
+        $record['addon_id'] = $id;
+
+        foreach ($this->records as $index => $existing) {
+            if (($existing['addon_id'] ?? null) === $id) {
+                $this->records[$index] = array_merge($existing, $record);
+                $this->current = $this->records[$index];
+
+                return;
+            }
+        }
+
+        $this->records[] = $record;
+        $this->current = $record;
+    }
+
+    public function clear(): self
+    {
+        $this->current = [];
+
+        return $this;
+    }
+
+    public function read($values = null): self
+    {
+        $criteria = (array)($values ?? []);
+        $this->current = [];
+
+        foreach ($this->records as $record) {
+            $matches = true;
+            foreach ($criteria as $field => $value) {
+                if (($record[$field] ?? null) !== $value) {
+                    $matches = false;
+                    break;
+                }
+            }
+
+            if ($matches) {
+                $this->current = $record;
+                break;
+            }
+        }
+
+        return $this;
+    }
+
+    public function id(): mixed
+    {
+        return $this->current['addon_id'] ?? null;
+    }
+
+    public function data(): array
+    {
+        return $this->current;
+    }
+
+    public function all(): array
+    {
+        return array_map(static fn($record) => (object)$record, $this->records);
+    }
+
+    public function delete($values): void
+    {
+        $criteria = (array)$values;
+        $this->deletes[] = $criteria;
+        $this->records = array_values(array_filter(
+            $this->records,
+            static fn($record) => ($record['addon_id'] ?? null) !== ($criteria['addon_id'] ?? null)
+        ));
+        $this->current = [];
     }
 
     public function status(): string
@@ -169,8 +337,37 @@ class FakeAddOnModel
         return 'UPDATE addons';
     }
 
-    public function getAllAddOns(): array
+}
+
+class FakeDatasourceManager
+{
+    public int $migrationRuns = 0;
+
+    public function __construct(private bool $failRollback = false)
     {
-        return $this->addons;
+    }
+
+    public function setDeltaDirectory(string $directory): void
+    {
+    }
+
+    public function setGeneratorDirectory(string $directory): void
+    {
+    }
+
+    public function runMigrations(string $batch): void
+    {
+        $this->migrationRuns++;
+    }
+
+    public function populate(): void
+    {
+    }
+
+    public function revertBatch(string $batch): void
+    {
+        if ($this->failRollback) {
+            throw new \RuntimeException('Datasource rollback failed.');
+        }
     }
 }


### PR DESCRIPTION
## Intent

Make add-on registration and teardown idempotent, recoverable, and based only on supported model operations.

Closes #31.

## User stories and acceptance criteria

- Repeated installation does not create duplicate registration.
- Bulk install and activation use supported `clear`, `read`, `id`, and `all` model operations.
- Registration remains available for retry when hook, definition, dependency, or datasource teardown fails.
- Dependency mutation remains explicit and opt-in.
- Lifecycle results expose whether state changed, the current stage, the next action, and any error.

## Key files changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## How to test

```shell
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php
composer ci
```

## QA checklist

- [x] Missing `exists()` and `getAllAddOns()` dispatches are removed.
- [x] Clean and repeated installation are covered.
- [x] Successful and failed teardown are covered.
- [x] Failed teardown preserves registration and returns `retry_uninstall`.
- [x] Full CI passes: 47 tests, 145 assertions.

## Approval conditions

- Confirm additive lifecycle result fields are suitable for package callers.
- Confirm registration removal should remain the final teardown operation.
- Confirm bulk install should return an entry for unchanged add-ons.
- GitHub CI remains green on supported PHP versions.
