### PR TITLE
Delegate template rendering through registered service

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ The `ValueObject` class is used to store and manage values as an object, providi
 
 The `Theme` class manages theme-related properties and paths, allowing for easy customization of the application's look and feel.
 
+Applications may register a rendering service under the canonical `template` service name. The service must expose `render(string $themeName, string $file, array $data): string`; the global helper preserves the same arguments and returns its result directly.
+
+```php
+$app->delegate('template', $renderer);
+
+$output = template('admin', 'dashboard.vibe', [
+    'title' => 'Dashboard',
+]);
+```
+
+When no compatible service is registered, `template()` renders the selected theme with DevElation's `HTML\Template` and `Parsing\Parser` pipeline. The fallback configures the theme directory for template includes and its `modules` directory for module includes.
+
 ### MenuItem and Menu
 
 The `MenuItem` and `Menu` classes represent individual items and collections of items in a menu, respectively. These classes facilitate the creation and rendering of dynamic menu structures.

--- a/src/Helpers/response.php
+++ b/src/Helpers/response.php
@@ -6,6 +6,7 @@ use BlueFission\HTML\Template;
 use BlueFission\Services\Response;
 use BlueFission\Net\HTTP;
 use BlueFission\Arr;
+use BlueFission\Func;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Utils\File;
@@ -14,40 +15,69 @@ use BlueFission\Utils\Path;
 /**
  * Define the template function.
  *
+ * @param string $themeName Name of the registered theme
  * @param string $file Name of the file to load
  * @param array $data Data to be passed to the template
  * @return string The rendered template
  */
 if (!function_exists( 'template' )) {
 	function template(string $themeName, string $file, array $data = []) {
+		static $delegating = false;
+
+		if (Val::isFalsy($delegating)) {
+			$renderer = template_renderer_service();
+			if (Val::isNotNull($renderer) && Func::isCallable([$renderer, 'render'])) {
+				$delegating = true;
+				try {
+					return $renderer->render($themeName, $file, $data);
+				} finally {
+					$delegating = false;
+				}
+			}
+		}
+
+		return template_legacy_render($themeName, $file, $data);
+	}
+}
+
+if (!function_exists('template_renderer_service')) {
+	function template_renderer_service(): mixed
+	{
+		try {
+			return instance('template');
+		} catch (\Exception $exception) {
+			$missingService = Str::make($exception->getMessage())
+				->match('The service template is not registered');
+
+			if (Val::isFalsy($missingService)) {
+				throw $exception;
+			}
+
+			return null;
+		}
+	}
+}
+
+if (!function_exists('template_legacy_render')) {
+	function template_legacy_render(string $themeName, string $file, array $data = []): string
+	{
 		$app = instance();
 		$theme = $app->theme($themeName);
-		if (!$theme) {
+		if (Val::isEmpty($theme)) {
 			throw new \Exception("Theme '$themeName' not found.");
 		}
 
-		// $path = dirname(getcwd()).DIRECTORY_SEPARATOR.'resource'.DIRECTORY_SEPARATOR.'markup'.DIRECTORY_SEPARATOR.$file;
-		// $module_path = dirname(getcwd()).DIRECTORY_SEPARATOR.'resource'.DIRECTORY_SEPARATOR.'markup'.DIRECTORY_SEPARATOR.'modules';
 		store('asset_dir', $theme->location);
-		$path = $theme->location.$file;
-		$module_path = $theme->location.'modules';
+		$path = Path::normalize($theme->location . DIRECTORY_SEPARATOR . $file);
+		$modulePath = Path::normalize($theme->location . DIRECTORY_SEPARATOR . 'modules');
 
 		$template = new Template();
-		
-		// Configure the directory for template modules
-		$template->config('module_directory', $module_path);
-
-		// Load the template file
+		$template->config('template_directory', Path::normalize($theme->location));
+		$template->config('module_directory', $modulePath);
 		$template->load($path);
-
-		// Pass the data to the template
 		$template->field($data);
 
-		// Render the template
-		$output = $template->render();
-
-		// $template->cache();
-		return $output;
+		return $template->render();
 	}
 }
 

--- a/tests/Helpers/TemplateRenderingHelperTest.php
+++ b/tests/Helpers/TemplateRenderingHelperTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace BlueFission\Tests\Helpers;
+
+use BlueFission\BlueCore\Engine;
+use BlueFission\BlueCore\Theme;
+use BlueFission\Services\Application;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+use PHPUnit\Framework\TestCase;
+
+class TemplateRenderingHelperTest extends TestCase
+{
+    private static string $root;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$root = defined('APP_ROOT')
+            ? APP_ROOT
+            : sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-template-rendering-tests';
+
+        if (!defined('APP_ROOT')) {
+            define('APP_ROOT', self::$root);
+        }
+
+        if (!defined('PROJECT_ROOT')) {
+            define('PROJECT_ROOT', self::$root);
+        }
+
+        if (!defined('SITE_ROOT')) {
+            define('SITE_ROOT', self::$root);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->resetApplications();
+        Path::ensureDir($this->themePath());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetApplications();
+    }
+
+    public function testTemplateDelegatesToRegisteredRenderingService(): void
+    {
+        $renderer = new class {
+            public array $arguments = [];
+
+            public function render(string $theme, string $file, array $data): string
+            {
+                $this->arguments = [$theme, $file, $data];
+
+                return 'service output';
+            }
+        };
+
+        (new Engine())->delegate('template', $renderer);
+
+        $this->assertSame('service output', template('admin', 'dashboard.vibe', ['title' => 'Dashboard']));
+        $this->assertSame(['admin', 'dashboard.vibe', ['title' => 'Dashboard']], $renderer->arguments);
+    }
+
+    public function testTemplateFallsBackToDevelationParserRenderer(): void
+    {
+        $this->writeTemplate('welcome.tpl', 'Hello, {$name}!');
+        $this->engineWithTheme();
+
+        $this->assertSame('Hello, Ada!', template('test', 'welcome.tpl', ['name' => 'Ada']));
+    }
+
+    public function testTemplateFallsBackWhenServiceDoesNotExposeRender(): void
+    {
+        $this->writeTemplate('fallback.tpl', 'Fallback: {$value}');
+        $engine = $this->engineWithTheme();
+        $engine->delegate('template', new \stdClass());
+
+        $this->assertSame('Fallback: ready', template('test', 'fallback.tpl', ['value' => 'ready']));
+    }
+
+    public function testTemplatePropagatesRendererExceptionsUnchanged(): void
+    {
+        $failure = new \RuntimeException('Renderer failed.');
+        $renderer = new class ($failure) {
+            public function __construct(private \RuntimeException $failure)
+            {
+            }
+
+            public function render(string $theme, string $file, array $data): string
+            {
+                throw $this->failure;
+            }
+        };
+
+        (new Engine())->delegate('template', $renderer);
+
+        $this->expectExceptionObject($failure);
+        template('test', 'failure.tpl');
+    }
+
+    public function testRecursiveServiceEntryUsesParserFallback(): void
+    {
+        $this->writeTemplate('recursive.tpl', 'Recursive: {$value}');
+        $engine = $this->engineWithTheme();
+        $engine->delegate('template', new class {
+            public function render(string $theme, string $file, array $data): string
+            {
+                return template($theme, $file, $data);
+            }
+        });
+
+        $this->assertSame('Recursive: guarded', template('test', 'recursive.tpl', ['value' => 'guarded']));
+    }
+
+    private function engineWithTheme(): Engine
+    {
+        $engine = new Engine();
+        $engine->addTheme(new Theme('app/test', 'test'));
+
+        return $engine;
+    }
+
+    private function writeTemplate(string $file, string $contents): void
+    {
+        File::ensureFile($this->themePath($file), $contents, true);
+    }
+
+    private function themePath(string $file = ''): string
+    {
+        return Path::normalize(
+            self::$root
+            . DIRECTORY_SEPARATOR . 'resource'
+            . DIRECTORY_SEPARATOR . 'markup'
+            . DIRECTORY_SEPARATOR . 'test'
+            . (empty($file) ? '' : DIRECTORY_SEPARATOR . $file)
+        );
+    }
+
+    private function resetApplications(): void
+    {
+        $instances = new \ReflectionProperty(Application::class, '_instances');
+        $instances->setValue(null, []);
+    }
+}


### PR DESCRIPTION
## Intent
Delegate the global `template($themeName, $file, $data)` helper through a registered rendering service while preserving the DevElation parser-backed fallback.

## User stories and acceptance criteria
- Applications can register a renderer under the canonical `template` service name.
- The helper forwards the existing theme, file, and data arguments and returns renderer output directly.
- Missing or incompatible services use the existing `HTML\Template` and `Parsing\Parser` pipeline.
- Renderer and service-resolution exceptions propagate unchanged.
- Recursive helper entry is guarded and falls back to the parser renderer.
- Registration and fallback behavior are documented.

## Key files changed
- `src/Helpers/response.php`: service delegation, recursion guard, and parser include paths.
- `tests/Helpers/TemplateRenderingHelperTest.php`: delegation and fallback contract coverage.
- `README.md`: canonical renderer registration contract.

## How to test
```bash
composer ci
composer audit --locked
vendor/bin/phpunit --do-not-cache-result tests/Helpers/TemplateRenderingHelperTest.php
```

## QA checklist
- [x] Full test suite passes: 74 tests, 235 assertions.
- [x] Focused helper tests pass: 5 tests, 8 assertions.
- [x] Composer validation and PHP lint pass.
- [x] Locked dependency audit reports no advisories.
- [x] Public helper signature remains unchanged.
- [x] No package-specific aliases or renderer coupling were introduced.

## Approval conditions
Approve when canonical service delegation, unchanged failure propagation, recursion handling, and parser fallback match the documented contract.

Closes #47