### PR TITLE
Apply pending datasource deltas to installed add-ons

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -22,8 +22,16 @@ Add-on lifecycle managers implement `IAddOnLifecycleManager`:
 - `uninstall($addOnId, bool $removeDependencies = false): array`
 - `activate($addOnId): array`
 - `deactivate($addOnId): array`
+- `migrate($addOnId): array`
 
 Lifecycle methods return structured arrays so callers can compose results, log decisions, and avoid process termination.
+
+`migrate()` refreshes the datasource structure of an already-installed add-on
+without installing dependencies or populating data. Migration history is
+filtered by the add-on batch before pending deltas are discovered. Successful
+deltas are idempotent on repeat; failed deltas stop the batch, retain their
+exception diagnostics, and report `retry_migrate` without marking the
+lifecycle operation complete.
 
 ## Theme Registry
 

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -15,11 +15,12 @@ use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 use BlueFission\BlueCore\Domain\AddOn\Models\AddOnModel;
 use BlueFission\BlueCore\Domain\AddOn\AddOn;
+use BlueFission\BlueCore\Contracts\IAddOnLifecycleManager;
 use BlueFission\Str;
 use BlueFission\System\System;
 use BlueFission\Val;
 
-class AddOnManager extends Service
+class AddOnManager extends Service implements IAddOnLifecycleManager
 {
     private $_loader;
     protected $_model;
@@ -66,11 +67,19 @@ class AddOnManager extends Service
         $datasource = $this->datasourceManager();
         $datasource->setDeltaDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR);
         $datasource->setGeneratorDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'generator' . DIRECTORY_SEPARATOR);
-        ob_start();
-        $datasource->runMigrations($name);
+        $migrationResult = $datasource->runMigrations($data->name);
+        $result['migrations'] = $migrationResult;
+        if (Flag::isFalse(Arr::getPath($migrationResult, 'ok', false))) {
+            $result['ok'] = false;
+            $result['stage'] = 'datasource';
+            $result['nextAction'] = 'retry_install';
+            $result['error'] = Arr::getPath($migrationResult, 'error', 'Add-on migration failed.');
+            $result['messages'][] = $result['error'];
+
+            return $result;
+        }
+
         $datasource->populate();
-        $result['messages'][] = ob_get_contents();
-        ob_end_clean();
 
         $hookResult = $this->callHook($addon, 'install');
         if (Arr::is($hookResult)) {
@@ -190,6 +199,40 @@ class AddOnManager extends Service
         $this->_model->write(['addon_id' => $addOnId, 'is_active' => 0]);
 
         return $this->lifecycleResult('deactivate', (string)$addOnId, $this->_model->status(), $this->_model->query());
+    }
+
+    public function migrate($addOnId): array
+    {
+        $addOn = $this->getAddOnById($addOnId);
+        $result = $this->lifecycleResult('migrate', (string)$addOn->name);
+        $result['stage'] = 'datasource';
+
+        try {
+            $datasource = $this->datasourceManager();
+            $datasource->setDeltaDirectory(
+                $addOn->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR
+            );
+            $datasource->setGeneratorDirectory(
+                $addOn->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'generator' . DIRECTORY_SEPARATOR
+            );
+            $migrationResult = $datasource->runMigrations($addOn->name);
+            $result['migrations'] = $migrationResult;
+            $result['ok'] = Flag::parseBool(Arr::getPath($migrationResult, 'ok', false));
+            $result['changed'] = Flag::parseBool(Arr::getPath($migrationResult, 'changed', false));
+            $result['stage'] = $result['ok'] ? 'complete' : 'datasource';
+            $result['nextAction'] = $result['ok'] ? null : 'retry_migrate';
+            $result['error'] = Arr::getPath($migrationResult, 'error');
+            if (Val::isNotEmpty($result['error'])) {
+                $result['messages'][] = $result['error'];
+            }
+        } catch (\Throwable $exception) {
+            $result['ok'] = false;
+            $result['nextAction'] = 'retry_migrate';
+            $result['error'] = $exception->getMessage();
+            $result['messages'][] = $exception->getMessage();
+        }
+
+        return $result;
     }
 
     public function showAllAddOns()
