### PR TITLE
Execute active add-on registration factories once

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -22,8 +22,22 @@ Add-on lifecycle managers implement `IAddOnLifecycleManager`:
 - `uninstall($addOnId, bool $removeDependencies = false): array`
 - `activate($addOnId): array`
 - `deactivate($addOnId): array`
+- `loadActivatedAddOns(?Application $application = null, ?RegistrationPlan $plan = null): array`
 
 Lifecycle methods return structured arrays so callers can compose results, log decisions, and avoid process termination.
+
+An active add-on primary file may return a callable registration factory. When
+the application and baseline registration plan are supplied together, BlueCore
+invokes that factory with `(Application $application, RegistrationPlan $plan)`
+once per manager lifecycle. A factory may accept fewer arguments when it does
+not need the full context. Repeated loading reports `already_registered`
+without executing the factory again. Calls without a registration context keep
+the callable available and report `pending`, while legacy primary files that do
+not return a callable report `not_applicable`.
+
+Factory failures report the registration stage, primary file, original
+exception class, and message. A failed factory is not marked as registered, so
+a later lifecycle call can retry it.
 
 ## Theme Registry
 

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -9,6 +9,9 @@ use BlueFission\Data\Storage\Storage;
 use BlueFission\Func;
 use BlueFission\Net\HTTP;
 use BlueFission\Flag;
+use BlueFission\BlueCore\Registration\RegistrationPlan;
+use BlueFission\BlueCore\Contracts\IAddOnLifecycleManager;
+use BlueFission\Services\Application;
 use BlueFission\Services\Service;
 use BlueFission\Utils\Loader;
 use BlueFission\Utils\File;
@@ -19,10 +22,12 @@ use BlueFission\Str;
 use BlueFission\System\System;
 use BlueFission\Val;
 
-class AddOnManager extends Service
+class AddOnManager extends Service implements IAddOnLifecycleManager
 {
     private $_loader;
     protected $_model;
+    private array $_loadedAddOns = [];
+    private array $_registeredAddOns = [];
 
     public function __construct(MySQLLink $link)
     {
@@ -223,15 +228,63 @@ class AddOnManager extends Service
         return $list;
     }
 
-    public function loadActivatedAddOns()
+    public function loadActivatedAddOns(
+        ?Application $application = null,
+        ?RegistrationPlan $plan = null
+    ): array
     {
+        if (($application === null) !== ($plan === null)) {
+            throw new \InvalidArgumentException(
+                'Application and registration plan must be provided together.'
+            );
+        }
+
         $addOns = $this->_model->getActivatedAddOns();
         $results = Arr::make([]);
 
         foreach ($addOns as $addOn) {
             $object = new AddOn;
             $object->assign($addOn);
-            $results->push($this->loadAddOn($object));
+            $load = $this->loadAddOn($object);
+
+            if (Flag::isFalse($load['ok']) || !Func::isCallable($load['value'] ?? null)) {
+                $load['registration'] = $this->registrationResult(
+                    Flag::isFalse($load['ok']) ? 'load_failed' : 'not_applicable'
+                );
+                $results->push($load);
+                continue;
+            }
+
+            if ($application === null || $plan === null) {
+                $load['registration'] = $this->registrationResult('pending');
+                $results->push($load);
+                continue;
+            }
+
+            $key = $this->addOnRuntimeKey($object, $load['path']);
+            if (Arr::hasKey($this->_registeredAddOns, $key)) {
+                $load['registration'] = $this->registrationResult('already_registered');
+                $results->push($load);
+                continue;
+            }
+
+            try {
+                Func::make($load['value'])->call($application, $plan);
+                $this->_registeredAddOns[$key] = true;
+                $load['registration'] = $this->registrationResult('registered', true);
+            } catch (\Throwable $exception) {
+                $load['ok'] = false;
+                $load['stage'] = 'registration';
+                $load['error'] = $exception->getMessage();
+                $load['exception'] = $exception::class;
+                $load['registration'] = $this->registrationResult(
+                    'failed',
+                    false,
+                    $exception
+                );
+            }
+
+            $results->push($load);
         }
 
         return $results->toArray();
@@ -244,10 +297,45 @@ class AddOnManager extends Service
             return $resolution;
         }
 
+        $key = $this->addOnRuntimeKey($addOn, $resolution['path']);
+        if (Arr::hasKey($this->_loadedAddOns, $key)) {
+            $loaded = $this->_loadedAddOns[$key];
+            $loaded['status'] = 'already_loaded';
+            $loaded['changed'] = false;
+
+            return $loaded;
+        }
+
         $resolution['value'] = require_once($resolution['path']);
         $resolution['status'] = 'loaded';
+        $resolution['stage'] = 'load';
+        $resolution['changed'] = true;
+        $this->_loadedAddOns[$key] = $resolution;
 
         return $resolution;
+    }
+
+    private function addOnRuntimeKey(AddOn $addOn, string $primaryFile): string
+    {
+        $identifier = Val::isNotEmpty($addOn->addon_id)
+            ? (string)$addOn->addon_id
+            : (string)$addOn->name;
+
+        return Str::lower(Str::trim($identifier)) . ':' . Path::normalize($primaryFile);
+    }
+
+    private function registrationResult(
+        string $status,
+        bool $executed = false,
+        ?\Throwable $exception = null
+    ): array {
+        return Arr::make([
+            'ok' => $exception === null && $status !== 'load_failed',
+            'status' => $status,
+            'executed' => $executed,
+            'error' => $exception?->getMessage(),
+            'exception' => $exception === null ? null : $exception::class,
+        ])->toArray();
     }
 
     protected function callHook(AddOn $addOn, $hook)

