### PR TITLE
Fix project installer source and dist parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Run CI checks
         run: composer ci
+
+      - name: Verify project installer source and dist parity
+        run: php tests/Integration/project-installer-parity.php

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ composer require bluefission/bluecore:^0.1.0-alpha
 
 The alpha line is intended for integration testing while the public API is finalized. Pin an explicit alpha constraint in reproducible environments.
 
+### Project Packages
+
+Composer packages with the `opus-project` type install into `core/` by default. Project directories and root configuration files are promoted as non-destructive overrides: existing root files are preserved, while files introduced by later project versions are added during updates. Source and distribution installs follow the same lifecycle.
+
+Set `OPUS_STANDALONE=1` to install a project package under `vendor/` without promoting root overrides.
+
 ## Usage
 
 ### Event Management

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "scripts": {
         "lint": "@php scripts/lint.php",
         "test": "phpunit --do-not-cache-result tests",
+        "test:installer": "@php tests/Integration/project-installer-parity.php",
         "ci": [
             "Composer\\Config::disableProcessTimeout",
             "composer validate --no-check-publish --strict",

--- a/src/BlueCore/Installers/ProjectInstaller.php
+++ b/src/BlueCore/Installers/ProjectInstaller.php
@@ -7,6 +7,8 @@ use Composer\Installer\LibraryInstaller;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
+use RuntimeException;
+use Throwable;
 
 class ProjectInstaller extends LibraryInstaller
 {
@@ -29,41 +31,94 @@ class ProjectInstaller extends LibraryInstaller
 
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
-        parent::install($repo, $package);
+        return parent::install($repo, $package)->then(function () use ($repo, $package): void {
+            try {
+                $this->copyProjectOverrides($package);
+            } catch (Throwable $exception) {
+                if ($repo->hasPackage($package)) {
+                    $repo->removePackage($package);
+                }
 
-        // Post-install copy logic for override-able dirs
-        $projectPath = $this->getInstallPath($package);
-        $rootPath = dirname($projectPath); // likely the root of the current repo
+                $this->filesystem->removeDirectory($this->getInstallPath($package));
 
-        $overrideDirs = ['addons', 'common', 'public', 'resource', 'storage', 'datasources', 'mapping'];
-
-        foreach ($overrideDirs as $dir) {
-            $sourceDir = $projectPath . DIRECTORY_SEPARATOR . $dir;
-            $rootOverride = $rootPath . DIRECTORY_SEPARATOR . $dir;
-
-            if (is_dir($sourceDir)) {
-                $this->copyMerge($sourceDir, $rootOverride);
+                throw new RuntimeException(
+                    'Unable to install project overrides for ' . $package->getPrettyName() . ': ' . $exception->getMessage(),
+                    0,
+                    $exception
+                );
             }
+        });
+    }
+
+    public function update(
+        InstalledRepositoryInterface $repo,
+        PackageInterface $initial,
+        PackageInterface $target
+    ) {
+        return parent::update($repo, $initial, $target)->then(function () use ($target): void {
+            try {
+                $this->copyProjectOverrides($target);
+            } catch (Throwable $exception) {
+                throw new RuntimeException(
+                    'Unable to update project overrides for ' . $target->getPrettyName() . ': ' . $exception->getMessage(),
+                    0,
+                    $exception
+                );
+            }
+        });
+    }
+
+    private function copyProjectOverrides(PackageInterface $package): void
+    {
+        if ($this->getInstallPath($package) !== 'core') {
+            return;
         }
 
-        $overrideFiles = ['Procfile', '.env.example', '.env', 'webpack.config.js', 'terminal', 'websocket-server.php', 'package.json'];
+        $projectPath = $this->getInstallPath($package);
+        $rootPath = dirname($projectPath);
+        $createdFiles = [];
+        $createdDirectories = [];
 
-        // Copy override files to root
-        foreach ($overrideFiles as $file) {
-            $sourceFile = $projectPath . DIRECTORY_SEPARATOR . $file;
-            $rootFile = $rootPath . DIRECTORY_SEPARATOR . $file;
+        try {
+            $overrideDirectories = ['addons', 'common', 'public', 'resource', 'storage', 'datasources', 'mapping'];
 
-            if (file_exists($sourceFile)) {
-                $this->copyIfNotExists($sourceFile, $rootFile);
+            foreach ($overrideDirectories as $directory) {
+                $source = $projectPath . DIRECTORY_SEPARATOR . $directory;
+
+                if (is_dir($source)) {
+                    $this->copyMerge(
+                        $source,
+                        $rootPath . DIRECTORY_SEPARATOR . $directory,
+                        $createdFiles,
+                        $createdDirectories
+                    );
+                }
             }
+
+            $overrideFiles = ['Procfile', '.env.example', '.env', 'webpack.config.js', 'terminal', 'websocket-server.php', 'package.json'];
+
+            foreach ($overrideFiles as $file) {
+                $source = $projectPath . DIRECTORY_SEPARATOR . $file;
+
+                if (is_file($source)) {
+                    $this->copyIfNotExists(
+                        $source,
+                        $rootPath . DIRECTORY_SEPARATOR . $file,
+                        $createdFiles,
+                        $createdDirectories
+                    );
+                }
+            }
+        } catch (Throwable $exception) {
+            $this->rollbackOverrides($createdFiles, $createdDirectories);
+
+            throw $exception;
         }
     }
 
-    private function copyMerge($source, $dest)
+    private function copyMerge($source, $destination, array &$createdFiles, array &$createdDirectories): void
     {
-        if (!is_dir($source)) return;
-
-        @mkdir($dest, 0755, true);
+        $this->ensureDirectory($destination, $createdDirectories);
 
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
@@ -71,26 +126,79 @@ class ProjectInstaller extends LibraryInstaller
         );
 
         foreach ($iterator as $item) {
-            $targetPath = $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
+            $targetPath = $destination . DIRECTORY_SEPARATOR . $iterator->getSubPathName();
 
             if (is_dir($item)) {
-                @mkdir($targetPath, 0755, true);
+                $this->ensureDirectory($targetPath, $createdDirectories);
             } elseif (is_file($item)) {
-                $this->copyIfNotExists($item, $targetPath);
+                $this->copyIfNotExists($item->getPathname(), $targetPath, $createdFiles, $createdDirectories);
             }
         }
     }
 
-    private function copyIfNotExists($source, $dest)
+    private function copyIfNotExists(
+        $source,
+        $destination,
+        array &$createdFiles,
+        array &$createdDirectories
+    ): void
     {
-        if (!file_exists($dest)) {
-            copy($source, $dest);
+        if (file_exists($destination) || is_link($destination)) {
+            return;
+        }
+
+        $this->ensureDirectory(dirname($destination), $createdDirectories);
+        $this->filesystem->safeCopy($source, $destination);
+        $createdFiles[] = $destination;
+    }
+
+    private function ensureDirectory($directory, array &$createdDirectories): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+
+        if (file_exists($directory) || is_link($directory)) {
+            throw new RuntimeException('Override directory is blocked by an existing path: ' . $directory);
+        }
+
+        $missing = [];
+        $current = $directory;
+
+        while (!is_dir($current)) {
+            if (file_exists($current) || is_link($current)) {
+                throw new RuntimeException('Override directory is blocked by an existing path: ' . $current);
+            }
+
+            $missing[] = $current;
+            $parent = dirname($current);
+
+            if ($parent === $current) {
+                break;
+            }
+
+            $current = $parent;
+        }
+
+        $this->filesystem->ensureDirectoryExists($directory);
+
+        foreach (array_reverse($missing) as $createdDirectory) {
+            $createdDirectories[] = $createdDirectory;
         }
     }
 
-    public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
+    private function rollbackOverrides(array $createdFiles, array $createdDirectories): void
     {
-        // Optional: Add cleanup if needed
-        parent::uninstall($repo, $package);
+        foreach (array_reverse($createdFiles) as $file) {
+            if (file_exists($file) || is_link($file)) {
+                $this->filesystem->unlink($file);
+            }
+        }
+
+        foreach (array_reverse($createdDirectories) as $directory) {
+            if (is_dir($directory) && count(scandir($directory)) === 2) {
+                rmdir($directory);
+            }
+        }
     }
 }

--- a/tests/Integration/project-installer-parity.php
+++ b/tests/Integration/project-installer-parity.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+use BlueFission\Arr;
+use BlueFission\Flag;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+
+require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+restore_error_handler();
+restore_exception_handler();
+
+$root = Path::normalize(dirname(__DIR__, 2));
+$workspace = Path::normalize(
+    sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-installer-' . Str::rand('', 10)
+);
+$composer = getenv('COMPOSER_BINARY') ?: 'composer';
+
+try {
+    Path::ensureDir($workspace);
+    $plugin = createPluginPackage($workspace, $root);
+    $fixture = createFixturePackage($workspace);
+
+    verifyTransport($workspace, $plugin, $fixture, $composer, 'dist');
+    verifyTransport($workspace, $plugin, $fixture, $composer, 'source');
+    verifyFailureRollback($workspace, $plugin, $fixture, $composer);
+
+    fwrite(STDOUT, "Project installer source/dist parity passed.\n");
+} finally {
+    removeTree($workspace);
+}
+
+function createPluginPackage(string $workspace, string $root): string
+{
+    $plugin = Path::normalize($workspace . DIRECTORY_SEPARATOR . 'bluecore-plugin');
+    $installerRoot = 'src' . DIRECTORY_SEPARATOR . 'BlueCore' . DIRECTORY_SEPARATOR . 'Installers';
+    Path::ensureDir($plugin . DIRECTORY_SEPARATOR . $installerRoot);
+
+    foreach (Arr::make(['AddOnInstaller.php', 'ThemeInstaller.php', 'ProjectInstaller.php', 'PluginInstaller.php']) as $file) {
+        File::ensureFile(
+            $plugin . DIRECTORY_SEPARATOR . $installerRoot . DIRECTORY_SEPARATOR . $file,
+            File::readContents($root . DIRECTORY_SEPARATOR . $installerRoot . DIRECTORY_SEPARATOR . $file),
+            true
+        );
+    }
+    File::ensureFile(
+        $plugin . DIRECTORY_SEPARATOR . 'composer.json',
+        HTTP::jsonEncode([
+            'name' => 'bluefission/bluecore',
+            'version' => '0.0.0',
+            'type' => 'composer-plugin',
+            'require' => [
+                'php' => '>=8.2',
+                'composer-plugin-api' => '^2.0',
+            ],
+            'autoload' => [
+                'psr-4' => ['BlueFission\\' => 'src/'],
+            ],
+            'extra' => [
+                'class' => 'BlueFission\\BlueCore\\Installers\\PluginInstaller',
+            ],
+        ]),
+        true
+    );
+
+    return $plugin;
+}
+
+/**
+ * @return array{source: string, reference: string, dist: array<string, string>}
+ */
+function createFixturePackage(string $workspace): array
+{
+    $source = Path::normalize($workspace . DIRECTORY_SEPARATOR . 'project-package');
+    Path::ensureDir($source);
+
+    writeFixtureVersion($source, '1.0.0', [
+        'common' . DIRECTORY_SEPARATOR . 'config.php' => 'version-one',
+        'package.json' => '{"version":"1.0.0"}',
+    ]);
+    runProcess(['git', 'init'], $source);
+    runProcess(['git', 'config', 'user.email', 'installer-fixture@bluefission.com'], $source);
+    runProcess(['git', 'config', 'user.name', 'BlueCore Installer Fixture'], $source);
+    runProcess(['git', 'add', '.'], $source);
+    runProcess(['git', 'commit', '-m', 'fixture version 1.0.0'], $source);
+    runProcess(['git', 'tag', '1.0.0'], $source);
+
+    $dist10 = buildArchive($workspace, $source, '1.0.0');
+
+    writeFixtureVersion($source, '1.1.0', [
+        'common' . DIRECTORY_SEPARATOR . 'config.php' => 'version-two',
+        'common' . DIRECTORY_SEPARATOR . 'new.php' => 'new-override',
+        'package.json' => '{"version":"1.1.0"}',
+    ]);
+    runProcess(['git', 'add', '.'], $source);
+    runProcess(['git', 'commit', '-m', 'fixture version 1.1.0'], $source);
+    runProcess(['git', 'tag', '1.1.0'], $source);
+    $reference = Str::trim(runProcess(['git', 'rev-parse', 'HEAD'], $source)['output']);
+    $dist11 = buildArchive($workspace, $source, '1.1.0');
+
+    return Arr::make([
+        'source' => $source,
+        'reference' => $reference,
+        'dist' => [
+            '1.0.0' => $dist10,
+            '1.1.0' => $dist11,
+        ],
+    ])->toArray();
+}
+
+function writeFixtureVersion(string $source, string $version, array $overrides): void
+{
+    File::ensureFile(
+        $source . DIRECTORY_SEPARATOR . 'composer.json',
+        HTTP::jsonEncode([
+            'name' => 'bluefission/project-installer-fixture',
+            'version' => $version,
+            'type' => 'opus-project',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+        true
+    );
+    File::ensureFile($source . DIRECTORY_SEPARATOR . 'marker.txt', $version, true);
+
+    foreach (Arr::make($overrides) as $path => $contents) {
+        File::ensureFile($source . DIRECTORY_SEPARATOR . $path, $contents, true);
+    }
+}
+
+function buildArchive(string $workspace, string $source, string $version): string
+{
+    $archivePath = Path::normalize($workspace . DIRECTORY_SEPARATOR . "fixture-{$version}.zip");
+    $archive = new ZipArchive();
+    if ($archive->open($archivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+        throw new RuntimeException("Unable to create fixture archive {$archivePath}.");
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($iterator as $item) {
+        $path = Path::normalize($item->getPathname());
+        if (Str::has($path, DIRECTORY_SEPARATOR . '.git' . DIRECTORY_SEPARATOR)) {
+            continue;
+        }
+
+        $relative = Str::sub($path, Str::len($source) + 1);
+        $archive->addFile($path, Str::replace($relative, DIRECTORY_SEPARATOR, '/'));
+    }
+    $archive->close();
+
+    return $archivePath;
+}
+
+function verifyTransport(string $workspace, string $plugin, array $fixture, string $composer, string $transport): void
+{
+    $consumer = Path::normalize($workspace . DIRECTORY_SEPARATOR . "consumer-{$transport}");
+    Path::ensureDir($consumer);
+    writeConsumerManifest($consumer, $plugin, $fixture, '1.0.0');
+
+    $install = runProcess(
+        composerCommand($composer, ['install', '--no-interaction', '--no-progress', "--prefer-{$transport}"]),
+        $consumer,
+        true
+    );
+    assertProcessSucceeded($install, "{$transport} install");
+    assertCleanComposerOutput($install, "{$transport} install");
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'marker.txt', '1.0.0');
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config.php', 'version-one');
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'package.json', '{"version":"1.0.0"}');
+
+    writeConsumerManifest($consumer, $plugin, $fixture, '1.1.0');
+    $update = runProcess(
+        composerCommand($composer, ['update', 'bluefission/project-installer-fixture', '--with-dependencies', '--no-interaction', '--no-progress', "--prefer-{$transport}"]),
+        $consumer,
+        true
+    );
+    assertProcessSucceeded($update, "{$transport} update");
+    assertCleanComposerOutput($update, "{$transport} update");
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'marker.txt', '1.1.0');
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config.php', 'version-one');
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'new.php', 'new-override');
+
+    $remove = runProcess(
+        composerCommand($composer, ['remove', 'bluefission/project-installer-fixture', '--no-interaction', '--no-progress']),
+        $consumer,
+        true
+    );
+    assertProcessSucceeded($remove, "{$transport} uninstall");
+    assertCleanComposerOutput($remove, "{$transport} uninstall");
+    if ((new File())->exists($consumer . DIRECTORY_SEPARATOR . 'core')) {
+        throw new RuntimeException("{$transport} uninstall left the project install path behind.");
+    }
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config.php', 'version-one');
+}
+
+function verifyFailureRollback(string $workspace, string $plugin, array $fixture, string $composer): void
+{
+    $consumer = Path::normalize($workspace . DIRECTORY_SEPARATOR . 'consumer-failure');
+    Path::ensureDir($consumer);
+    File::ensureFile($consumer . DIRECTORY_SEPARATOR . 'common', 'blocking-file', true);
+    writeConsumerManifest($consumer, $plugin, $fixture, '1.0.0');
+
+    $install = runProcess(
+        composerCommand($composer, ['install', '--no-interaction', '--no-progress', '--prefer-dist']),
+        $consumer,
+        true
+    );
+    if ($install['exitCode'] === 0) {
+        throw new RuntimeException('A failed override copy returned a successful Composer exit code.');
+    }
+    if ((new File())->exists($consumer . DIRECTORY_SEPARATOR . 'core')) {
+        throw new RuntimeException('A failed install left a partial project path behind.');
+    }
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'common', 'blocking-file');
+}
+
+function writeConsumerManifest(string $consumer, string $plugin, array $fixture, string $version): void
+{
+    $packages = Arr::make(['1.0.0', '1.1.0'])
+        ->map(fn (string $candidate): array => [
+            'name' => 'bluefission/project-installer-fixture',
+            'version' => $candidate,
+            'type' => 'opus-project',
+            'dist' => [
+                'type' => 'zip',
+                'url' => fileUrl($fixture['dist'][$candidate]),
+            ],
+            'source' => [
+                'type' => 'git',
+                'url' => Str::replace($fixture['source'], DIRECTORY_SEPARATOR, '/'),
+                'reference' => $candidate,
+            ],
+        ])
+        ->toArray();
+    $repositories = Arr::make([
+        [
+            'type' => 'path',
+            'url' => Str::replace($plugin, DIRECTORY_SEPARATOR, '/'),
+            'options' => ['symlink' => false],
+            'canonical' => true,
+        ],
+    ]);
+    $repositories
+        ->push(['type' => 'package', 'package' => $packages])
+        ->push(['packagist.org' => false]);
+
+    File::ensureFile(
+        $consumer . DIRECTORY_SEPARATOR . 'composer.json',
+        HTTP::jsonEncode([
+            'name' => 'bluefission/project-installer-consumer',
+            'repositories' => $repositories->toArray(),
+            'require' => [
+                'bluefission/bluecore' => '0.0.0',
+                'bluefission/project-installer-fixture' => $version,
+            ],
+            'minimum-stability' => 'dev',
+            'prefer-stable' => true,
+            'config' => [
+                'allow-plugins' => ['bluefission/bluecore' => true],
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+        true
+    );
+}
+
+/**
+ * @return array{exitCode: int, output: string}
+ */
+function runProcess(array $command, string $cwd, bool $allowFailure = false): array
+{
+    $pipes = [];
+    $process = proc_open($command, [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['redirect', 1],
+    ], $pipes, $cwd);
+    if (!is_resource($process)) {
+        throw new RuntimeException('Unable to start process: ' . Arr::make($command)->join(' ')->val());
+    }
+
+    fclose($pipes[0]);
+    $output = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    $exitCode = proc_close($process);
+    $result = Arr::make(['exitCode' => $exitCode, 'output' => $output])->toArray();
+
+    if (Flag::isFalse($allowFailure) && $exitCode !== 0) {
+        throw new RuntimeException("Process failed:\n{$output}");
+    }
+
+    return $result;
+}
+
+function assertProcessSucceeded(array $result, string $operation): void
+{
+    if ($result['exitCode'] !== 0) {
+        throw new RuntimeException("Composer {$operation} failed:\n{$result['output']}");
+    }
+}
+
+function assertCleanComposerOutput(array $result, string $operation): void
+{
+    $output = Str::make($result['output']);
+    foreach (Arr::make(['Fatal Error:', 'autoload_real.php', 'another package operation']) as $diagnostic) {
+        if ($output->has($diagnostic)) {
+            throw new RuntimeException("Composer {$operation} emitted {$diagnostic}:\n{$result['output']}");
+        }
+    }
+}
+
+function assertFile(string $path, string $expected): void
+{
+    if (!(new File())->isReachable($path)) {
+        throw new RuntimeException("Expected file is not reachable: {$path}");
+    }
+
+    $actual = File::readContents($path);
+    if (!Str::match($actual, $expected)) {
+        throw new RuntimeException("Unexpected contents for {$path}: {$actual}");
+    }
+}
+
+function fileUrl(string $path): string
+{
+    $normalized = Str::replace(Path::normalize($path), DIRECTORY_SEPARATOR, '/');
+
+    return Str::startsWith($normalized, '/') ? "file://{$normalized}" : "file:///{$normalized}";
+}
+
+function composerCommand(string $binary, array $arguments): array
+{
+    $command = Str::endsWith(Str::lower($binary), '.phar')
+        ? [PHP_BINARY, $binary]
+        : [$binary];
+
+    return Arr::make($command)->merge($arguments)->values()->toArray();
+}
+
+function removeTree(string $path): void
+{
+    if (!is_dir($path)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($iterator as $item) {
+        $item->isDir()
+            ? rmdir($item->getPathname())
+            : (chmod($item->getPathname(), 0666) && unlink($item->getPathname()));
+    }
+    rmdir($path);
+}


### PR DESCRIPTION
## Intent

Make `opus-project` package installation deterministic for Composer source and distribution transports.

## User Stories / Acceptance Criteria

- A project archive installs into `core/` without racing Composer extraction.
- Source and distribution installs expose the same root overrides.
- Updates add newly introduced overrides without replacing existing root customizations.
- Failed override promotion exits nonzero and removes partial install artifacts.
- Uninstall removes `core/` while preserving promoted root overrides.
- `OPUS_STANDALONE=1` continues to install under `vendor/` without root promotion.

## Key Files

- `src/BlueCore/Installers/ProjectInstaller.php`
- `tests/Integration/project-installer-parity.php`
- `.github/workflows/ci.yml`
- `README.md`

## Verification

- `composer ci` - 74 tests, 235 assertions
- `composer test:installer` - source/dist install, update, uninstall, and rollback passed
- `composer audit --locked` - attempted; local Packagist DNS resolution timed out

## QA Checklist

- [x] Composer promises are returned and chained
- [x] Existing root overrides remain untouched
- [x] Copy failures are contextual and transactional
- [x] Source and dist paths are exercised in CI
- [x] No secrets or environment configuration changed

## Approval Conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms Composer lifecycle chaining and non-destructive override behavior.

Closes #51
