### PR TITLE
Propagate bulk add-on lifecycle failures

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -6,6 +6,7 @@ use BlueFission\Arr;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\FileSystem;
 use BlueFission\Data\Storage\Storage;
+use BlueFission\Flag;
 use BlueFission\Services\Service;
 use BlueFission\Utils\Loader;
 use BlueFission\Utils\File;
@@ -84,9 +85,14 @@ class AddOnManager extends Service
         $addOns = $this->showAllAddOns();
         $results = [];
         foreach ($addOns as $addOn) {
-            $results[] = $this->install($addOn->name, $installDependencies);
+            try {
+                $results[] = $this->install($addOn->name, $installDependencies);
+            } catch (\Throwable $exception) {
+                $results[] = $this->failedLifecycleResult('install', (string)$addOn->name, $exception);
+            }
         }
-        return $results;
+
+        return $this->lifecycleBatchResult('install_all', $results);
     }
 
     public function uninstall($addOnId, bool $removeDependencies = false): array
@@ -150,11 +156,25 @@ class AddOnManager extends Service
         $addOns = $this->installedAddOns();
         $results = [];
         foreach ($addOns as $addOn) {
-            if (!$addOn->is_active) {
-                $results[] = $this->activate($addOn->addon_id);
+            $record = Arr::make($addOn);
+            if (Flag::parseBool($record->get('is_active'))) {
+                continue;
             }
+
+            $addOnId = $record->get('addon_id');
+            if (Val::isEmpty($addOnId)) {
+                $results[] = $this->failedLifecycleResult(
+                    'activate',
+                    '',
+                    new \UnexpectedValueException('Persisted add-on row is missing addon_id.')
+                );
+                continue;
+            }
+
+            $results[] = $this->activate($addOnId);
         }
-        return $results;
+
+        return $this->lifecycleBatchResult('activate_all', $results);
     }
 
     public function deactivate($addOnId): array
@@ -350,7 +370,10 @@ class AddOnManager extends Service
         $this->_model->clear();
         $this->_model->read();
 
-        return $this->_model->all();
+        return Arr::make(Arr::toArray($this->_model->all(), true))
+            ->map(fn ($addOn) => Arr::toArray($addOn, true))
+            ->values()
+            ->toArray();
     }
 
     protected function datasourceManager(): mixed
@@ -389,18 +412,57 @@ class AddOnManager extends Service
 
     private function lifecycleResult(string $action, string $addOn = '', mixed $modelStatus = null, string $query = ''): array
     {
+        $hasModelStatus = Val::isNotNull($modelStatus);
+        $ok = !$hasModelStatus || $modelStatus === Storage::STATUS_SUCCESS;
+
         return Arr::make([
-            'ok' => true,
+            'ok' => $ok,
             'action' => $action,
             'addon' => $addOn,
-            'changed' => false,
-            'stage' => 'pending',
-            'nextAction' => null,
-            'error' => null,
-            'messages' => [],
+            'changed' => $hasModelStatus && $ok,
+            'stage' => $hasModelStatus ? ($ok ? 'complete' : 'registration') : 'pending',
+            'nextAction' => $ok ? null : "retry_{$action}",
+            'error' => $ok ? null : 'Add-on registration could not be updated.',
+            'messages' => $ok ? [] : ['Add-on registration could not be updated.'],
             'dependencies' => [],
             'modelStatus' => $modelStatus,
             'query' => $query,
+        ])->toArray();
+    }
+
+    private function failedLifecycleResult(string $action, string $addOn, \Throwable $exception): array
+    {
+        $result = $this->lifecycleResult($action, $addOn);
+        $result['ok'] = false;
+        $result['stage'] = 'failed';
+        $result['nextAction'] = "retry_{$action}";
+        $result['error'] = $exception->getMessage();
+        $result['messages'][] = $exception->getMessage();
+
+        return $result;
+    }
+
+    private function lifecycleBatchResult(string $action, array $results): array
+    {
+        $failures = Arr::make($results)
+            ->filter(fn ($result) => Flag::isFalse(Arr::getPath($result, 'ok', false)))
+            ->values()
+            ->toArray();
+        $changes = Arr::make($results)
+            ->filter(fn ($result) => Flag::parseBool(Arr::getPath($result, 'changed', false)))
+            ->values()
+            ->toArray();
+        $total = Arr::size($results);
+        $failed = Arr::size($failures);
+
+        return Arr::make([
+            'ok' => $failed === 0,
+            'action' => $action,
+            'changed' => Arr::isNotEmpty($changes),
+            'total' => $total,
+            'succeeded' => $total - $failed,
+            'failed' => $failed,
+            'results' => $results,
         ])->toArray();
     }
 

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -104,9 +104,9 @@ class AddOnManagerTest extends TestCase
     public function testActivateAndActivateAllReturnStructuredStatuses(): void
     {
         $model = new FakeAddOnModel([
-            (object)['addon_id' => 1, 'is_active' => 0],
-            (object)['addon_id' => 2, 'is_active' => 1],
-        ]);
+            ['addon_id' => 1, 'is_active' => 0],
+            ['addon_id' => 2, 'is_active' => 1],
+        ], returnArrays: true);
         $manager = new TestableAddOnManager($model);
 
         $result = $manager->activate(5);
