### PR TITLE
Halt routes after gateway denial

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ BlueCore's event management system allows you to hook into various events and fi
 
 The plugin-based architecture allows for seamless feature additions and management. You can create plugins to extend the core functionality without modifying the core files directly.
 
+### Gateway Denials
+
+Gateways may stop a mapped controller by producing their response and throwing `GatewayDenied`. `Engine` records the denial and skips route execution without replacing the gateway-owned response. Successful gateways continue through the standard dispatch path.
+
+```php
+use BlueFission\BlueCore\Gateway\GatewayDenied;
+
+http_response_code(403);
+echo 'Forbidden';
+
+throw new GatewayDenied('Forbidden', 403);
+```
+
+Hosts can inspect `Engine::denied()` and `Engine::denial()` after processing when denial metadata is needed.
+
 ### AI Integration
 
 BlueCore is designed to integrate seamlessly with AI libraries such as Automata (`bluefission/automata`), providing native compatibility and simplifying the process of building AI-powered applications.

--- a/src/BlueCore/Engine.php
+++ b/src/BlueCore/Engine.php
@@ -7,6 +7,8 @@ use BlueFission\Services\Response;
 use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Utils\Loader;
 use BlueFission\BlueCore\Security;
+use BlueFission\BlueCore\Gateway\GatewayDenied;
+use BlueFission\Val;
 
 /**
  * Class Engine
@@ -51,6 +53,40 @@ class Engine extends Application {
 	 * @var Session
 	 */
 	private $_session;
+
+	private ?GatewayDenied $_gatewayDenial = null;
+
+	public function process()
+	{
+		$this->_gatewayDenial = null;
+
+		try {
+			parent::process();
+		} catch (GatewayDenied $denial) {
+			$this->_gatewayDenial = $denial;
+		}
+
+		return $this;
+	}
+
+	public function run()
+	{
+		if ($this->denied()) {
+			return $this;
+		}
+
+		return parent::run();
+	}
+
+	public function denied(): bool
+	{
+		return Val::isNotNull($this->_gatewayDenial);
+	}
+
+	public function denial(): ?GatewayDenied
+	{
+		return $this->_gatewayDenial;
+	}
 
 	/**
 	 * Bootstraps the application, loading configurations and auto-discovering helpers and mappings

--- a/src/BlueCore/Gateway/AuthenticationGateway.php
+++ b/src/BlueCore/Gateway/AuthenticationGateway.php
@@ -6,6 +6,7 @@ use BlueFission\Services\Request;
 use BlueFission\Data\Storage\{Session, Storage};
 use BlueFission\BlueCore\Auth as Authenticator;
 use BlueFission\Services\Application as App;
+use BlueFission\Net\HTTP;
 
 /**
  * AuthenticationGateway class for processing authentication request and managing session
@@ -13,6 +14,7 @@ use BlueFission\Services\Application as App;
  * @package BlueFission\BlueCore\Gateway
  */
 class AuthenticationGateway extends Gateway {
+	private ?Authenticator $_authenticator;
 
 	/**
 	 * Redirection URI after authentication fails
@@ -24,7 +26,10 @@ class AuthenticationGateway extends Gateway {
 	/**
 	 * Initialize the Authentication Gateway class
 	 */
-	public function __construct() {}
+	public function __construct(?Authenticator $authenticator = null)
+	{
+		$this->_authenticator = $authenticator;
+	}
 	
 	/**
 	 * Processes the authentication request, sets session if authenticated, otherwise redirects to login page
@@ -34,21 +39,24 @@ class AuthenticationGateway extends Gateway {
 	 */
 	public function process( Request $request, &$arguments )
 	{
-		$auth = App::makeInstance(Authenticator::class);
+		$auth = $this->_authenticator ?? App::makeInstance(Authenticator::class);
 
 		if ( $auth->isAuthenticated() ) {
 			$auth->setSession();
 		} else {
 			$auth->destroySession();
 			$this->redirect();
+
+			throw new GatewayDenied('Authentication required.', 302);
 		}
 	}
 
 	/**
 	 * Redirects to the login page
 	 */
-	public function redirect()
+	public function redirect(): void
 	{
-		header('Location: '.$this->_redirectUri);
+		header(HTTP::headerLine('Location', $this->_redirectUri));
+		http_response_code(302);
 	}
 }

