### PR TITLE
Resolve application wildcard paths before fallback

### DIFF
--- a/src/Helpers/global.php
+++ b/src/Helpers/global.php
@@ -129,10 +129,10 @@ if (!function_exists('whisper')) {
 }
 
 if(!function_exists('resolve_path')) {
-	function resolve_path($pathInProject)
+	function resolve_path($pathInProject, ?string $applicationRoot = null, ?string $legacyProjectRoot = null)
 	{
-	    $rootPath = rtrim(APP_ROOT, DIRECTORY_SEPARATOR);
-	    $projectPath = rtrim(PROJECT_ROOT, DIRECTORY_SEPARATOR);
+	    $rootPath = rtrim($applicationRoot ?? APP_ROOT, DIRECTORY_SEPARATOR);
+	    $projectPath = rtrim($legacyProjectRoot ?? PROJECT_ROOT, DIRECTORY_SEPARATOR);
 	    $relativePath = Path::normalize((string)$pathInProject);
 
 	    $candidate = Path::normalize($rootPath . DIRECTORY_SEPARATOR . $relativePath);

--- a/src/Helpers/global.php
+++ b/src/Helpers/global.php
@@ -1,6 +1,7 @@
 <?php
 use App\Business\Managers\CommunicationManager;
 use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
 use BlueFission\Flag;
 use BlueFission\Utils\Util;
 use BlueFission\Utils\File;
@@ -132,12 +133,24 @@ if(!function_exists('resolve_path')) {
 	{
 	    $rootPath = rtrim(APP_ROOT, DIRECTORY_SEPARATOR);
 	    $projectPath = rtrim(PROJECT_ROOT, DIRECTORY_SEPARATOR);
+	    $relativePath = Path::normalize((string)$pathInProject);
 
-	    $candidate = Path::normalize($rootPath . DIRECTORY_SEPARATOR . $pathInProject);
-	    $fallback = Path::normalize($projectPath . DIRECTORY_SEPARATOR . $pathInProject);
+	    $candidate = Path::normalize($rootPath . DIRECTORY_SEPARATOR . $relativePath);
+	    $fallback = Path::normalize($projectPath . DIRECTORY_SEPARATOR . $relativePath);
+	    $hasWildcard = Str::matchPattern($relativePath, '/[*?\[]/');
 
-	    if (file_exists($candidate)) {
+	    if (!$hasWildcard && (
+	        FileSystem::fileExists($candidate)
+	        || FileSystem::directoryExists($candidate)
+	    )) {
 	        return $candidate;
+	    }
+
+	    if ($hasWildcard) {
+	        $matches = glob($candidate);
+	        if (!Flag::isFalse($matches) && Arr::isNotEmpty($matches)) {
+	            return $candidate;
+	        }
 	    }
 
 	    return $fallback;

--- a/tests/Helpers/ResolvePathHelperTest.php
+++ b/tests/Helpers/ResolvePathHelperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace BlueFission\Tests\Helpers;
+
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+class ResolvePathHelperTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testApplicationPathsAndWildcardsResolveBeforeProjectFallback(): void
+    {
+        $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-resolve-path-' . uniqid();
+        $applicationRoot = $root . DIRECTORY_SEPARATOR . 'application';
+        $projectRoot = $root . DIRECTORY_SEPARATOR . 'project';
+
+        define('APP_ROOT', $applicationRoot);
+        define('PROJECT_ROOT', $projectRoot);
+
+        File::ensureFile(
+            $applicationRoot . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'app.php',
+            '<?php return [];',
+            true
+        );
+        File::ensureFile(
+            $projectRoot . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'fallback.php',
+            '<?php return [];',
+            true
+        );
+
+        $this->assertSame(
+            Path::normalize($applicationRoot . DIRECTORY_SEPARATOR . 'common/config/app.php'),
+            resolve_path('common/config/app.php')
+        );
+        $this->assertSame(
+            Path::normalize($applicationRoot . DIRECTORY_SEPARATOR . 'common/config/*.php'),
+            resolve_path('common/config/*.php')
+        );
+        $this->assertSame(
+            Path::normalize($applicationRoot . DIRECTORY_SEPARATOR . 'common/config/*.php'),
+            resolve_path('common\\config/*.php')
+        );
+        $this->assertSame(
+            Path::normalize($projectRoot . DIRECTORY_SEPARATOR . 'common/config/missing-*.php'),
+            resolve_path('common/config/missing-*.php')
+        );
+        $this->assertSame(
+            Path::normalize($projectRoot . DIRECTORY_SEPARATOR . 'common/config/[invalid.php'),
+            resolve_path('common/config/[invalid.php')
+        );
+
+        $this->removeDir($root);
+    }
+
+    private function removeDir(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Helpers/ResolvePathHelperTest.php
+++ b/tests/Helpers/ResolvePathHelperTest.php
@@ -4,22 +4,15 @@ namespace BlueFission\Tests\Helpers;
 
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 class ResolvePathHelperTest extends TestCase
 {
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function testApplicationPathsAndWildcardsResolveBeforeProjectFallback(): void
     {
         $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-resolve-path-' . uniqid();
         $applicationRoot = $root . DIRECTORY_SEPARATOR . 'application';
         $projectRoot = $root . DIRECTORY_SEPARATOR . 'project';
-
-        define('APP_ROOT', $applicationRoot);
-        define('PROJECT_ROOT', $projectRoot);
 
         File::ensureFile(
             $applicationRoot . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'app.php',
@@ -34,23 +27,23 @@ class ResolvePathHelperTest extends TestCase
 
         $this->assertSame(
             Path::normalize($applicationRoot . DIRECTORY_SEPARATOR . 'common/config/app.php'),
-            resolve_path('common/config/app.php')
+            resolve_path('common/config/app.php', $applicationRoot, $projectRoot)
         );
         $this->assertSame(
             Path::normalize($applicationRoot . DIRECTORY_SEPARATOR . 'common/config/*.php'),
-            resolve_path('common/config/*.php')
+            resolve_path('common/config/*.php', $applicationRoot, $projectRoot)
         );
         $this->assertSame(
             Path::normalize($applicationRoot . DIRECTORY_SEPARATOR . 'common/config/*.php'),
-            resolve_path('common\\config/*.php')
+            resolve_path('common\\config/*.php', $applicationRoot, $projectRoot)
         );
         $this->assertSame(
             Path::normalize($projectRoot . DIRECTORY_SEPARATOR . 'common/config/missing-*.php'),
-            resolve_path('common/config/missing-*.php')
+            resolve_path('common/config/missing-*.php', $applicationRoot, $projectRoot)
         );
         $this->assertSame(
             Path::normalize($projectRoot . DIRECTORY_SEPARATOR . 'common/config/[invalid.php'),
-            resolve_path('common/config/[invalid.php')
+            resolve_path('common/config/[invalid.php', $applicationRoot, $projectRoot)
         );
 
         $this->removeDir($root);


### PR DESCRIPTION
## Intent

Resolve matching application-root wildcard patterns before applying the legacy project-root fallback.

Closes #39.

## User stories / acceptance criteria

- Direct files and directories continue to resolve from the application root first.
- Wildcard paths return the application-root pattern when at least one match exists.
- Empty or failed glob evaluation falls through to the project-root pattern.
- Mixed path separators normalize consistently across supported platforms.
- DevElation `FileSystem`, `Path`, `Str`, `Flag`, and `Arr` helpers carry the path decision contract.

## Key files changed

- `src/Helpers/global.php`
- `tests/Helpers/ResolvePathHelperTest.php`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/Helpers/ResolvePathHelperTest.php
composer ci
```

Validated locally: 52 tests, 161 assertions.

## QA checklist

- [x] Direct application file resolution
- [x] Matching application wildcard resolution
- [x] Mixed separator normalization
- [x] Unmatched wildcard fallback
- [x] Failed glob fallback
- [x] Full lint and PHPUnit suite pass

## Approval conditions

- Confirm returning the unresolved matching pattern, rather than the expanded file list, preserves the existing helper contract.
- Confirm project-root fallback remains authoritative when no application match exists.
