### PR TITLE
Resolve namespaced add-on lifecycle components

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -6,6 +6,7 @@ use BlueFission\Arr;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\FileSystem;
 use BlueFission\Data\Storage\Storage;
+use BlueFission\Func;
 use BlueFission\Services\Service;
 use BlueFission\Utils\Loader;
 use BlueFission\Utils\File;
@@ -69,7 +70,10 @@ class AddOnManager extends Service
         $result['messages'][] = ob_get_contents();
         ob_end_clean();
 
-        $this->callHook($addon, 'install');
+        $hookResult = $this->callHook($addon, 'install');
+        if (Arr::is($hookResult)) {
+            $result['hooks'][] = $hookResult;
+        }
         $this->_model->write($addon);
         $result['changed'] = true;
         $result['stage'] = 'complete';
@@ -96,7 +100,10 @@ class AddOnManager extends Service
 
         try {
             $result['stage'] = 'hook';
-            $this->callHook($addon, 'uninstall');
+            $hookResult = $this->callHook($addon, 'uninstall');
+            if (Arr::is($hookResult)) {
+                $result['hooks'][] = $hookResult;
+            }
 
             $result['stage'] = 'definition';
             $data = $this->getAddOnData($addon->name);
@@ -220,15 +227,54 @@ class AddOnManager extends Service
 
     protected function callHook(AddOn $addOn, $hook)
     {
+        $hook = Str::trim((string)$hook);
         $primaryFile = $addOn->path . DIRECTORY_SEPARATOR . $addOn->primary_file;
-        if ((new File())->exists($primaryFile)) {
-            require_once($primaryFile);
+        $result = Arr::make([
+            'ok' => false,
+            'hook' => $hook,
+            'status' => 'pending',
+            'strategy' => null,
+            'callable' => null,
+            'attempted' => [],
+            'error' => null,
+        ]);
 
-            $hookFunction = "{$addOn->name}_{$hook}";
-            if (function_exists($hookFunction)) {
-                $hookFunction();
-            }
+        if (!(new File())->isReachable($primaryFile)) {
+            $result->set('status', 'missing_primary_file');
+            $result->set('error', 'Add-on primary file is not reachable.');
+
+            return $result->toArray();
         }
+
+        require_once($primaryFile);
+
+        $legacyHook = "{$addOn->name}_{$hook}";
+        $namespace = Str::trim((string)$addOn->namespace, '\\');
+        $candidates = Arr::make([]);
+        if (Val::isNotEmpty($namespace)) {
+            $candidates->push("{$namespace}\\{$legacyHook}");
+        }
+        $candidates->push($legacyHook)->unique()->values();
+        $result->set('attempted', $candidates->toArray());
+
+        foreach ($candidates as $candidate) {
+            if (!Func::isCallable($candidate)) {
+                continue;
+            }
+
+            Func::make($candidate)->call();
+            $result->set('ok', true);
+            $result->set('status', 'called');
+            $result->set('strategy', $candidate === $legacyHook ? 'legacy' : 'namespaced');
+            $result->set('callable', $candidate);
+
+            return $result->toArray();
+        }
+
+        $result->set('status', 'missing_callable');
+        $result->set('error', 'No compatible lifecycle hook callable was found.');
+
+        return $result->toArray();
     }
 
     public function uploadAddonFile($file, $destination)
@@ -399,6 +445,7 @@ class AddOnManager extends Service
             'error' => null,
             'messages' => [],
             'dependencies' => [],
+            'hooks' => [],
             'modelStatus' => $modelStatus,
             'query' => $query,
         ])->toArray();

--- a/src/BlueCore/Business/Managers/DatasourceManager.php
+++ b/src/BlueCore/Business/Managers/DatasourceManager.php
@@ -5,7 +5,9 @@ use BlueFission\Services\Service;
 use BlueFission\Collections\Collection;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\Storage\Storage;
