### PR TITLE
Validate add-on definitions before lifecycle mutation

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -6,6 +6,7 @@ use BlueFission\Arr;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\FileSystem;
 use BlueFission\Data\Storage\Storage;
+use BlueFission\Net\HTTP;
 use BlueFission\Services\Service;
 use BlueFission\Utils\Loader;
 use BlueFission\Utils\File;
@@ -32,8 +33,8 @@ class AddOnManager extends Service
 
     public function install($name, bool $installDependencies = false): array
     {
-        $addOnPath = $this->addOnPath((string)$name);
         $data = $this->getAddOnData($name);
+        $addOnPath = $this->addOnPath($data->name);
         $result = $this->lifecycleResult('install', $data->name);
 
         if ($this->isInstalled($data->name)) {
@@ -271,24 +272,135 @@ class AddOnManager extends Service
 
     protected function getAddOnData($name)
     {
+        $name = $this->normalizeAddOnIdentifier($name, 'name');
         $definitionPath = resolve_path('addons' . DIRECTORY_SEPARATOR . $name  . DIRECTORY_SEPARATOR . 'definition.json');
         if (!(new File())->isReachable($definitionPath)) {
             throw new \InvalidArgumentException("Add-on definition not found for {$name}.");
         }
 
-        $data = json_decode(File::readContents($definitionPath));
-        if (!$data || json_last_error() !== JSON_ERROR_NONE) {
-            throw new \RuntimeException("Add-on definition is invalid JSON for {$name}.");
+        $contents = File::readContents($definitionPath);
+        $decodedObject = HTTP::jsonDecode($contents, false);
+        if (!is_object($decodedObject)) {
+            throw $this->invalidDefinition('definition', 'a valid JSON object');
         }
 
-        if (Val::isEmpty($data->name ?? null)) {
-            $data->name = $name;
+        $definition = Arr::make(HTTP::jsonDecode($contents, true, []));
+        $rawName = $definition->get('name');
+        if (Val::isNotNull($rawName) && !Str::is($rawName)) {
+            throw $this->invalidDefinition('name', 'a safe add-on identifier');
+        }
+        $definedName = Val::isEmpty($rawName)
+            ? $name
+            : $this->normalizeAddOnIdentifier($rawName, 'name');
+
+        if ($definedName !== $name) {
+            throw $this->invalidDefinition('name', 'the add-on directory identifier');
         }
 
-        $data->libraries = Arr::toArray($data->libraries ?? [], true);
-        $data->primary_file = $data->primary_file ?? 'main.php';
+        $rawVersion = $definition->get('version');
+        if (Val::isNotNull($rawVersion) && !Str::is($rawVersion)) {
+            throw $this->invalidDefinition('version', 'a semantic version string');
+        }
+        $version = Val::isEmpty($rawVersion)
+            ? '0.0.0'
+            : Str::trim($rawVersion);
+        if (!Str::matchPattern($version, '/^[0-9]+(?:\.[0-9]+){0,3}(?:[-+][0-9A-Za-z.-]+)?$/')) {
+            throw $this->invalidDefinition('version', 'a semantic version string');
+        }
 
-        return $data;
+        $rawNamespace = $definition->get('namespace');
+        if (Val::isNotNull($rawNamespace) && !Str::is($rawNamespace)) {
+            throw $this->invalidDefinition('namespace', 'a valid PHP namespace');
+        }
+        $namespace = Val::isEmpty($rawNamespace)
+            ? ''
+            : Str::trim($rawNamespace, '\\');
+        if (Val::isNotEmpty($namespace) && !Str::matchPattern(
+            $namespace,
+            '/^(?:[A-Za-z_][A-Za-z0-9_]*)(?:\\\\[A-Za-z_][A-Za-z0-9_]*)*$/'
+        )) {
+            throw $this->invalidDefinition('namespace', 'a valid PHP namespace');
+        }
+
+        $rawPrimaryFile = $definition->get('primary_file');
+        if (Val::isNotNull($rawPrimaryFile) && !Str::is($rawPrimaryFile)) {
+            throw $this->invalidDefinition('primary_file', 'a relative path within the add-on root');
+        }
+        $primaryFile = Val::isEmpty($rawPrimaryFile)
+            ? 'main.php'
+            : $this->normalizeDefinitionPath($rawPrimaryFile, 'primary_file');
+
+        $libraries = $definition->get('libraries');
+        if (Val::isNull($libraries)) {
+            $libraries = [];
+        }
+        if (!Arr::is($libraries)) {
+            throw $this->invalidDefinition('libraries', 'an array of Composer package names');
+        }
+
+        $libraries = Arr::make($libraries)
+            ->map(function ($library) {
+                if (!Str::is($library)) {
+                    throw $this->invalidDefinition('libraries', 'an array of Composer package names');
+                }
+
+                $normalized = $this->sanitizeLibraryName($library);
+                if (Val::isNull($normalized)) {
+                    throw $this->invalidDefinition('libraries', 'an array of Composer package names');
+                }
+
+                return $normalized;
+            })
+            ->unique()
+            ->values()
+            ->toArray();
+
+        return (object)Arr::make([
+            'name' => $definedName,
+            'version' => $version,
+            'namespace' => $namespace,
+            'primary_file' => $primaryFile,
+            'libraries' => $libraries,
+            'description' => (string)($definition->get('description') ?? ''),
+        ])->toArray();
+    }
+
+    private function normalizeAddOnIdentifier(mixed $identifier, string $field): string
+    {
+        if (!Str::is($identifier)) {
+            throw $this->invalidDefinition($field, 'a safe add-on identifier');
+        }
+
+        $identifier = Str::trim($identifier);
+        if (!Str::matchPattern($identifier, '/^[A-Za-z0-9][A-Za-z0-9._-]*$/')) {
+            throw $this->invalidDefinition($field, 'a safe add-on identifier');
+        }
+
+        return $identifier;
+    }
+
+    private function normalizeDefinitionPath(mixed $path, string $field): string
+    {
+        if (!Str::is($path)) {
+            throw $this->invalidDefinition($field, 'a relative path within the add-on root');
+        }
+
+        $path = Path::normalize(Str::trim($path));
+        $segments = Str::make($path)->split(DIRECTORY_SEPARATOR)->val();
+        $isAbsolute = Str::startsWith($path, DIRECTORY_SEPARATOR)
+            || Str::matchPattern($path, '/^[A-Za-z]:/')
+            || Arr::has($segments, '..', true);
+
+        if (Val::isEmpty($path) || $isAbsolute) {
+            throw $this->invalidDefinition($field, 'a relative path within the add-on root');
+        }
+
+        return Str::replace($path, '\\', '/');
+    }
+
+    private function invalidDefinition(string $field, string $expected): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException("Invalid add-on definition field '{$field}': expected {$expected}.");
     }
 
     protected function addOnPath(string $name): string

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -5,6 +5,7 @@ namespace BlueFission\Tests\BlueCore\Business\Managers;
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class AddOnManagerTest extends TestCase
@@ -77,11 +78,67 @@ class AddOnManagerTest extends TestCase
         $definition = $manager->definition('demo');
 
         $this->assertSame('demo', $definition->name);
+        $this->assertSame('0.0.0', $definition->version);
+        $this->assertSame('', $definition->namespace);
         $this->assertSame('main.php', $definition->primary_file);
         $this->assertSame(['bluefission/develation'], $definition->libraries);
 
         $this->expectException(\InvalidArgumentException::class);
         $manager->definition('missing');
+    }
+
+    #[DataProvider('invalidDefinitionProvider')]
+    public function testDefinitionValidationIdentifiesInvalidFields(array $definition, string $field): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        File::ensureFile(
+            self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'demo' . DIRECTORY_SEPARATOR . 'definition.json',
+            json_encode($definition),
+            true
+        );
+
+        try {
+            $manager->definition('demo');
+            $this->fail('Expected definition validation to fail.');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertStringContainsString("field '{$field}'", $exception->getMessage());
+        }
+    }
+
+    public static function invalidDefinitionProvider(): array
+    {
+        return [
+            'mismatched name' => [['name' => 'other'], 'name'],
+            'invalid version type' => [['name' => 'demo', 'version' => []], 'version'],
+            'invalid namespace' => [['name' => 'demo', 'namespace' => 'Vendor\\Bad-Name'], 'namespace'],
+            'escaping primary file' => [['name' => 'demo', 'primary_file' => '../main.php'], 'primary_file'],
+            'invalid libraries type' => [['name' => 'demo', 'libraries' => 'vendor/package'], 'libraries'],
+            'invalid library name' => [['name' => 'demo', 'libraries' => ['Bad Package']], 'libraries'],
+        ];
+    }
+
+    public function testMalformedDefinitionAndUnsafeDirectoryFailBeforeLifecycleMutation(): void
+    {
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $manager = new TestableAddOnManager($model, $datasource);
+        File::ensureFile(
+            self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'demo' . DIRECTORY_SEPARATOR . 'definition.json',
+            '{invalid',
+            true
+        );
+
+        foreach (['demo', '../outside'] as $name) {
+            try {
+                $manager->install($name);
+                $this->fail('Expected definition validation to fail.');
+            } catch (\InvalidArgumentException $exception) {
+                $this->assertStringContainsString('Invalid add-on definition', $exception->getMessage());
+            }
+        }
+
+        $this->assertSame(0, $datasource->migrationRuns);
+        $this->assertSame([], $model->writes);
     }
 
     public function testAddOnPathsArePortableAndRemainWithinTheConfiguredRoot(): void


### PR DESCRIPTION
## Intent

Normalize and validate package-owned add-on metadata before dependencies, datasources, hooks, or registration are mutated.

Closes #29.

## User stories / acceptance criteria

- Directory and definition names use one safe, predictable lifecycle identifier.
- Version, namespace, primary file, and libraries receive explicit defaults and type/shape validation.
- Primary files cannot escape the add-on root.
- Composer package names are normalized and invalid entries are rejected rather than silently discarded.
- Malformed JSON and unsafe directory identifiers fail before datasource or model side effects.
- Validation errors identify the invalid field and expected shape.
- JSON parsing and normalization favor DevElation HTTP, `Arr`, `Str`, `Val`, `File`, and `Path` helpers.

## Key files changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php
composer ci
```

Local verification: Composer validation and full repository lint passed through `composer ci`; its outer process timed out before PHPUnit began because lint process startup exceeded five minutes. `composer test` then passed 58 tests / 168 assertions.

## QA checklist

- [x] Backward-compatible defaults for omitted metadata
- [x] Malformed JSON rejection
- [x] Unsafe identifier and path rejection
- [x] Invalid scalar/array type rejection
- [x] Invalid Composer package rejection
- [x] No lifecycle mutation before validation
- [x] Full lint and PHPUnit suite pass

## Approval conditions

- Confirm `0.0.0` and an empty namespace are acceptable compatibility defaults.
- Confirm a declared name must match its containing add-on directory.
- Confirm field-level `InvalidArgumentException` is the intended validation surface.
