### PR TITLE
Make clean custom package installation deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3']
+        include:
+          - php-version: '8.2'
+            composer-version: '2.2'
+          - php-version: '8.3'
+            composer-version: 'latest'
 
     steps:
       - name: Checkout
@@ -20,6 +24,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          tools: composer:${{ matrix.composer-version }}
           extensions: sqlite3
           coverage: none
 

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
         }
     },
     "extra": {
-        "class": "BlueFission\\BlueCore\\Installers\\PluginInstaller"
+        "class": "BlueFission\\BlueCore\\Installers\\PluginInstaller",
+        "plugin-modifies-install-path": true
     },
     "config": {
         "platform-check": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08d994f7ee7599ad096cc28a1903bf6e",
+    "content-hash": "4985f677a975d6caca1d7582966070cf",
     "packages": [
         {
             "name": "bluefission/develation",

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -45,6 +45,7 @@ final class ComposerMetadataTest extends TestCase
         $this->assertSame(self::PACKAGE_REPOSITORY . '/issues', $composer['support']['issues']);
         $this->assertSame(self::PACKAGE_REPOSITORY, $composer['support']['source']);
         $this->assertTrue($composer['config']['platform-check']);
+        $this->assertTrue($composer['extra']['plugin-modifies-install-path']);
     }
 
     public function testReleaseUsesCurrentDevElationConstraint(): void
@@ -108,5 +109,8 @@ final class ComposerMetadataTest extends TestCase
 
         $this->assertTrue($workflow->has("'8.2'"));
         $this->assertTrue($workflow->has("'8.3'"));
+        $this->assertTrue($workflow->has("composer-version: '2.2'"));
+        $this->assertTrue($workflow->has("composer-version: 'latest'"));
+        $this->assertTrue($workflow->has('tools: composer:${{ matrix.composer-version }}'));
     }
 }

--- a/tests/Integration/project-installer-parity.php
+++ b/tests/Integration/project-installer-parity.php
@@ -62,6 +62,7 @@ function createPluginPackage(string $workspace, string $root): string
             ],
             'extra' => [
                 'class' => 'BlueFission\\BlueCore\\Installers\\PluginInstaller',
+                'plugin-modifies-install-path' => true,
             ],
         ]),
         true
@@ -124,6 +125,16 @@ function writeFixtureVersion(string $source, string $version, array $overrides):
         true
     );
     File::ensureFile($source . DIRECTORY_SEPARATOR . 'marker.txt', $version, true);
