### PR TITLE
Preserve installed add-on records in bulk lifecycle operations

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -19,11 +19,21 @@ Registrars implement `BlueFission\BlueCore\Contracts\IApplicationRegistrar` and 
 Add-on lifecycle managers implement `IAddOnLifecycleManager`:
 
 - `install($name, bool $installDependencies = false): array`
+- `installAll(bool $installDependencies = false): array`
 - `uninstall($addOnId, bool $removeDependencies = false): array`
 - `activate($addOnId): array`
+- `activateAll(): array`
 - `deactivate($addOnId): array`
+- `deactivateAll(): array`
 
 Lifecycle methods return structured arrays so callers can compose results, log decisions, and avoid process termination.
+
+Bulk lifecycle operations normalize DevElation `Collection` and `Group`
+containers through the collection API before processing their rows. Each result
+retains the exact persisted row used for the operation, including identifiers,
+namespace separators, paths, primary files, and activation state. A malformed
+row or failed storage write makes the aggregate result fail while preserving
+the per-row diagnostic and leaving other rows visible to the caller.
 
 ## Theme Registry
 

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -4,6 +4,8 @@ namespace BlueFission\BlueCore\Business\Managers;
 
 use BlueFission\Arr;
 use BlueFission\Connections\Database\MySQLLink;
+use BlueFission\Collections\ICollection;
+use BlueFission\BlueCore\Contracts\IAddOnLifecycleManager;
 use BlueFission\Data\FileSystem;
 use BlueFission\Data\Storage\Storage;
 use BlueFission\Func;
@@ -19,7 +21,7 @@ use BlueFission\Str;
 use BlueFission\System\System;
 use BlueFission\Val;
 