@@ -118,8 +118,31 @@ class AddOnManagerTest extends TestCase
 
         $all = $manager->activateAll();
 
-        $this->assertCount(1, $all);
-        $this->assertSame('1', $all[0]['addon']);
+        $this->assertTrue($all['ok']);
+        $this->assertSame('activate_all', $all['action']);
+        $this->assertSame(1, $all['total']);
+        $this->assertSame(1, $all['succeeded']);
+        $this->assertSame(0, $all['failed']);
+        $this->assertSame('1', $all['results'][0]['addon']);
+    }
+
+    public function testActivateAllPropagatesInnerFailuresAndMalformedRows(): void
+    {
+        $model = new FakeAddOnModel([
+            ['addon_id' => 3, 'is_active' => 0],
+            ['is_active' => 0],
+        ], returnArrays: true, failWritesForIds: [3]);
+        $manager = new TestableAddOnManager($model);
+
+        $result = $manager->activateAll();
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(0, $result['succeeded']);
+        $this->assertSame(2, $result['failed']);
+        $this->assertSame('registration', $result['results'][0]['stage']);
+        $this->assertSame('failed', $result['results'][1]['stage']);
+        $this->assertSame('Persisted add-on row is missing addon_id.', $result['results'][1]['error']);
     }
 
     public function testRepeatedInstallUsesSupportedModelOperationsAndDoesNotDuplicateRegistration(): void
@@ -267,8 +290,13 @@ class FakeAddOnModel
     public array $deletes = [];
     public array $records = [];
     private array $current = [];
+    private string $currentStatus = 'Success.';
 
-    public function __construct(array $addons = [])
+    public function __construct(
+        array $addons = [],
+        private bool $returnArrays = false,
+        private array $failWritesForIds = []
+    )
     {
         $this->records = array_map(static fn($addon) => (array)$addon, $addons);
     }
@@ -278,6 +306,14 @@ class FakeAddOnModel
         $record = (array)$values;
         $this->writes[] = $record;
         $id = $record['addon_id'] ?? count($this->records) + 1;
+        $this->currentStatus = in_array($id, $this->failWritesForIds, true)
+            ? 'Failed.'
+            : 'Success.';
+
+        if ($this->currentStatus !== 'Success.') {
+            return;
+        }
+
         $record['addon_id'] = $id;
 
         foreach ($this->records as $index => $existing) {
@@ -335,6 +371,10 @@ class FakeAddOnModel
 
     public function all(): array
     {
+        if ($this->returnArrays) {
+            return $this->records;
+        }
+
         return array_map(static fn($record) => (object)$record, $this->records);
     }
 
@@ -351,7 +391,7 @@ class FakeAddOnModel
 
     public function status(): string
     {
-        return 'Success.';
+        return $this->currentStatus;
     }
 
     public function query(): string


### PR DESCRIPTION
## Intent

Normalize persisted add-on rows before lifecycle access and expose deterministic aggregate success/failure metadata for bulk operations.

Closes #38.

## User stories / acceptance criteria

- Array- and object-backed persisted rows are normalized through DevElation `Arr` helpers.
- Bulk activation skips active records and reports malformed records without warnings or invalid writes.
- Single activation/deactivation results reflect storage write failure.
- Bulk install and activation return `ok`, `changed`, total/succeeded/failed counts, and individual results so command adapters can select a nonzero exit status.

## Key files changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php
composer ci
```

Validated locally: 52 tests, 167 assertions.

## QA checklist

- [x] Successful array-backed bulk activation
- [x] Failed model writes propagate to the aggregate
- [x] Missing persisted identifiers produce structured diagnostics
- [x] Existing install/uninstall recovery tests remain green
- [x] Full lint and PHPUnit suite pass

## Approval conditions

- Confirm the explicit aggregate result envelope is the intended bulk command contract.
- Confirm command adapters should map top-level `ok=false` to a nonzero exit status.