+    File::ensureFile(
+        $source . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Project' . DIRECTORY_SEPARATOR . 'Marker.php',
+        "<?php\n\nnamespace BlueFission\\InstallerFixture\\Project;\n\nfinal class Marker {}\n",
+        true
+    );
+    File::ensureFile(
+        $source . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'AddOn' . DIRECTORY_SEPARATOR . 'Marker.php',
+        "<?php\n\nnamespace BlueFission\\InstallerFixture\\AddOn;\n\nfinal class Marker {}\n",
+        true
+    );
 
     foreach (Arr::make($overrides) as $path => $contents) {
         File::ensureFile($source . DIRECTORY_SEPARATOR . $path, $contents, true);
@@ -169,8 +180,19 @@ function verifyTransport(string $workspace, string $plugin, array $fixture, stri
     assertProcessSucceeded($install, "{$transport} install");
     assertCleanComposerOutput($install, "{$transport} install");
     assertFile($consumer . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'marker.txt', '1.0.0');
+    assertFile($consumer . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'addon-installer-fixture' . DIRECTORY_SEPARATOR . 'marker.txt', '1.0.0');
     assertFile($consumer . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config.php', 'version-one');
     assertFile($consumer . DIRECTORY_SEPARATOR . 'package.json', '{"version":"1.0.0"}');
+    assertInstalledTopology($consumer);
+
+    $repeat = runProcess(
+        composerCommand($composer, ['install', '--no-interaction', '--no-progress', "--prefer-{$transport}"]),
+        $consumer,
+        true
+    );
+    assertProcessSucceeded($repeat, "{$transport} repeated install");
+    assertCleanComposerOutput($repeat, "{$transport} repeated install");
+    assertInstalledTopology($consumer);
 
     writeConsumerManifest($consumer, $plugin, $fixture, '1.1.0');
     $update = runProcess(
@@ -195,6 +217,7 @@ function verifyTransport(string $workspace, string $plugin, array $fixture, stri
         throw new RuntimeException("{$transport} uninstall left the project install path behind.");
     }
     assertFile($consumer . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config.php', 'version-one');
+    assertInstalledPackage($consumer, 'bluefission/addon-installer-fixture');
 }
 
 function verifyFailureRollback(string $workspace, string $plugin, array $fixture, string $composer): void
@@ -234,6 +257,26 @@ function writeConsumerManifest(string $consumer, string $plugin, array $fixture,
                 'url' => Str::replace($fixture['source'], DIRECTORY_SEPARATOR, '/'),
                 'reference' => $candidate,
             ],
+            'autoload' => [
+                'psr-4' => ['BlueFission\\InstallerFixture\\Project\\' => 'src/Project/'],
+            ],
+        ])
+        ->push([
+            'name' => 'bluefission/addon-installer-fixture',
+            'version' => '1.0.0',
+            'type' => 'opus-addon',
+            'dist' => [
+                'type' => 'zip',
+                'url' => fileUrl($fixture['dist']['1.0.0']),
+            ],
+            'source' => [
+                'type' => 'git',
+                'url' => Str::replace($fixture['source'], DIRECTORY_SEPARATOR, '/'),
+                'reference' => '1.0.0',
+            ],
+            'autoload' => [
+                'psr-4' => ['BlueFission\\InstallerFixture\\AddOn\\' => 'src/AddOn/'],
+            ],
         ])
         ->toArray();
     $repositories = Arr::make([
@@ -256,6 +299,7 @@ function writeConsumerManifest(string $consumer, string $plugin, array $fixture,
             'require' => [
                 'bluefission/bluecore' => '0.0.0',
                 'bluefission/project-installer-fixture' => $version,
+                'bluefission/addon-installer-fixture' => '1.0.0',
             ],
             'minimum-stability' => 'dev',
             'prefer-stable' => true,
@@ -265,6 +309,29 @@ function writeConsumerManifest(string $consumer, string $plugin, array $fixture,
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
         true
     );
+}
+
+function assertInstalledTopology(string $consumer): void
+{
+    assertInstalledPackage($consumer, 'bluefission/project-installer-fixture');
+    assertInstalledPackage($consumer, 'bluefission/addon-installer-fixture');
+
+    $autoload = runProcess([
+        PHP_BINARY,
+        '-r',
+        "require 'vendor/autoload.php'; exit(class_exists('BlueFission\\InstallerFixture\\Project\\Marker') && class_exists('BlueFission\\InstallerFixture\\AddOn\\Marker') ? 0 : 1);",
+    ], $consumer, true);
+    assertProcessSucceeded($autoload, 'generated autoload verification');
+}
+
+function assertInstalledPackage(string $consumer, string $package): void
+{
+    $installed = runProcess([
+        PHP_BINARY,
+        '-r',
+        "require 'vendor/autoload.php'; exit(Composer\\InstalledVersions::isInstalled('{$package}') ? 0 : 1);",
+    ], $consumer, true);
+    assertProcessSucceeded($installed, "InstalledVersions verification for {$package}");
 }
 
 /**


### PR DESCRIPTION
## Intent

Make custom package placement deterministic during a single clean Composer transaction.

## User Stories / Acceptance Criteria

- Declare that the Composer plugin modifies install paths.
- Activate custom installers before `opus-project` and `opus-addon` packages are placed.
- Verify the `core/`, `addons/`, and root-overlay topology in a clean consumer directory.
- Verify generated autoloading and Composer installed-package registration.
- Keep repeated installs idempotent and placement failures nonzero.
- Exercise the minimum supported Composer 2 release and current Composer on Linux.

## Key Files Changed

- `composer.json`
- `composer.lock`
- `.github/workflows/ci.yml`
- `tests/ComposerMetadataTest.php`
- `tests/Integration/project-installer-parity.php`

## How To Test

- `composer ci`
- `php tests/Integration/project-installer-parity.php`

## QA Checklist

- [x] Strict Composer validation passes
- [x] Full unit suite passes: 85 tests, 283 assertions
- [x] Clean source and dist installs place both package types correctly
- [x] Generated autoloading resolves classes from the installed topology
- [x] Repeated installs retain `InstalledVersions` entries
- [x] Failed root-overlay placement exits nonzero and rolls back the project path

## Approval Conditions

- CI passes on Composer 2.2 and current Composer.
- Review confirms the plugin metadata matches Composer's install-path contract.
- Review confirms the integration fixture starts from clean consumer directories.

Closes #62