@@ -681,6 +724,7 @@ class AddOnManager extends Service
             'messages' => $ok ? [] : ['Add-on registration could not be updated.'],
             'dependencies' => [],
             'hooks' => [],
+            'migrations' => [],
             'modelStatus' => $modelStatus,
             'query' => $query,
         ])->toArray();

--- a/src/BlueCore/Business/Managers/DatasourceManager.php
+++ b/src/BlueCore/Business/Managers/DatasourceManager.php
@@ -6,15 +6,18 @@ use BlueFission\Collections\Collection;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\Storage\Storage;
 use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
 use BlueFission\Arr;
+use BlueFission\Flag;
+use BlueFission\Func;
 use BlueFission\Str;
 use BlueFission\Val;
 
 class DatasourceManager extends Service {
 
-	private $_deltaDir = '';
-	private $_generatorDir = '';
-	private $_db = null;
+	protected $_deltaDir = '';
+	protected $_generatorDir = '';
+	protected $_db = null;
 
 	public function __construct( MySQLLink $link, Storage $storage )
     {
@@ -37,63 +40,124 @@ class DatasourceManager extends Service {
 		$this->_generatorDir = $directory;
 	}
 
-	public function runMigrations($batch = null)
+	public function runMigrations($batch = null): array
 	{
-		$batch = $batch ?: 'opus';
+		$batch = Val::isEmpty($batch) ? 'opus' : Str::trim((string)$batch);
+		$result = Arr::make([
+			'ok' => true,
+			'batch' => $batch,
+			'changed' => false,
+			'stage' => 'discovery',
+			'total' => 0,
+			'applied' => 0,
+			'failed' => 0,
+			'results' => [],
+			'nextAction' => null,
+			'error' => null,
+		]);
 
-		if ( !file_exists($this->_deltaDir) ) {
-			return;
+		if (Flag::isFalse($this->deltaDirectoryExists())) {
+			$result->set('stage', 'complete');
+
+			return $result->toArray();
 		}
 
 		$deltas = $this->loadDeltas();
 		$iteration = 0;
-		$storedDeltas = $this->getDeltasFromDB($iteration);
+		$storedDeltas = $this->getDeltasFromDB($iteration, $batch);
 		$iteration++;
 
 		$deltas = Arr::make($deltas)
 			->diff($storedDeltas)
+			->filter(fn ($delta) => Str::pos((string)$delta, '.') !== 0)
 			->values()
 			->toArray();
 
-		$dbActive = false;
-		if ( MySQLLink::tableExists('migrations') ) {
-			$dbActive = true;
-		}
+		$result->set('total', Arr::size($deltas));
+		$result->set('stage', 'migration');
+		$dbActive = $this->migrationTableExists();
+		$migrations = Arr::make([]);
 
-		foreach ( $deltas as $delta ) {
-			$classname = '';
-			if ( strpos($delta, '.') != 0 ) {
-				$classname = $this->findClassName( $this->_deltaDir . $delta );
-				if ( $classname ) {
-					include_once($this->_deltaDir . $delta);
-					$this->_db->clear();
-					$this->_db->assign([
-						'name' => $delta,
-						'batch' => $batch,
-						'iteration' => $iteration,
-						'status' => 1
-					])->write();
-					$this->_db->id($this->_db->lastRow());
-					$status = 2;
-					$object = \App::makeInstance($classname);
-					try {
-						call_user_func([$object, 'change']);
-					} catch ( \Exception $e ) {
-						$status = 3;
-					}
-					if ( !$dbActive ) {
-						$this->_db->activate();
-						$dbActive = true;
-					}
-					$this->_db->assign([
-						'name' => $delta,
-						'batch' => $batch,
-						'iteration' => $iteration,
-						'status' => $status
-					])->write();
-				}
+		foreach ($deltas as $delta) {
+			$migration = Arr::make([
+				'ok' => false,
+				'name' => $delta,
+				'batch' => $batch,
+				'iteration' => $iteration,
+				'status' => 'pending',
+				'error' => null,
+				'exception' => null,
+			]);
+			$classname = $this->findClassName($this->_deltaDir . $delta);
+
+			if (Val::isEmpty($classname)) {
+				$migration->set('status', 'missing_class');
+				$migration->set('error', 'Migration class could not be resolved.');
+				$migrations->push($migration->toArray());
+				break;
+			}
+
+			$this->includeMigration($this->_deltaDir . $delta);
+			$this->_db->clear();
+			$this->_db->assign([
+				'name' => $delta,
+				'batch' => $batch,
+				'iteration' => $iteration,
+				'status' => 1,
+			])->write();
+			$this->_db->id($this->_db->lastRow());
+			$status = 2;
+
+			try {
+				$object = $this->migrationInstance($classname);
+				Func::make([$object, 'change'])->call();
+				$migration->set('ok', true);
+				$migration->set('status', 'applied');
+			} catch (\Throwable $exception) {
+				$status = 3;
+				$migration->set('status', 'failed');
+				$migration->set('error', $exception->getMessage());
+				$migration->set('exception', $exception::class);
+			}
+
+			if (Flag::isFalse($dbActive)) {
+				$this->_db->activate();
+				$dbActive = true;
+			}
+
+			$this->_db->assign([
+				'name' => $delta,
+				'batch' => $batch,
+				'iteration' => $iteration,
+				'status' => $status,
+			])->write();
+			$migrations->push($migration->toArray());
+
+			if (Flag::isFalse($migration->get('ok'))) {
+				break;
 			}
 		}
+
+		$failures = $migrations
+			->filter(fn ($migration) => Flag::isFalse(Arr::getPath($migration, 'ok', false)))
+			->values();
+		$applied = $migrations
+			->filter(fn ($migration) => Flag::parseBool(Arr::getPath($migration, 'ok', false)))
+			->values();
+		$result->set('results', $migrations->toArray());
+		$result->set('applied', $applied->count());
+		$result->set('failed', $failures->count());
+		$result->set('changed', Arr::isNotEmpty($applied->toArray()));
+		$result->set('ok', Arr::isEmpty($failures->toArray()));
+		$result->set('stage', Arr::isEmpty($failures->toArray()) ? 'complete' : 'migration');
+
+		if (Arr::isNotEmpty($failures->toArray())) {
+			$failure = Arr::getPath($failures->values()->toArray(), '0', []);
+			$result->set('nextAction', 'retry_migrations');
+			$result->set('error', Arr::getPath($failure, 'error', 'Migration failed.'));
+		}
+
+		return $result->toArray();
 	}
 
 	public function revertMigrations()
@@ -205,7 +269,7 @@ class DatasourceManager extends Service {
 		}
 	}
 
-	private function getDeltasFromDB( &$iteration ): array
+	protected function getDeltasFromDB(&$iteration, ?string $batch = null): array
 	{
 		if ( !MySQLLink::tableExists('migrations') ) {
 			return [];
@@ -213,6 +277,9 @@ class DatasourceManager extends Service {
 
 		$this->_db->activate();
 		$this->_db->clear();
+		if (Val::isNotEmpty($batch)) {
+			$this->_db->where('batch', $batch);
+		}
 		$this->_db->order('iteration', 'DESC')
 			->order('migration_id', 'DESC')
 			->read();
@@ -265,9 +332,29 @@ class DatasourceManager extends Service {
 		return scandir($this->_generatorDir);
 	}
 
-	private function loadDeltas( $reverse = SCANDIR_SORT_ASCENDING )
+	protected function loadDeltas( $reverse = SCANDIR_SORT_ASCENDING )
 	{
 		return scandir($this->_deltaDir, $reverse);
+	}
+
+	protected function deltaDirectoryExists(): bool
+	{
+		return Flag::parseBool(Arr::getPath(Path::readiness($this->_deltaDir), 'exists', false));
+	}
+
+	protected function migrationTableExists(): bool
+	{
+		return MySQLLink::tableExists('migrations');
+	}
+
+	protected function includeMigration(string $path): void
+	{
+		include_once($path);
+	}
+
+	protected function migrationInstance(string $classname): object
+	{
+		return \App::makeInstance($classname);
 	}
 
 	protected function findClassName($file): ?string

--- a/src/BlueCore/Contracts/IAddOnLifecycleManager.php
+++ b/src/BlueCore/Contracts/IAddOnLifecycleManager.php
@@ -8,4 +8,5 @@ interface IAddOnLifecycleManager
     public function uninstall($addOnId, bool $removeDependencies = false): array;
     public function activate($addOnId): array;
     public function deactivate($addOnId): array;
+    public function migrate($addOnId): array;
 }

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -440,6 +440,72 @@ class AddOnManagerTest extends TestCase
         $this->assertSame(1, $datasource->migrationRuns);
     }
 
+    public function testInstalledAddOnAppliesOnlyPendingMigrationsAndRepeatsAsNoOp(): void
+    {
+        $this->writeDefinition('demo');
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $datasource->publish('001_initial.php');
+        $manager = new TestableAddOnManager($model, $datasource);
+
+        $install = $manager->install('demo');
+        $datasource->publish('002_later.php');
+        $refresh = $manager->migrate($model->records[0]['addon_id']);
+        $repeat = $manager->migrate($model->records[0]['addon_id']);
+
+        $this->assertTrue($install['ok']);
+        $this->assertSame(1, $install['migrations']['applied']);
+        $this->assertTrue($refresh['ok']);
+        $this->assertTrue($refresh['changed']);
+        $this->assertSame('complete', $refresh['stage']);
+        $this->assertSame('002_later.php', $refresh['migrations']['results'][0]['name']);
+        $this->assertTrue($repeat['ok']);
+        $this->assertFalse($repeat['changed']);
+        $this->assertSame(0, $repeat['migrations']['total']);
+        $this->assertSame(1, $datasource->populationRuns);
+    }
+
+    public function testMigrationHistoryIsScopedToEachInstalledAddOn(): void
+    {
+        $this->writeDefinition('first');
+        $this->writeDefinition('second');
+        $datasource = new FakeDatasourceManager();
+        $datasource->publish('001_shared.php');
+        $manager = new TestableAddOnManager(new FakeAddOnModel(), $datasource);
+
+        $first = $manager->install('first');
+        $second = $manager->install('second');
+
+        $this->assertSame(1, $first['migrations']['applied']);
+        $this->assertSame(1, $second['migrations']['applied']);
+        $this->assertSame(['001_shared.php'], $datasource->appliedFor('first'));
+        $this->assertSame(['001_shared.php'], $datasource->appliedFor('second'));
+    }
+
+    public function testMigrationFailurePreventsSuccessAndRemainsRetryable(): void
+    {
+        $this->writeDefinition('demo');
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $datasource->publish('001_initial.php');
+        $manager = new TestableAddOnManager($model, $datasource);
+        $manager->install('demo');
+        $datasource->publish('002_retry.php');
+        $datasource->failOn('002_retry.php');
+
+        $failed = $manager->migrate($model->records[0]['addon_id']);
+        $retried = $manager->migrate($model->records[0]['addon_id']);
+
+        $this->assertFalse($failed['ok']);
+        $this->assertFalse($failed['changed']);
+        $this->assertSame('datasource', $failed['stage']);
+        $this->assertSame('retry_migrate', $failed['nextAction']);
+        $this->assertSame('Migration 002_retry.php failed.', $failed['error']);
+        $this->assertFalse($retried['ok']);
+        $this->assertSame('002_retry.php', $retried['migrations']['results'][0]['name']);
+        $this->assertSame(['001_initial.php'], $datasource->appliedFor('demo'));
+    }
+
     public function testFailedTeardownPreservesRegistrationForRetry(): void
     {
         $this->writeDefinition('demo');
@@ -694,6 +760,10 @@ class FakeAddOnModel
 class FakeDatasourceManager
 {
     public int $migrationRuns = 0;
+    public int $populationRuns = 0;
+    private array $published = [];
+    private array $applied = [];
+    private ?string $failedMigration = null;
 
     public function __construct(private bool $failRollback = false)
     {
@@ -707,13 +777,75 @@ class FakeDatasourceManager
     {
     }
 
-    public function runMigrations(string $batch): void
+    public function publish(string $migration): void
+    {
+        if (!\BlueFission\Arr::has($this->published, $migration, true)) {
+            $this->published[] = $migration;
+        }
+    }
+
+    public function failOn(?string $migration): void
+    {
+        $this->failedMigration = $migration;
+    }
+
+    public function appliedFor(string $batch): array
+    {
+        return $this->applied[$batch] ?? [];
+    }
+
+    public function runMigrations(string $batch): array
     {
         $this->migrationRuns++;
+        $applied = $this->applied[$batch] ?? [];
+        $pending = \BlueFission\Arr::make($this->published)
+            ->diff($applied)
+            ->values()
+            ->toArray();
+        $results = [];
+
+        foreach ($pending as $migration) {
+            $ok = $migration !== $this->failedMigration;
+            $results[] = [
+                'ok' => $ok,
+                'name' => $migration,
+                'status' => $ok ? 'applied' : 'failed',
+                'error' => $ok ? null : "Migration {$migration} failed.",
+            ];
+
+            if (!$ok) {
+                return [
+                    'ok' => false,
+                    'batch' => $batch,
+                    'changed' => false,
+                    'total' => \BlueFission\Arr::size($pending),
+                    'applied' => 0,
+                    'failed' => 1,
+                    'results' => $results,
+                    'nextAction' => 'retry_migrations',
+                    'error' => "Migration {$migration} failed.",
+                ];
+            }
+
+            $this->applied[$batch][] = $migration;
+        }
+
+        return [
+            'ok' => true,
+            'batch' => $batch,
+            'changed' => \BlueFission\Arr::isNotEmpty($pending),
+            'total' => \BlueFission\Arr::size($pending),
+            'applied' => \BlueFission\Arr::size($pending),
+            'failed' => 0,
+            'results' => $results,
+            'nextAction' => null,
+            'error' => null,
+        ];
     }
 
     public function populate(): void
     {
+        $this->populationRuns++;
     }
 
     public function revertBatch(string $batch): void

--- a/tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Business\Managers;
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use PHPUnit\Framework\TestCase;
+
+class DatasourceManagerMigrationRunTest extends TestCase
+{
+    public function testPendingMigrationsAreScopedByBatchAndRepeatAsNoOp(): void
+    {
+        $manager = new ExecutableDatasourceManager(['001_initial.php', '002_later.php']);
+
+        $first = $manager->runMigrations('first-addon');
+        $repeat = $manager->runMigrations('first-addon');
+        $other = $manager->runMigrations('second-addon');
+
+        $this->assertTrue($first['ok']);
+        $this->assertTrue($first['changed']);
+        $this->assertSame(2, $first['applied']);
+        $this->assertSame(['001_initial.php', '002_later.php'], $manager->historyFor('first-addon'));
+        $this->assertTrue($repeat['ok']);
+        $this->assertFalse($repeat['changed']);
+        $this->assertSame(0, $repeat['total']);
+        $this->assertSame(2, $other['applied']);
+        $this->assertSame(['001_initial.php', '002_later.php'], $manager->historyFor('second-addon'));
+    }
+
+    public function testFailedMigrationStopsTheBatchAndRemainsRetryable(): void
+    {
+        $manager = new ExecutableDatasourceManager(['001_initial.php', '002_retry.php', '003_after.php']);
+        $manager->failOn('002_retry.php');
+
+        $failed = $manager->runMigrations('retry-addon');
+        $historyAfterFailure = $manager->historyFor('retry-addon');
+        $manager->failOn(null);
+        $retried = $manager->runMigrations('retry-addon');
+
+        $this->assertFalse($failed['ok']);
+        $this->assertSame('migration', $failed['stage']);
+        $this->assertSame(1, $failed['applied']);
+        $this->assertSame(1, $failed['failed']);
+        $this->assertSame('retry_migrations', $failed['nextAction']);
+        $this->assertSame('002_retry.php failed', $failed['error']);
+        $this->assertSame(['001_initial.php'], $historyAfterFailure);
+        $this->assertTrue($retried['ok']);
+        $this->assertSame(2, $retried['applied']);
+        $this->assertSame(
+            ['001_initial.php', '002_retry.php', '003_after.php'],
+            $manager->historyFor('retry-addon')
+        );
+    }
+}
+
+class ExecutableDatasourceManager extends DatasourceManager
+{
+    private array $history = [];
+    private ?string $failedMigration = null;
+
+    public function __construct(private array $available)
+    {
+        $this->_deltaDir = 'virtual' . DIRECTORY_SEPARATOR;
+        $this->_db = new MigrationRunStorage(function (array $record): void {
+            if ((int)Arr::getPath($record, 'status', 0) !== 2) {
+                return;
+            }
+
+            $batch = (string)Arr::getPath($record, 'batch', '');
+            $name = (string)Arr::getPath($record, 'name', '');
+            if (!Arr::has($this->history[$batch] ?? [], $name, true)) {
+                $this->history[$batch][] = $name;
+            }
+        });
+    }
+
+    public function failOn(?string $migration): void
+    {
+        $this->failedMigration = $migration;
+    }
+
+    public function historyFor(string $batch): array
+    {
+        return $this->history[$batch] ?? [];
+    }
+
+    protected function deltaDirectoryExists(): bool
+    {
+        return true;
+    }
+
+    protected function migrationTableExists(): bool
+    {
+        return true;
+    }
+
+    protected function loadDeltas($reverse = SCANDIR_SORT_ASCENDING): array
+    {
+        return Arr::make(['.', '..'])->merge($this->available)->toArray();
+    }
+
+    protected function getDeltasFromDB(&$iteration, ?string $batch = null): array
+    {
+        $iteration = Arr::isNotEmpty($this->historyFor((string)$batch)) ? 1 : 0;
+
+        return $this->historyFor((string)$batch);
+    }
+
+    protected function findClassName($file): ?string
+    {
+        return basename((string)$file);
+    }
+
+    protected function includeMigration(string $path): void
+    {
+    }
+
+    protected function migrationInstance(string $classname): object
+    {
+        return new TestMigration($classname, $this->failedMigration === $classname);
+    }
+}
+
+class TestMigration
+{
+    public function __construct(private string $name, private bool $fails)
+    {
+    }
+
+    public function change(): void
+    {
+        if ($this->fails) {
+            throw new \RuntimeException("{$this->name} failed");
+        }
+    }
+}
+
+class MigrationRunStorage
+{
+    private array $record = [];
+    private int $lastRow = 0;
+
+    public function __construct(private $onWrite)
+    {
+    }
+
+    public function clear(): self
+    {
+        $this->record = [];
+
+        return $this;
+    }
+
+    public function assign(array $record): self
+    {
+        $this->record = $record;
+
+        return $this;
+    }
+
+    public function write(): self
+    {
+        $this->lastRow++;
+        ($this->onWrite)($this->record);
+
+        return $this;
+    }
+
+    public function id(mixed $id): self
+    {
+        return $this;
+    }
+
+    public function lastRow(): int
+    {
+        return $this->lastRow;
+    }
+
+    public function activate(): self
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
## Intent

Apply pending datasource deltas to already-installed add-ons through an explicit, scoped, retry-safe lifecycle operation.

## User Stories / Acceptance Criteria

- Installed add-ons expose a dedicated `migrate($addOnId)` operation.
- Migration discovery is scoped to the add-on batch.
- Only pending successful-history deltas execute.
- Repeating a successful migration is a structured no-op.
- A failed delta stops the batch, preserves its exception diagnostics, and remains retryable.
- Installation does not report success when a material migration fails.
- Migration refresh does not install dependencies or populate data.

## Key Files Changed

- `src/BlueCore/Business/Managers/DatasourceManager.php`
- `src/BlueCore/Business/Managers/AddOnManager.php`
- `src/BlueCore/Contracts/IAddOnLifecycleManager.php`
- `tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `docs/extension-registration-contracts.md`

## How To Test

- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php tests/BlueCore/Business/Managers/AddOnManagerTest.php tests/BlueCore/Business/Managers/DatasourceManagerMigrationHistoryTest.php`
- `composer ci`

## QA Checklist

- [x] Pending discovery is batch-scoped
- [x] Successful history is idempotent
- [x] Failed deltas are not recorded as successful
- [x] Failure stops later deltas and exposes retry guidance
- [x] Installed add-ons can refresh without dependency or population work
- [x] Full package suite passes

## Approval Conditions

- CI passes on PHP 8.2 and 8.3.
- Review confirms migration-history filtering cannot consume another add-on's deltas.
- Live MySQL pending/repeat/failure proof is run in an approved opt-in environment.

Closes #56