--- a/src/BlueCore/Contracts/IAddOnLifecycleManager.php
+++ b/src/BlueCore/Contracts/IAddOnLifecycleManager.php
@@ -2,10 +2,17 @@
 
 namespace BlueFission\BlueCore\Contracts;
 
+use BlueFission\BlueCore\Registration\RegistrationPlan;
+use BlueFission\Services\Application;
+
 interface IAddOnLifecycleManager
 {
     public function install($name, bool $installDependencies = false): array;
     public function uninstall($addOnId, bool $removeDependencies = false): array;
     public function activate($addOnId): array;
     public function deactivate($addOnId): array;
+    public function loadActivatedAddOns(
+        ?Application $application = null,
+        ?RegistrationPlan $plan = null
+    ): array;
 }

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -4,6 +4,8 @@ namespace BlueFission\Tests\BlueCore\Business\Managers;
 
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
 use BlueFission\BlueCore\Domain\AddOn\AddOn;
+use BlueFission\BlueCore\Registration\RegistrationPlan;
+use BlueFission\Services\Application;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -32,6 +34,11 @@ class AddOnManagerTest extends TestCase
 
     protected function setUp(): void
     {
+        unset(
+            $GLOBALS['bluecore_registration_factory_calls'],
+            $GLOBALS['bluecore_inactive_primary_loads']
+        );
+
         if (self::$ownsRoot) {
             $this->removeDir(self::$root);
         }
@@ -379,6 +386,119 @@ class AddOnManagerTest extends TestCase
         $this->assertContains('portable', $GLOBALS['bluecore_hook_calls']);
     }
 