-class AddOnManager extends Service
+class AddOnManager extends Service implements IAddOnLifecycleManager
 {
     private $_loader;
     protected $_model;
@@ -161,28 +163,46 @@ class AddOnManager extends Service
 
     public function activateAll(): array
     {
+        return $this->updateAllActivation(true);
+    }
+
+    public function deactivateAll(): array
+    {
+        return $this->updateAllActivation(false);
+    }
+
+    private function updateAllActivation(bool $active): array
+    {
         $addOns = $this->installedAddOns();
-        $results = [];
+        $results = Arr::make([]);
+        $action = $active ? 'activate' : 'deactivate';
+
         foreach ($addOns as $addOn) {
             $record = Arr::make($addOn);
-            if (Flag::parseBool($record->get('is_active'))) {
+            if (Flag::parseBool($record->get('is_active')) === $active) {
                 continue;
             }
 
             $addOnId = $record->get('addon_id');
             if (Val::isEmpty($addOnId)) {
-                $results[] = $this->failedLifecycleResult(
-                    'activate',
+                $failure = $this->failedLifecycleResult(
+                    $action,
                     '',
                     new \UnexpectedValueException('Persisted add-on row is missing addon_id.')
                 );
+                $failure['record'] = $record->toArray();
+                $results->push($failure);
                 continue;
             }
 
-            $results[] = $this->activate($addOnId);
+            $result = $active
+                ? $this->activate($addOnId)
+                : $this->deactivate($addOnId);
+            $result['record'] = $record->toArray();
+            $results->push($result);
         }
 
-        return $this->lifecycleBatchResult('activate_all', $results);
+        return $this->lifecycleBatchResult("{$action}_all", $results->toArray());
     }
 
     public function deactivate($addOnId): array
@@ -624,11 +644,41 @@ class AddOnManager extends Service
     {
         $this->_model->clear();
         $this->_model->read();
+        $records = $this->_model->all();
 
-        return Arr::make(Arr::toArray($this->_model->all(), true))
-            ->map(fn ($addOn) => Arr::toArray($addOn, true))
+        if ($records instanceof ICollection) {
+            $records = $records->toArray(true);
+        } elseif ($records instanceof \Traversable) {
+            $records = iterator_to_array($records);
+        } else {
+            $records = Arr::toArray($records, true);
+        }
+
+        return Arr::make($records)
+            ->map(fn ($addOn) => $this->normalizeInstalledAddOn($addOn))
             ->values()
             ->toArray();
+    }
+
+    private function normalizeInstalledAddOn(mixed $addOn): array
+    {
+        if (Arr::is($addOn)) {
+            return $addOn;
+        }
+
+        if ($addOn instanceof ICollection) {
+            return $addOn->toArray(true);
+        }
+
+        if (Func::isCallable([$addOn, 'data'])) {
+            return Arr::toArray(Func::make([$addOn, 'data'])->call(), true);
+        }
+
+        if (is_object($addOn)) {
+            return get_object_vars($addOn);
+        }
+
+        return [];
     }
 
     protected function datasourceManager(): mixed

--- a/src/BlueCore/Contracts/IAddOnLifecycleManager.php
+++ b/src/BlueCore/Contracts/IAddOnLifecycleManager.php
@@ -5,7 +5,10 @@ namespace BlueFission\BlueCore\Contracts;
 interface IAddOnLifecycleManager
 {
     public function install($name, bool $installDependencies = false): array;
+    public function installAll(bool $installDependencies = false): array;
     public function uninstall($addOnId, bool $removeDependencies = false): array;
     public function activate($addOnId): array;
+    public function activateAll(): array;
     public function deactivate($addOnId): array;
+    public function deactivateAll(): array;
 }

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -4,6 +4,8 @@ namespace BlueFission\Tests\BlueCore\Business\Managers;
 
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
 use BlueFission\BlueCore\Domain\AddOn\AddOn;
+use BlueFission\Collections\Collection;
+use BlueFission\Collections\Group;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -423,6 +425,72 @@ class AddOnManagerTest extends TestCase
         $this->assertSame('Persisted add-on row is missing addon_id.', $result['results'][1]['error']);
     }
 
+    #[DataProvider('collectionContainerProvider')]
+    public function testBulkLifecyclePreservesCollectionRowsAndNamespaceRoundTrips(string $container): void
+    {
+        $namespace = 'BlueFission\\Fixtures\\InstalledAddOn';
+        $records = [
+            [
+                'addon_id' => 31,
+                'name' => 'first',
+                'namespace' => $namespace,
+                'path' => '/addons/first',
+                'primary_file' => 'main.php',
+                'is_active' => 0,
+            ],
+            [
+                'addon_id' => 32,
+                'name' => 'second',
+                'namespace' => 'BlueFission\\Fixtures\\SecondAddOn',
+                'path' => '/addons/second',
+                'primary_file' => 'bootstrap.php',
+                'is_active' => 0,
+            ],
+        ];
+        $model = new FakeAddOnModel($records, containerClass: $container);
+        $manager = new TestableAddOnManager($model);
+
+        $activated = $manager->activateAll();
+        $deactivated = $manager->deactivateAll();
+
+        $this->assertTrue($activated['ok']);
+        $this->assertSame(2, $activated['total']);
+        $this->assertSame($records[0], $activated['results'][0]['record']);
+        $this->assertSame($namespace, $activated['results'][0]['record']['namespace']);
+        $this->assertTrue($deactivated['ok']);
+        $this->assertSame(2, $deactivated['total']);
+        $this->assertSame($namespace, $model->records[0]['namespace']);
+        $this->assertSame([1, 1, 0, 0], array_column($model->writes, 'is_active'));
+    }
+
+    public static function collectionContainerProvider(): array
+    {
+        return [
+            'collection' => [Collection::class],
+            'group' => [Group::class],
+        ];
+    }
+
+    public function testDeactivateAllFailsClosedForMalformedRowsAndWriteFailures(): void
+    {
+        $model = new FakeAddOnModel([
+            ['addon_id' => 41, 'name' => 'failed', 'is_active' => 1],
+            ['name' => 'malformed', 'is_active' => 1],
+        ], containerClass: Group::class, failWritesForIds: [41]);
+        $manager = new TestableAddOnManager($model);
+
+        $result = $manager->deactivateAll();
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('deactivate_all', $result['action']);
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(0, $result['succeeded']);
+        $this->assertSame(2, $result['failed']);
+        $this->assertSame('registration', $result['results'][0]['stage']);
+        $this->assertSame('failed', $result['results'][1]['stage']);
+        $this->assertSame('malformed', $result['results'][1]['record']['name']);
+    }
+
     public function testRepeatedInstallUsesSupportedModelOperationsAndDoesNotDuplicateRegistration(): void
     {
         $this->writeDefinition('demo');
@@ -585,6 +653,7 @@ class FakeAddOnModel
     public function __construct(
         array $addons = [],
         private bool $returnArrays = false,
+        private ?string $containerClass = null,
         private array $failWritesForIds = []
     )
     {
@@ -659,13 +728,15 @@ class FakeAddOnModel
         return $this->current;
     }
 
-    public function all(): array
+    public function all(): mixed
     {
-        if ($this->returnArrays) {
-            return $this->records;
-        }
+        $records = $this->returnArrays
+            ? $this->records
+            : array_map(static fn($record) => (object)$record, $this->records);
 
-        return array_map(static fn($record) => (object)$record, $this->records);
+        return $this->containerClass === null
+            ? $records
+            : new $this->containerClass($records);
     }
 
     public function delete($values): void


### PR DESCRIPTION
## Intent

Preserve persisted add-on rows when bulk lifecycle operations receive DevElation collection containers.

## User Stories / Acceptance Criteria

- Normalize `Collection` and `Group` through their collection API.
- Preserve identifiers, names, namespaces, paths, primary files, and activation state per row.
- Preserve namespace separators through read/write lifecycle round trips.
- Activate and deactivate multiple installed add-ons deterministically.
- Fail the aggregate result when a row is malformed or a storage write fails.
- Keep each original persisted row in its structured lifecycle result.

## Key Files Changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `src/BlueCore/Contracts/IAddOnLifecycleManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `docs/extension-registration-contracts.md`

## How To Test

- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `composer ci`

## QA Checklist

- [x] Real DevElation `Collection` and `Group` containers are covered
- [x] Multiple rows remain independent
- [x] Namespace separators round-trip exactly
- [x] Activation and deactivation use one fail-closed implementation
- [x] Malformed rows and failed writes remain visible in batch results
- [x] Full package suite passes

## Approval Conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms supported collection containers are not collapsed into one row.
- Live MySQL integration proof is run in an approved opt-in environment.

Closes #54