--- a/src/BlueCore/Gateway/GatewayDenied.php
+++ b/src/BlueCore/Gateway/GatewayDenied.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BlueFission\BlueCore\Gateway;
+
+use BlueFission\Num;
+use RuntimeException;
+use Throwable;
+
+class GatewayDenied extends RuntimeException
+{
+    private int $statusCode;
+
+    public function __construct(
+        string $message = 'Gateway denied request dispatch.',
+        int $statusCode = 403,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $statusCode, $previous);
+
+        $this->statusCode = Num::int($statusCode);
+    }
+
+    public function statusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/Helpers/errors.php
+++ b/src/Helpers/errors.php
@@ -1,184 +1,176 @@
 <?php
 
+use BlueFission\Arr;
+use BlueFission\Flag;
+use BlueFission\Net\HTTP;
+use BlueFission\Num;
+use BlueFission\Str;
+use BlueFission\Utils\File;
+
+if (!function_exists('blueCoreDebugMode')) {
+    function blueCoreDebugMode(): bool
+    {
+        return Flag::parseBool(env('DEBUG_MODE'), false);
+    }
+}
+
+if (!function_exists('blueCoreSetErrorStatus')) {
+    function blueCoreSetErrorStatus(): void
+    {
+        if (Str::match(PHP_SAPI, 'cli') || headers_sent()) {
+            return;
+        }
+
+        $status = HTTP::statusLine(500);
+        if (Str::isNotEmpty($status)) {
+            header($status);
+        }
+    }
+}
+
 if (!function_exists('customErrorHandler')) {
-    function customErrorHandler($errno, $errstr, $errfile, $errline) {
-        // Prevent default error handler
+    function customErrorHandler($errno, $errstr, $errfile, $errline): bool
+    {
         if (!(error_reporting() & $errno)) {
             return false;
         }
 
-        // Check if running in CLI mode
-        $isCli = php_sapi_name() === 'cli';
+        error_log("Error: [{$errno}] {$errstr} in {$errfile} on line {$errline}");
 
-        // Determine the background and border color based on the error type
-        switch ($errno) {
-            case E_WARNING:
-            case E_NOTICE:
-                $backgroundColor = '#cce5ff';
-                $borderColor = '#b8daff';
-                break;
-            case E_ERROR:
-            case E_USER_ERROR:
-            case E_RECOVERABLE_ERROR:
-                $backgroundColor = '#fff3cd';
-                $borderColor = '#ffeeba';
-                break;
-            default:
-                $backgroundColor = '#f8d7da';
-                $borderColor = '#f5c6cb';
+        if (!blueCoreDebugMode()) {
+            return true;
         }
 
-        // Customize the error display based on DEBUG_MODE and CLI
-        if (env('DEBUG_MODE') === 'true') {
-            if ($isCli) {
-                // CLI output
-                echo "Error [$errno]: $errstr in $errfile on line $errline\n";
-                sourceCodeWindow($errfile, $errline);
-            } else {
-                // HTML output
-                echo "<div style='background-color: $backgroundColor; color: #721c24; border: 1px solid $borderColor; padding: 20px; font-family: Arial, sans-serif;'>";
-                echo "<h2 style='color: #721c24;'>An error occurred!</h2>";
-                echo "<p><strong>Error Code:</strong> $errno</p>";
-                echo "<p><strong>Message:</strong> $errstr</p>";
-                echo "<p><strong>File:</strong> $errfile</p>";
-                echo "<p><strong>Line:</strong> $errline</p>";
-                sourceCodeWindow($errfile, $errline);
-                echo "<hr>";
-                echo "<p>Please contact support or try again later.</p>";
-                echo "</div>";
-            }
-        } else {
-            if ($isCli) {
-                // CLI output without sensitive information
-                echo "Error [$errno]: An error occurred. Please contact your administrator.\n";
-            } else {
-                // HTML output without sensitive information
-                echo "<div style='background-color: $backgroundColor; color: #721c24; border: 1px solid $borderColor; padding: 20px; font-family: Arial, sans-serif;'>";
-                echo "<h2 style='color: #721c24;'>An error occurred!</h2>";
-                echo "<p>Please contact your administrator.</p>";
-                echo "</div>";
-            }
+        if (Str::match(PHP_SAPI, 'cli')) {
+            echo "Error [{$errno}]: {$errstr} in {$errfile} on line {$errline}\n";
+            sourceCodeWindow($errfile, $errline);
+
+            return true;
         }
 
-        // Log the error to a file
-        error_log("Error: [$errno] $errstr in $errfile on line $errline");
+        echo "<div style='background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; padding: 20px; font-family: Arial, sans-serif;'>";
+        echo '<h2>An error occurred!</h2>';
+        echo '<p><strong>Error Code:</strong> ' . htmlspecialchars((string)$errno) . '</p>';
+        echo '<p><strong>Message:</strong> ' . htmlspecialchars((string)$errstr) . '</p>';
+        echo '<p><strong>File:</strong> ' . htmlspecialchars((string)$errfile) . '</p>';
+        echo '<p><strong>Line:</strong> ' . htmlspecialchars((string)$errline) . '</p>';
+        sourceCodeWindow($errfile, $errline);
+        echo '</div>';
 
-        /* Don't execute PHP internal error handler */
         return true;
     }
 
-    // Set custom error handler
-    set_error_handler("customErrorHandler");
+    set_error_handler('customErrorHandler');
 }
 
 if (!function_exists('customExceptionHandler')) {
-    function customExceptionHandler($exception) {
-        $isCli = php_sapi_name() === 'cli';
-        $backgroundColor = '#fff3cd';
-        $borderColor = '#ffeeba';
+    function customExceptionHandler(Throwable $exception): void
+    {
+        error_log(
+            'Exception: ' . $exception->getMessage()
+            . ' in ' . $exception->getFile()
+            . ' on line ' . $exception->getLine()
+        );
+        blueCoreSetErrorStatus();
 
-        if (env('DEBUG_MODE') === 'true') {
-            if ($isCli) {
-                // CLI output
-                echo "Exception: " . $exception->getMessage() . " in " . $exception->getFile() . " on line " . $exception->getLine() . "\n";
+        if (blueCoreDebugMode()) {
+            if (Str::match(PHP_SAPI, 'cli')) {
+                echo 'Exception: ' . $exception->getMessage()
+                    . ' in ' . $exception->getFile()
+                    . ' on line ' . $exception->getLine() . "\n";
                 sourceCodeWindow($exception->getFile(), $exception->getLine());
             } else {
-                // HTML output
-                echo "<div style='background-color: $backgroundColor; color: #721c24; border: 1px solid $borderColor; padding: 20px; font-family: Arial, sans-serif;'>";
-                echo "<h2 style='color: #721c24;'>An exception occurred!</h2>";
-                echo "<p><strong>Message:</strong> " . $exception->getMessage() . "</p>";
-                echo "<p><strong>File:</strong> " . $exception->getFile() . "</p>";
-                echo "<p><strong>Line:</strong> " . $exception->getLine() . "</p>";
+                echo "<div style='background-color: #fff3cd; color: #721c24; border: 1px solid #ffeeba; padding: 20px; font-family: Arial, sans-serif;'>";
+                echo '<h2>An exception occurred!</h2>';
+                echo '<p><strong>Message:</strong> ' . htmlspecialchars($exception->getMessage()) . '</p>';
+                echo '<p><strong>File:</strong> ' . htmlspecialchars($exception->getFile()) . '</p>';
+                echo '<p><strong>Line:</strong> ' . htmlspecialchars((string)$exception->getLine()) . '</p>';
                 sourceCodeWindow($exception->getFile(), $exception->getLine());
-                echo "<hr>";
-                echo "<p>Please contact support or try again later.</p>";
-                echo "</div>";
-            }
-        } else {
-            if ($isCli) {
-                // CLI output without sensitive information
-                echo "Exception: An error occurred. Please contact your administrator.\n";
-            } else {
-                // HTML output without sensitive information
-                echo "<div style='background-color: $backgroundColor; color: #721c24; border: 1px solid $borderColor; padding: 20px; font-family: Arial, sans-serif;'>";
-                echo "<h2 style='color: #721c24;'>An exception occurred!</h2>";
-                echo "<p>Please contact your administrator.</p>";
-                echo "</div>";
+                echo '</div>';
             }
         }
 
-        // Log the exception to a file
-        error_log("Exception: " . $exception->getMessage() . " in " . $exception->getFile() . " on line " . $exception->getLine());
+        if (Str::match(PHP_SAPI, 'cli')) {
+            exit(1);
+        }
     }
 
-    // Set custom exception handler
-    set_exception_handler("customExceptionHandler");
+    set_exception_handler('customExceptionHandler');
 }
 
 if (!function_exists('shutdownHandler')) {
-    function shutdownHandler() {
+    function shutdownHandler(): void
+    {
         $error = error_get_last();
-        if ($error !== NULL) {
-            $isCli = php_sapi_name() === 'cli';
-            $backgroundColor = '#f8d7da';
-            $borderColor = '#f5c6cb';
+        $fatalTypes = Arr::make([E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR]);
 
-            if (env('DEBUG_MODE') === 'true') {
-                if ($isCli) {
-                    // CLI output
-                    echo "Fatal Error: " . $error['message'] . " in " . $error['file'] . " on line " . $error['line'] . "\n";
-                    sourceCodeWindow($error['file'], $error['line']);
-                } else {
-                    // HTML output
-                    echo "<div style='background-color: $backgroundColor; color: #721c24; border: 1px solid $borderColor; padding: 20px; font-family: Arial, sans-serif;'>";
-                    echo "<h2 style='color: #721c24;'>A fatal error occurred!</h2>";
-                    echo "<p><strong>Error Type:</strong> " . $error['type'] . "</p>";
-                    echo "<p><strong>Message:</strong> " . $error['message'] . "</p>";
-                    echo "<p><strong>File:</strong> " . $error['file'] . "</p>";
-                    echo "<p><strong>Line:</strong> " . $error['line'] . "</p>";
-                    sourceCodeWindow($error['file'], $error['line']);
-                    echo "<hr>";
-                    echo "<p>Please contact support or try again later.</p>";
-                    echo "</div>";
-                }
-            } else {
-                if ($isCli) {
-                    // CLI output without sensitive information
-                    echo "Fatal Error: An error occurred. Please contact your administrator.\n";
-                } else {
-                    // HTML output without sensitive information
-                    echo "<div style='background-color: $backgroundColor; color: #721c24; border: 1px solid $borderColor; padding: 20px; font-family: Arial, sans-serif;'>";
-                    echo "<h2 style='color: #721c24;'>A fatal error occurred!</h2>";
-                    echo "<p>Please contact your administrator.</p>";
-                    echo "</div>";
-                }
-            }
-
-            // Log the fatal error
-            error_log("Fatal Error: [" . $error['type'] . "] " . $error['message'] . " in " . $error['file'] . " on line " . $error['line']);
+        if (!Arr::is($error) || !$fatalTypes->has($error['type'] ?? null, true)) {
+            return;
         }
+
+        error_log(
+            'Fatal Error: [' . $error['type'] . '] ' . $error['message']
+            . ' in ' . $error['file']
+            . ' on line ' . $error['line']
+        );
+        blueCoreSetErrorStatus();
+
+        if (!blueCoreDebugMode()) {
+            return;
+        }
+
+        if (Str::match(PHP_SAPI, 'cli')) {
+            echo 'Fatal Error: ' . $error['message']
+                . ' in ' . $error['file']
+                . ' on line ' . $error['line'] . "\n";
+            sourceCodeWindow($error['file'], $error['line']);
+
+            return;
+        }
+
+        echo "<div style='background-color: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; padding: 20px; font-family: Arial, sans-serif;'>";
+        echo '<h2>A fatal error occurred!</h2>';
+        echo '<p><strong>Message:</strong> ' . htmlspecialchars((string)$error['message']) . '</p>';
+        echo '<p><strong>File:</strong> ' . htmlspecialchars((string)$error['file']) . '</p>';
+        echo '<p><strong>Line:</strong> ' . htmlspecialchars((string)$error['line']) . '</p>';
+        sourceCodeWindow($error['file'], $error['line']);
+        echo '</div>';
     }
 
-    // Register shutdown function for fatal errors
     register_shutdown_function('shutdownHandler');
 }
 
 if (!function_exists('sourceCodeWindow')) {
-    function sourceCodeWindow($file, $line) {
-        $lines = file($file);
-        $start = $line - 5;
-        $end = $line + 5;
-        $start = $start < 0 ? 0 : $start;
-        $end = $end >= count($lines) ? count($lines) - 1 : $end;
+    function sourceCodeWindow($file, $line): void
+    {
+        if (!(new File())->isReachable($file)) {
+            return;
+        }
 
-        echo "<pre>";
-        for ($i = $start; $i <= $end; $i++) {
-            if ($i === $line - 1) {
-                echo "<strong style='color: red;'>{$lines[$i]}</strong>";
+        $contents = Str::replace(File::readContents($file), "\r\n", "\n");
+        $lines = Str::make($contents)->split("\n");
+        $start = Num::max((int)$line - 5, 0);
+        $end = Num::min($lines->count() - 1, (int)$line + 5);
+        $isCli = Str::match(PHP_SAPI, 'cli');
+
+        if (!$isCli) {
+            echo '<pre>';
+        }
+
+        for ($index = $start; $index <= $end; $index++) {
+            $source = (string)$lines[$index];
+            if ($isCli) {
+                echo ($index === (int)$line - 1 ? '> ' : '  ') . $source . "\n";
             } else {
-                echo $lines[$i];
+                $source = htmlspecialchars($source) . "\n";
+                echo $index === (int)$line - 1
+                    ? "<strong style='color: red;'>{$source}</strong>"
+                    : $source;
             }
         }
-        echo "</pre>";
+
+        if (!$isCli) {
+            echo '</pre>';
+        }
     }
 }

--- a/tests/BlueCore/Gateway/GatewayDenialTest.php
+++ b/tests/BlueCore/Gateway/GatewayDenialTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Gateway;
+
+use BlueFission\BlueCore\Auth;
+use BlueFission\BlueCore\Engine;
+use BlueFission\BlueCore\Gateway\AuthenticationGateway;
+use BlueFission\BlueCore\Gateway\GatewayDenied;
+use BlueFission\Flag;
+use BlueFission\Net\HTTP;
+use BlueFission\Services\Gateway;
+use BlueFission\Services\Request;
+use BlueFission\Str;
+use PHPUnit\Framework\TestCase;
+
+class GatewayDenialTest extends TestCase
+{
+    private array $server;
+
+    private array $argv;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->server = $_SERVER;
+        $this->argv = $GLOBALS['argv'] ?? [];
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $GLOBALS['argv'] = [__FILE__];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->server;
+        $GLOBALS['argv'] = $this->argv;
+        http_response_code(200);
+
+        parent::tearDown();
+    }
+
+    public function testDeniedGatewayHaltsMappedController(): void
+    {
+        $controllerInvoked = Flag::make(false);
+        $engine = $this->engine('/protected');
+        $engine->gateway('deny', DenyingGateway::class);
+        $engine
+            ->map('get', 'protected', function () use ($controllerInvoked): string {
+                $controllerInvoked->val(true);
+
+                return 'controller';
+            })
+            ->gateway('deny');
+
+        ob_start();
+        $engine->args()->process()->run();
+        $response = ob_get_clean();
+
+        $this->assertFalse($controllerInvoked->val());
+        $this->assertTrue($engine->denied());
+        $this->assertSame(403, $engine->denial()?->statusCode());
+        $this->assertSame('forbidden', $response);
+    }
+
+    public function testSuccessfulGatewayDispatchRemainsUnchanged(): void
+    {
+        $controllerInvoked = Flag::make(false);
+        $engine = $this->engine('/available');
+        $engine->gateway('pass', PassingGateway::class);
+        $engine
+            ->map('get', 'available', function () use ($controllerInvoked): string {
+                $controllerInvoked->val(true);
+
+                return 'available';
+            })
+            ->gateway('pass');
+
+        ob_start();
+        $engine->args()->process()->run();
+        $response = ob_get_clean();
+
+        $this->assertTrue($controllerInvoked->val());
+        $this->assertFalse($engine->denied());
+        $this->assertSame('available', $response);
+    }
+
+    public function testAnonymousAuthenticationEmitsOnlyTheLoginRedirect(): void
+    {
+        $auth = $this->getMockBuilder(Auth::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isAuthenticated', 'destroySession'])
+            ->getMock();
+        $auth->expects($this->once())->method('isAuthenticated')->willReturn(false);
+        $auth->expects($this->once())->method('destroySession');
+
+        $gateway = new class($auth) extends AuthenticationGateway {
+            public string $header = '';
+
+            public function redirect(): void
+            {
+                $this->header = HTTP::headerLine('Location', $this->_redirectUri);
+                http_response_code(302);
+            }
+        };
+        $arguments = [];
+        $denial = null;
+
+        ob_start();
+        try {
+            $gateway->process(new Request(), $arguments);
+            $this->fail('Anonymous authentication did not deny dispatch.');
+        } catch (GatewayDenied $exception) {
+            $denial = $exception;
+        } finally {
+            $response = ob_get_clean();
+        }
+
+        $this->assertInstanceOf(GatewayDenied::class, $denial);
+        $this->assertSame(302, $denial->statusCode());
+        $this->assertSame('Location: /login', $gateway->header);
+        $this->assertSame('', $response);
+    }
+
+    private function engine(string $uri): Engine
+    {
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        return new Engine(['name' => 'gateway-test-' . Str::rand('', 12)]);
+    }
+}
+
+class DenyingGateway extends Gateway
+{
+    public function process(Request $request, &$arguments): void
+    {
+        http_response_code(403);
+        echo 'forbidden';
+
+        throw new GatewayDenied('Forbidden', 403);
+    }
+}
+
+class PassingGateway extends Gateway
+{
+    public function process(Request $request, &$arguments): void
+    {
+    }
+}

--- a/tests/Fixtures/runtime-unhandled-exception.php
+++ b/tests/Fixtures/runtime-unhandled-exception.php
@@ -1,0 +1,5 @@
+<?php
+
+require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+throw new RuntimeException('private exception');

--- a/tests/Helpers/ProductionErrorHandlerTest.php
+++ b/tests/Helpers/ProductionErrorHandlerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BlueFission\Tests\Helpers;
+
+use BlueFission\Str;
+use BlueFission\System\Process;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+use PHPUnit\Framework\TestCase;
+
+class ProductionErrorHandlerTest extends TestCase
+{
+    public function testProductionWarningIsLoggedWithoutResponseOutput(): void
+    {
+        $debugMode = getenv('DEBUG_MODE');
+        $errorLog = ini_get('error_log');
+        $testLog = Path::normalize(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-warning-' . Str::rand('', 10) . '.log');
+        putenv('DEBUG_MODE=false');
+        ini_set('error_log', $testLog);
+
+        try {
+            ob_start();
+            customErrorHandler(E_WARNING, 'private warning', __FILE__, __LINE__);
+            $response = ob_get_clean();
+
+            $this->assertSame('', $response);
+            $this->assertStringContainsString('private warning', File::readContents($testLog));
+        } finally {
+            ini_set('error_log', (string)$errorLog);
+            $debugMode === false ? putenv('DEBUG_MODE') : putenv("DEBUG_MODE={$debugMode}");
+            if ((new File())->exists($testLog)) {
+                unlink($testLog);
+            }
+        }
+    }
+
+    public function testUnhandledCliExceptionExitsNonzeroWithoutResponseOutput(): void
+    {
+        $root = Path::normalize(dirname(__DIR__, 2));
+        $fixture = Path::normalize($root . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'runtime-unhandled-exception.php');
+        $errorLog = Path::normalize(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-error-' . Str::rand('', 10) . '.log');
+        $command = Str::make(escapeshellarg(PHP_BINARY))
+            ->append(' ')
+            ->append(escapeshellarg($fixture))
+            ->val();
+        $process = new Process($command, $root, ['DEBUG_MODE' => 'false'], [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['file', $errorLog, 'a'],
+        ]);
+
+        $process->start();
+        while ($process->status() === true) {
+            usleep(10000);
+        }
+        $response = $process->output();
+        $exitCode = $process->close();
+
+        $this->assertNotSame(0, $exitCode);
+        $this->assertSame('', $response);
+        $this->assertStringContainsString('private exception', File::readContents($errorLog));
+
+        unlink($errorLog);
+    }
+}


### PR DESCRIPTION
## Intent

Stop route dispatch after a gateway denies a request and keep production diagnostics out of host-owned responses.

## User Stories / Acceptance Criteria

- A gateway can produce a response and halt dispatch before the mapped controller runs.
- Anonymous authentication preserves a single login redirect.
- Authorized gateway responses such as a host-owned 403 remain untouched.
- Successful gateways continue through normal route execution.
- Production warning and exception handlers log without writing inline response markup.
- Unhandled CLI exceptions return a nonzero exit status.

## Key Files

- `src/BlueCore/Gateway/GatewayDenied.php`
- `src/BlueCore/Engine.php`
- `src/BlueCore/Gateway/AuthenticationGateway.php`
- `src/Helpers/errors.php`
- `tests/BlueCore/Gateway/GatewayDenialTest.php`
- `tests/Helpers/ProductionErrorHandlerTest.php`

## Verification

- `composer validate --no-check-publish --strict`
- `composer lint`
- `vendor/bin/phpunit --do-not-cache-result tests` - 79 tests, 252 assertions

## QA Checklist

- [x] Denied controller is not invoked
- [x] Successful gateway behavior is unchanged
- [x] Authentication redirect uses DevElation HTTP headers
- [x] Production diagnostics are log-only
- [x] CLI exception status is nonzero
- [x] DevElation received the generalized upstream gateway-contract request

## Approval Conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms the denial sentinel does not replace host-owned response bodies or headers.
- Review confirms non-debug handlers do not expose diagnostic text.

Closes #46