+    public function testActiveRegistrationFactoryExecutesOnceAfterBaselinePlanIsAvailable(): void
+    {
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'factory';
+        File::ensureFile(
+            $path . DIRECTORY_SEPARATOR . 'main.php',
+            <<<'PHP'
+<?php
+
+return static function (\BlueFission\Services\Application $application, \BlueFission\BlueCore\Registration\RegistrationPlan $plan): void {
+    $GLOBALS['bluecore_registration_factory_calls'] =
+        ($GLOBALS['bluecore_registration_factory_calls'] ?? 0) + 1;
+    $plan->service('factory.service', $application->name());
+};
+PHP,
+            true
+        );
+        $model = new FakeAddOnModel([
+            [
+                'addon_id' => 21,
+                'name' => 'factory',
+                'path' => $path,
+                'primary_file' => 'main.php',
+                'is_active' => 1,
+            ],
+        ]);
+        $manager = new TestableAddOnManager($model);
+        $application = new Application(['name' => 'registration-factory-test']);
+        $plan = (new RegistrationPlan())->service('baseline', 'ready');
+
+        $first = $manager->loadActivatedAddOns($application, $plan);
+        $second = $manager->loadActivatedAddOns($application, $plan);
+
+        $this->assertTrue($first[0]['ok']);
+        $this->assertSame('registered', $first[0]['registration']['status']);
+        $this->assertTrue($first[0]['registration']['executed']);
+        $this->assertSame('already_registered', $second[0]['registration']['status']);
+        $this->assertFalse($second[0]['registration']['executed']);
+        $this->assertSame(1, $GLOBALS['bluecore_registration_factory_calls']);
+        $this->assertSame('ready', $plan->entries('services')['baseline']);
+        $this->assertSame('registration-factory-test', $plan->entries('services')['factory.service']);
+    }
+
+    public function testInactiveAndLegacyAddOnsDoNotExecuteRegistrationFactories(): void
+    {
+        $activePath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'legacyload';
+        $inactivePath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'inactive';
+        File::ensureFile($activePath . DIRECTORY_SEPARATOR . 'main.php', '<?php return null;', true);
+        File::ensureFile(
+            $inactivePath . DIRECTORY_SEPARATOR . 'main.php',
+            "<?php \$GLOBALS['bluecore_inactive_primary_loads'] = true; return static function (): void {};",
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel([
+            [
+                'addon_id' => 22,
+                'name' => 'legacyload',
+                'path' => $activePath,
+                'primary_file' => 'main.php',
+                'is_active' => 1,
+            ],
+            [
+                'addon_id' => 23,
+                'name' => 'inactive',
+                'path' => $inactivePath,
+                'primary_file' => 'main.php',
+                'is_active' => 0,
+            ],
+        ]));
+
+        $results = $manager->loadActivatedAddOns(
+            new Application(['name' => 'legacy-registration-test']),
+            new RegistrationPlan()
+        );
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results[0]['ok']);
+        $this->assertSame('not_applicable', $results[0]['registration']['status']);
+        $this->assertArrayNotHasKey('bluecore_inactive_primary_loads', $GLOBALS);
+    }
+
+    public function testRegistrationFactoryFailureKeepsOriginalDiagnosticsAndCanRetry(): void
+    {
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'failingfactory';
+        File::ensureFile(
+            $path . DIRECTORY_SEPARATOR . 'main.php',
+            '<?php return static function (): void { throw new \\DomainException("factory failed"); };',
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel([
+            [
+                'addon_id' => 24,
+                'name' => 'failingfactory',
+                'path' => $path,
+                'primary_file' => 'main.php',
+                'is_active' => 1,
+            ],
+        ]));
+        $application = new Application(['name' => 'failing-registration-test']);
+        $plan = new RegistrationPlan();
+
+        $first = $manager->loadActivatedAddOns($application, $plan);
+        $second = $manager->loadActivatedAddOns($application, $plan);
+
+        foreach ([$first[0], $second[0]] as $result) {
+            $this->assertFalse($result['ok']);
+            $this->assertSame('registration', $result['stage']);
+            $this->assertSame('failed', $result['registration']['status']);
+            $this->assertSame('factory failed', $result['error']);
+            $this->assertSame(\DomainException::class, $result['exception']);
+            $this->assertSame(Path::normalize($path . DIRECTORY_SEPARATOR . 'main.php'), $result['path']);
+        }
+    }
+
     public function testActivateAndActivateAllReturnStructuredStatuses(): void
     {
         $model = new FakeAddOnModel([
@@ -666,6 +786,14 @@ class FakeAddOnModel
         }
 
         return array_map(static fn($record) => (object)$record, $this->records);
+    }
+
+    public function getActivatedAddOns(): array
+    {
+        return array_values(array_filter(
+            $this->records,
+            static fn ($record) => (int)($record['is_active'] ?? 0) === 1
+        ));
     }
 
     public function delete($values): void


### PR DESCRIPTION
## Intent

Execute callable registration factories returned by active add-on primary files through BlueCore's application registration boundary.

## User Stories / Acceptance Criteria

- Active add-on primary files may return callable registration factories.
- Factories receive the application and baseline registration plan.
- Each factory executes once per add-on and manager lifecycle.
- Repeated loading remains idempotent and retains the cached callable.
- Inactive add-ons do not load or execute.
- Legacy primary files without callable returns remain supported.
- Registration failures identify the add-on primary file, stage, exception class, and message and remain retryable.

## Key Files Changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `src/BlueCore/Contracts/IAddOnLifecycleManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `docs/extension-registration-contracts.md`

## How To Test

- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `composer ci`

## QA Checklist

- [x] Callable return values survive repeated `require_once` entry
- [x] Factory execution is exactly once after baseline registration exists
- [x] Inactive and legacy add-ons preserve existing behavior
- [x] Failures remain structured and retryable
- [x] Public lifecycle contract and documentation are updated
- [x] Full suite passes

## Approval Conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms the application/plan factory signature is sufficiently general.
- Review confirms failed factories are not marked registered.

Closes #53
