### PR TITLE
Resolve add-on primary files across runtime roots

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -226,30 +226,34 @@ class AddOnManager extends Service
     public function loadActivatedAddOns()
     {
         $addOns = $this->_model->getActivatedAddOns();
-        
+        $results = Arr::make([]);
+
         foreach ($addOns as $addOn) {
             $object = new AddOn;
             $object->assign($addOn);
-            // $object->path = resolve_path('addons' . DIRECTORY_SEPARATOR . $addOn);
-            // $object->primary_file = 'main.php';
-            $addOn = $object;
-            $this->loadAddOn($addOn);
+            $results->push($this->loadAddOn($object));
         }
+
+        return $results->toArray();
     }
 
-    protected function loadAddOn(AddOn $addOn)
+    protected function loadAddOn(AddOn $addOn): array
     {
-        $primaryFile = $addOn->path . DIRECTORY_SEPARATOR . $addOn->primary_file;
-        // $primaryFile = resolve_path('addons' . DIRECTORY_SEPARATOR . $addon . DIRECTORY_SEPARATOR . 'main.php');
-        if ($primaryFile != DIRECTORY_SEPARATOR && (new File())->exists($primaryFile)) {
-            require_once($primaryFile);
+        $resolution = $this->resolvePrimaryFile($addOn);
+        if (Flag::isFalse($resolution['ok'])) {
+            return $resolution;
         }
+
+        $resolution['value'] = require_once($resolution['path']);
+        $resolution['status'] = 'loaded';
+
+        return $resolution;
     }
 
     protected function callHook(AddOn $addOn, $hook)
     {
         $hook = Str::trim((string)$hook);
-        $primaryFile = $addOn->path . DIRECTORY_SEPARATOR . $addOn->primary_file;
+        $resolution = $this->resolvePrimaryFile($addOn);
         $result = Arr::make([
             'ok' => false,
             'hook' => $hook,
@@ -257,17 +261,19 @@ class AddOnManager extends Service
             'strategy' => null,
             'callable' => null,
             'attempted' => [],
+            'primaryFile' => $resolution['path'],
+            'primaryFileResolution' => $resolution,
             'error' => null,
         ]);
 
-        if (!(new File())->isReachable($primaryFile)) {
-            $result->set('status', 'missing_primary_file');
-            $result->set('error', 'Add-on primary file is not reachable.');
+        if (Flag::isFalse($resolution['ok'])) {
+            $result->set('status', $resolution['status']);
+            $result->set('error', $resolution['error']);
 
             return $result->toArray();
         }
 
-        require_once($primaryFile);
+        require_once($resolution['path']);
 
         $legacyHook = "{$addOn->name}_{$hook}";
         $namespace = Str::trim((string)$addOn->namespace, '\\');
@@ -296,6 +302,97 @@ class AddOnManager extends Service
         $result->set('error', 'No compatible lifecycle hook callable was found.');
 
         return $result->toArray();
+    }
+
+    protected function resolvePrimaryFile(AddOn $addOn): array
+    {
+        $result = Arr::make([
+            'ok' => false,
+            'status' => 'pending',
+            'strategy' => null,
+            'path' => null,
+            'configured' => null,
+            'fallback' => null,
+            'attempted' => [],
+            'error' => null,
+        ]);
+
+        try {
+            $name = $this->normalizeAddOnIdentifier($addOn->name, 'name');
+            $primaryFile = Val::isEmpty($addOn->primary_file)
+                ? 'main.php'
+                : $this->normalizeDefinitionPath($addOn->primary_file, 'primary_file');
+        } catch (\InvalidArgumentException $exception) {
+            $result->set('status', 'unsafe_primary_file');
+            $result->set('error', $exception->getMessage());
+
+            return $result->toArray();
+        }
+
+        $addOnRoot = Path::normalize(resolve_path('addons' . DIRECTORY_SEPARATOR . $name));
+        $configuredRoot = Path::normalize((string)$addOn->path);
+        $configured = Val::isEmpty($configuredRoot)
+            ? null
+            : Path::normalize($configuredRoot . DIRECTORY_SEPARATOR . $primaryFile);
+        $fallback = Path::normalize($addOnRoot . DIRECTORY_SEPARATOR . $primaryFile);
+        $candidates = Arr::make([]);
+        if (Val::isNotEmpty($configured)) {
+            $candidates->push(['strategy' => 'configured', 'path' => $configured]);
+        }
+        if (Val::isEmpty($configured) || !Str::match($configured, $fallback)) {
+            $candidates->push(['strategy' => 'fallback', 'path' => $fallback]);
+        }
+
+        $result->set('configured', $configured);
+        $result->set('fallback', $fallback);
+        $result->set('attempted', $candidates->map(fn ($candidate) => $candidate['path'])->toArray());
+
+        foreach ($candidates as $candidate) {
+            if (!(new File())->isReachable($candidate['path'])) {
+                continue;
+            }
+
+            if (!$this->primaryFileIsContained($candidate['path'], $addOnRoot)) {
+                $result->set('status', 'unsafe_primary_file');
+                $result->set('error', 'Add-on primary file escapes its configured add-on root.');
+
+                return $result->toArray();
+            }
+
+            $result->set('ok', true);
+            $result->set('status', 'resolved');
+            $result->set('strategy', $candidate['strategy']);
+            $result->set('path', Path::normalize(realpath($candidate['path'])));
+
+            return $result->toArray();
+        }
+
+        $result->set('status', 'missing_primary_file');
+        $result->set('error', 'Add-on primary file is not reachable from configured or canonical paths.');
+
+        return $result->toArray();
+    }
+
+    private function primaryFileIsContained(string $primaryFile, string $addOnRoot): bool
+    {
+        $resolvedFile = realpath($primaryFile);
+        $resolvedRoot = realpath($addOnRoot);
+        if (Val::isEmpty($resolvedFile) || Val::isEmpty($resolvedRoot)) {
+            return false;
+        }
+
+        $resolvedFile = Path::normalize($resolvedFile);
+        $resolvedRoot = Path::normalize($resolvedRoot);
+        if (Str::match(DIRECTORY_SEPARATOR, '\\')) {
+            $resolvedFile = Str::lower($resolvedFile);
+            $resolvedRoot = Str::lower($resolvedRoot);
+        }
+
+        $rootPrefix = Str::endsWith($resolvedRoot, DIRECTORY_SEPARATOR)
+            ? $resolvedRoot
+            : $resolvedRoot . DIRECTORY_SEPARATOR;
+
+        return Str::startsWith($resolvedFile, $rootPrefix);
     }
 
     public function uploadAddonFile($file, $destination)

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -162,7 +162,7 @@ class AddOnManagerTest extends TestCase
     public function testNamespacedHookResolutionAndLegacyFallbackReturnDiagnostics(): void
     {
         $manager = new TestableAddOnManager(new FakeAddOnModel());
-        $namespacedPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'namespaced';
+        $namespacedPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'demo';
         File::ensureFile(
             $namespacedPath . DIRECTORY_SEPARATOR . 'main.php',
             "<?php\nnamespace BlueFission\\Tests\\Fixtures\\AddOnHooks;\nfunction demo_install() { \$GLOBALS['bluecore_hook_calls'][] = 'namespaced'; }",
@@ -185,7 +185,7 @@ class AddOnManagerTest extends TestCase
             $namespacedResult['callable']
         );
 
-        $legacyPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'legacy';
+        $legacyPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'legacydemo';
         File::ensureFile(
             $legacyPath . DIRECTORY_SEPARATOR . 'main.php',
             "<?php\nfunction legacydemo_install() { \$GLOBALS['bluecore_hook_calls'][] = 'legacy'; }",
@@ -210,7 +210,7 @@ class AddOnManagerTest extends TestCase
     public function testMissingHookReturnsStructuredDiagnostics(): void
     {
         $manager = new TestableAddOnManager(new FakeAddOnModel());
-        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'missing-hook';
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'missing';
         File::ensureFile($path . DIRECTORY_SEPARATOR . 'main.php', '<?php', true);
         $addOn = new AddOn();
         $addOn->assign([
@@ -229,6 +229,154 @@ class AddOnManagerTest extends TestCase
             $result['attempted']
         );
         $this->assertNotEmpty($result['error']);
+    }
+
+    public function testPrimaryFilePrefersReachableConfiguredCandidate(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $addOnRoot = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'configured';
+        $configuredRoot = $addOnRoot . DIRECTORY_SEPARATOR . 'current';
+        File::ensureFile($configuredRoot . DIRECTORY_SEPARATOR . 'main.php', '<?php', true);
+        File::ensureFile($addOnRoot . DIRECTORY_SEPARATOR . 'main.php', '<?php', true);
+        $addOn = new AddOn();
+        $addOn->assign([
+            'name' => 'configured',
+            'path' => $configuredRoot,
+            'primary_file' => 'main.php',
+        ]);
+
+        $resolution = $manager->primaryFile($addOn);
+
+        $this->assertTrue($resolution['ok']);
+        $this->assertSame('configured', $resolution['strategy']);
+        $this->assertSame(Path::normalize($configuredRoot . DIRECTORY_SEPARATOR . 'main.php'), $resolution['path']);
+    }
+
+    public function testPrimaryFileFallsBackFromStalePersistedRoot(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $fallback = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'portable' . DIRECTORY_SEPARATOR . 'main.php';
+        File::ensureFile($fallback, '<?php', true);
+        $addOn = new AddOn();
+        $addOn->assign([
+            'name' => 'portable',
+            'path' => self::$root . DIRECTORY_SEPARATOR . 'retired-root' . DIRECTORY_SEPARATOR . 'portable',
+            'primary_file' => 'main.php',
+        ]);
+
+        $resolution = $manager->primaryFile($addOn);
+
+        $this->assertTrue($resolution['ok']);
+        $this->assertSame('fallback', $resolution['strategy']);
+        $this->assertSame(Path::normalize($fallback), $resolution['path']);
+        $this->assertCount(2, $resolution['attempted']);
+    }
+
+    public function testPrimaryFileUsesCanonicalDefaultForLegacyRecord(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $fallback = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'legacyrecord' . DIRECTORY_SEPARATOR . 'main.php';
+        File::ensureFile($fallback, '<?php', true);
+        $addOn = new AddOn();
+        $addOn->assign([
+            'name' => 'legacyrecord',
+            'path' => '',
+            'primary_file' => '',
+        ]);
+
+        $resolution = $manager->primaryFile($addOn);
+
+        $this->assertTrue($resolution['ok']);
+        $this->assertSame('fallback', $resolution['strategy']);
+        $this->assertNull($resolution['configured']);
+        $this->assertSame(Path::normalize($fallback), $resolution['path']);
+    }
+
+    public function testPrimaryFileRejectsReachablePathOutsideAddOnRoot(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $outside = self::$root . DIRECTORY_SEPARATOR . 'outside' . DIRECTORY_SEPARATOR . 'main.php';
+        File::ensureFile($outside, '<?php', true);
+        File::ensureFile(
+            self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'contained' . DIRECTORY_SEPARATOR . 'main.php',
+            '<?php',
+            true
+        );
+        $addOn = new AddOn();
+        $addOn->assign([
+            'name' => 'contained',
+            'path' => dirname($outside),
+            'primary_file' => 'main.php',
+        ]);
+
+        $resolution = $manager->primaryFile($addOn);
+
+        $this->assertFalse($resolution['ok']);
+        $this->assertSame('unsafe_primary_file', $resolution['status']);
+        $this->assertNull($resolution['path']);
+        $this->assertNotEmpty($resolution['error']);
+    }
+
+    public function testPrimaryFileRejectsTraversalAndReportsMissingCandidates(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        Path::ensureDir(self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'unsafe');
+        $unsafe = new AddOn();
+        $unsafe->assign([
+            'name' => 'unsafe',
+            'path' => self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'unsafe',
+            'primary_file' => '../main.php',
+        ]);
+
+        $unsafeResolution = $manager->primaryFile($unsafe);
+
+        $this->assertFalse($unsafeResolution['ok']);
+        $this->assertSame('unsafe_primary_file', $unsafeResolution['status']);
+
+        $missing = new AddOn();
+        $missing->assign([
+            'name' => 'missing-primary',
+            'path' => self::$root . DIRECTORY_SEPARATOR . 'retired-root' . DIRECTORY_SEPARATOR . 'missing-primary',
+            'primary_file' => 'main.php',
+        ]);
+        Path::ensureDir(self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'missing-primary');
+
+        $missingResolution = $manager->primaryFile($missing);
+
+        $this->assertFalse($missingResolution['ok']);
+        $this->assertSame('missing_primary_file', $missingResolution['status']);
+        $this->assertCount(2, $missingResolution['attempted']);
+        $this->assertSame([
+            $missingResolution['configured'],
+            $missingResolution['fallback'],
+        ], $missingResolution['attempted']);
+    }
+
+    public function testHookAndLoaderSharePortablePrimaryFileResolution(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        $fallback = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'sharedresolver' . DIRECTORY_SEPARATOR . 'main.php';
+        File::ensureFile(
+            $fallback,
+            "<?php\n\$GLOBALS['bluecore_primary_loads'][] = 'loaded';\nfunction sharedresolver_install() { \$GLOBALS['bluecore_hook_calls'][] = 'portable'; }",
+            true
+        );
+        $addOn = new AddOn();
+        $addOn->assign([
+            'name' => 'sharedresolver',
+            'path' => self::$root . DIRECTORY_SEPARATOR . 'retired-root' . DIRECTORY_SEPARATOR . 'sharedresolver',
+            'primary_file' => 'main.php',
+        ]);
+
+        $load = $manager->load($addOn);
+        $hook = $manager->hook($addOn, 'install');
+
+        $this->assertTrue($load['ok']);
+        $this->assertSame('fallback', $load['strategy']);
+        $this->assertTrue($hook['ok']);
+        $this->assertSame(Path::normalize($fallback), $hook['primaryFile']);
+        $this->assertSame(['loaded'], $GLOBALS['bluecore_primary_loads']);
+        $this->assertContains('portable', $GLOBALS['bluecore_hook_calls']);
     }
 
     public function testActivateAndActivateAllReturnStructuredStatuses(): void
@@ -407,6 +555,16 @@ class TestableAddOnManager extends AddOnManager
     public function hook(AddOn $addOn, string $hook): array
     {
         return $this->callHook($addOn, $hook);
+    }
+
+    public function primaryFile(AddOn $addOn): array
+    {
+        return $this->resolvePrimaryFile($addOn);
+    }
+
+    public function load(AddOn $addOn): array
+    {
+        return $this->loadAddOn($addOn);
     }
 
     protected function datasourceManager(): mixed


### PR DESCRIPTION
## Intent

Resolve persisted add-on primary files portably across runtime roots while enforcing add-on directory containment.

## User Stories / Acceptance Criteria

- Prefer a reachable configured primary-file candidate.
- Fall back to `addons/<name>/<primary_file>` when the persisted root is stale.
- Preserve the legacy `main.php` default for incomplete records.
- Reject traversal and reachable paths outside the canonical add-on directory.
- Return configured, fallback, attempted, strategy, path, status, and error diagnostics.
- Use one resolver for active loading and lifecycle hooks.

## Key Files

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## Verification

- `composer validate --no-check-publish --strict`
- `php -l src/BlueCore/Business/Managers/AddOnManager.php`
- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php` - 23 tests, 91 assertions
- `vendor/bin/phpunit --do-not-cache-result tests` - 80 tests, 262 assertions

## QA Checklist

- [x] Configured path preference covered
- [x] Stale-root canonical fallback covered
- [x] Legacy defaults covered
- [x] Traversal and outside-root paths rejected
- [x] Missing candidates return structured diagnostics
- [x] Loader and hook resolution share the same implementation

## Approval Conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms `realpath` containment prevents cross-add-on and symlink escapes.
- Review confirms no application-specific root is encoded.

Closes #52
