### PR TITLE
Ignore generated agent standards file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /.codex/
 /AGENTS.md
 /AGENTS.behavior.md
+/AGENTS.standards.md
 /harness.json


### PR DESCRIPTION
## Intent
Keep the root-generated AGENTS.standards.md harness file outside version control.

## User stories and acceptance criteria
- Contributors do not see the generated root standards file as repository work.
- The rule is root-scoped.
- Nested files with the same name remain trackable.
- Existing harness ignore entries are preserved.

## Key files changed
- .gitignore: adds /AGENTS.standards.md beside the existing agent configuration exclusions.

## How to test
- git check-ignore -v AGENTS.standards.md
- git check-ignore --no-index nested/AGENTS.standards.md (expected non-zero because it is not ignored)
- git diff --check

## QA checklist
- [x] Root generated file is ignored.
- [x] Nested same-name path is not ignored.
- [x] No local generated file was modified or committed.
- [x] Diff contains one root-scoped ignore rule.

## Approval conditions
Approve when the generated root standards file is excluded without broadening ignore behavior.

Closes #49