+use BlueFission\Utils\File;
 use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Val;
 
 class DatasourceManager extends Service {
@@ -174,16 +176,15 @@ class DatasourceManager extends Service {
 		}
 
 		$generators = $this->loadGenerators();
-		if ( in_array('RootSeeder.php', $generators) ) {
+		if ( Arr::has($generators, 'RootSeeder.php', true) ) {
 			$classname = $this->findClassName( $this->_generatorDir . 'RootSeeder.php' );
 			if ( $classname ) {
 				include_once($this->_generatorDir . 'RootSeeder.php');
 				$object = \App::makeInstance($classname);
 				if ( method_exists($object, 'seeders') ) {
-					$generators = call_user_func([$object, 'seeders']);
-					array_walk($generators, function(&$generator) {
-						$generator = $generator.'.php';
-					});
+					$generators = Arr::make(call_user_func([$object, 'seeders']))
+						->map(fn ($generator) => Str::endsWith($generator, '.php') ? $generator : $generator . '.php')
+						->toArray();
 				}
 			}
 		}
@@ -192,7 +193,7 @@ class DatasourceManager extends Service {
 			$classname = '';
 
 			if ( strpos($generator, '.') !== 0 ) {
-				$generator = strpos($generator, '.php') ? $generator : $generator . '.php';
+				$generator = Str::endsWith($generator, '.php') ? $generator : $generator . '.php';
 				
 				$classname = $this->findClassName( $this->_generatorDir . $generator );
 				if ( $classname ) {
@@ -269,41 +270,74 @@ class DatasourceManager extends Service {
 		return scandir($this->_deltaDir, $reverse);
 	}
 
-	// https://stackoverflow.com/questions/7153000/get-class-name-from-file
-	private function findClassName( $file )
+	protected function findClassName($file): ?string
 	{
-		$fp = fopen($file, 'r');
-		$class = $namespace = $buffer = '';
-		$i = 0;
-		while (!$class) {
-		    if (feof($fp)) break;
-
-		    $buffer .= fread($fp, 512);
-		    $tokens = token_get_all($buffer);
-
-		    if (strpos($buffer, '{') === false) continue;
-
-		    for (;$i<count($tokens);$i++) {
-		        if ($tokens[$i][0] === T_NAMESPACE) {
-		            for ($j=$i+1;$j<count($tokens); $j++) {
-		                if ($tokens[$j][0] === T_STRING) {
-		                     $namespace .= '\\'.$tokens[$j][1];
-		                } else if ($tokens[$j] === '{' || $tokens[$j] === ';') {
-		                     break;
-		                }
-		            }
-		        }
-
-		        if ($tokens[$i][0] === T_CLASS) {
-		            for ($j=$i+1;$j<count($tokens);$j++) {
-		                if ($tokens[$j] === '{') {
-		                    $class = $tokens[$i+2][1];
-		                }
-		            }
-		        }
-		    }
+		if (!(new File())->isReachable($file)) {
+			return null;
 		}
 
-		return $class;
+		$tokens = token_get_all(File::readContents($file));
+		$namespace = '';
+		$previousToken = null;
+
+		foreach ($tokens as $index => $token) {
+			if (!Arr::is($token)) {
+				continue;
+			}
+
+			$tokenType = Arr::getPath($token, '0');
+			if ($tokenType === T_NAMESPACE) {
+				$namespace = $this->namespaceFromTokens($tokens, $index + 1);
+			}
+
+			if ($tokenType === T_CLASS && !Arr::has([T_NEW, T_DOUBLE_COLON], $previousToken, true)) {
+				$class = $this->classFromTokens($tokens, $index + 1);
+				if (Val::isNotEmpty($class)) {
+					return Str::trim(
+						Val::isEmpty($namespace) ? $class : "{$namespace}\\{$class}",
+						'\\'
+					);
+				}
+			}
+
+			if (!Arr::has([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], $tokenType, true)) {
+				$previousToken = $tokenType;
+			}
+		}
+
+		return null;
+	}
+
+	private function namespaceFromTokens(array $tokens, int $offset): string
+	{
+		$namespace = '';
+		for ($index = $offset, $size = Arr::size($tokens); $index < $size; $index++) {
+			$token = $tokens[$index];
+			if ($token === ';' || $token === '{') {
+				break;
+			}
+
+			if (Arr::is($token) && Arr::has([T_STRING, T_NAME_QUALIFIED, T_NS_SEPARATOR], $token[0], true)) {
+				$namespace .= $token[1];
+			}
+		}
+
+		return Str::trim($namespace, '\\');
+	}
+
+	private function classFromTokens(array $tokens, int $offset): ?string
+	{
+		for ($index = $offset, $size = Arr::size($tokens); $index < $size; $index++) {
+			$token = $tokens[$index];
+			if ($token === '{') {
+				break;
+			}
+
+			if (Arr::is($token) && $token[0] === T_STRING) {
+				return $token[1];
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -3,6 +3,7 @@
 namespace BlueFission\Tests\BlueCore\Business\Managers;
 
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
+use BlueFission\BlueCore\Domain\AddOn\AddOn;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 use PHPUnit\Framework\TestCase;
@@ -99,6 +100,78 @@ class AddOnManagerTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $manager->path('../outside');
+    }
+
+    public function testNamespacedHookResolutionAndLegacyFallbackReturnDiagnostics(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $namespacedPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'namespaced';
+        File::ensureFile(
+            $namespacedPath . DIRECTORY_SEPARATOR . 'main.php',
+            "<?php\nnamespace BlueFission\\Tests\\Fixtures\\AddOnHooks;\nfunction demo_install() { \$GLOBALS['bluecore_hook_calls'][] = 'namespaced'; }",
+            true
+        );
+        $namespaced = new AddOn();
+        $namespaced->assign([
+            'name' => 'demo',
+            'namespace' => 'BlueFission\\Tests\\Fixtures\\AddOnHooks',
+            'path' => $namespacedPath,
+            'primary_file' => 'main.php',
+        ]);
+
+        $namespacedResult = $manager->hook($namespaced, 'install');
+
+        $this->assertTrue($namespacedResult['ok']);
+        $this->assertSame('namespaced', $namespacedResult['strategy']);
+        $this->assertSame(
+            'BlueFission\\Tests\\Fixtures\\AddOnHooks\\demo_install',
+            $namespacedResult['callable']
+        );
+
+        $legacyPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'legacy';
+        File::ensureFile(
+            $legacyPath . DIRECTORY_SEPARATOR . 'main.php',
+            "<?php\nfunction legacydemo_install() { \$GLOBALS['bluecore_hook_calls'][] = 'legacy'; }",
+            true
+        );
+        $legacy = new AddOn();
+        $legacy->assign([
+            'name' => 'legacydemo',
+            'namespace' => 'Missing\\Namespace',
+            'path' => $legacyPath,
+            'primary_file' => 'main.php',
+        ]);
+
+        $legacyResult = $manager->hook($legacy, 'install');
+
+        $this->assertTrue($legacyResult['ok']);
+        $this->assertSame('legacy', $legacyResult['strategy']);
+        $this->assertSame('legacydemo_install', $legacyResult['callable']);
+        $this->assertSame(['namespaced', 'legacy'], $GLOBALS['bluecore_hook_calls']);
+    }
+
+    public function testMissingHookReturnsStructuredDiagnostics(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'missing-hook';
+        File::ensureFile($path . DIRECTORY_SEPARATOR . 'main.php', '<?php', true);
+        $addOn = new AddOn();
+        $addOn->assign([
+            'name' => 'missing',
+            'namespace' => 'Vendor\\Package',
+            'path' => $path,
+            'primary_file' => 'main.php',
+        ]);
+
+        $result = $manager->hook($addOn, 'install');
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('missing_callable', $result['status']);
+        $this->assertSame(
+            ['Vendor\\Package\\missing_install', 'missing_install'],
+            $result['attempted']
+        );
+        $this->assertNotEmpty($result['error']);
     }
 
     public function testActivateAndActivateAllReturnStructuredStatuses(): void
@@ -251,14 +324,16 @@ class TestableAddOnManager extends AddOnManager
         return $this->addOnPath($name);
     }
 
+    public function hook(AddOn $addOn, string $hook): array
+    {
+        return $this->callHook($addOn, $hook);
+    }
+
     protected function datasourceManager(): mixed
     {
         return $this->datasource;
     }
 
-    protected function callHook(\BlueFission\BlueCore\Domain\AddOn\AddOn $addOn, $hook): void
-    {
-    }
 }
 
 class FakeAddOnModel

--- a/tests/BlueCore/Business/Managers/DatasourceManagerClassResolutionTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerClassResolutionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Business\Managers;
+
+use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use BlueFission\Utils\File;
+use PHPUnit\Framework\TestCase;
+
+class DatasourceManagerClassResolutionTest extends TestCase
+{
+    public function testNamespacedAndLegacyComponentClassesAreResolved(): void
+    {
+        $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-datasource-components-' . uniqid();
+        $manager = new ClassResolvingDatasourceManager();
+        $namespacedFile = $root . DIRECTORY_SEPARATOR . 'CreateRecords.php';
+        $legacyFile = $root . DIRECTORY_SEPARATOR . 'LegacySeeder.php';
+        $missingClassFile = $root . DIRECTORY_SEPARATOR . 'functions.php';
+
+        File::ensureFile(
+            $namespacedFile,
+            "<?php\nnamespace Vendor\\Package\\Datasource;\nclass CreateRecords {}",
+            true
+        );
+        File::ensureFile($legacyFile, "<?php\nclass LegacySeeder {}", true);
+        File::ensureFile($missingClassFile, "<?php\nfunction helper() {}", true);
+
+        $this->assertSame(
+            'Vendor\\Package\\Datasource\\CreateRecords',
+            $manager->className($namespacedFile)
+        );
+        $this->assertSame('LegacySeeder', $manager->className($legacyFile));
+        $this->assertNull($manager->className($missingClassFile));
+        $this->assertNull($manager->className($root . DIRECTORY_SEPARATOR . 'missing.php'));
+    }
+}
+
+class ClassResolvingDatasourceManager extends DatasourceManager
+{
+    public function __construct()
+    {
+    }
+
+    public function className(string $file): ?string
+    {
+        return $this->findClassName($file);
+    }
+}


### PR DESCRIPTION
## Intent

Resolve normal namespaced PHP datasource classes and add-on lifecycle hooks while retaining an explicit legacy hook fallback.

Closes #30.

## User stories / acceptance criteria

- Migration, generator, and seeder token parsing retains the fully qualified class name.
- Application resolution receives the fully qualified class returned by the parser.
- Add-on namespace metadata selects the namespaced lifecycle function first.
- Legacy unqualified hook functions remain a documented fallback.
- Hook resolution returns structured status, strategy, selected callable, attempted callables, and errors.
- Missing primary files or hook callables remain nonfatal for compatibility but are no longer silent.
- Touched paths favor DevElation `File`, `Arr`, `Str`, `Val`, and `Func` helpers.

## Key files changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `src/BlueCore/Business/Managers/DatasourceManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `tests/BlueCore/Business/Managers/DatasourceManagerClassResolutionTest.php`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php tests/BlueCore/Business/Managers/DatasourceManagerClassResolutionTest.php
composer ci
```

Validated locally: 54 tests, 171 assertions.

## QA checklist

- [x] Namespaced datasource class resolution
- [x] Legacy global datasource class resolution
- [x] Missing class/file behavior
- [x] Namespaced lifecycle hook execution
- [x] Legacy lifecycle hook fallback
- [x] Missing-hook structured diagnostics
- [x] Full lint and PHPUnit suite pass

## Approval conditions

- Confirm namespace metadata should resolve `<namespace>\\<name>_<hook>` before the global function.
- Confirm missing hooks remain optional while returning `ok=false` diagnostics within the hook record.
- Confirm parser visibility as `protected` is acceptable for extension and characterization.
