### PR TITLE
Return structured datasource population results

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -26,6 +26,12 @@ Add-on lifecycle managers implement `IAddOnLifecycleManager`:
 
 Lifecycle methods return structured arrays so callers can compose results, log decisions, and avoid process termination.
 
+Datasource migration and population are reported as distinct result blocks. Population
+stops on the first material generator failure, identifies completed and failed
+generators, and uses `review_population_failure` as its next action because BlueCore
+cannot guarantee that an arbitrary generator is retry-idempotent. Installation does
+not continue to hooks or registration writes after such a failure.
+
 `migrate()` refreshes the datasource structure of an already-installed add-on
 without installing dependencies or populating data. Migration history is
 filtered by the add-on batch before pending deltas are discovered. Successful

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -79,7 +79,17 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             return $result;
         }
 
-        $datasource->populate();
+		$populationResult = $datasource->populate();
+		$result['population'] = $populationResult;
+		if (Flag::isFalse(Arr::getPath($populationResult, 'ok', false))) {
+			$result['ok'] = false;
+			$result['stage'] = 'datasource';
+			$result['nextAction'] = 'review_population_failure';
+			$result['error'] = Arr::getPath($populationResult, 'error', 'Add-on population failed.');
+			$result['messages'][] = $result['error'];
+
+			return $result;
+		}
 
         $hookResult = $this->callHook($addon, 'install');
         if (Arr::is($hookResult)) {
@@ -724,7 +734,8 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             'messages' => $ok ? [] : ['Add-on registration could not be updated.'],
             'dependencies' => [],
             'hooks' => [],
-            'migrations' => [],
+			'migrations' => [],
+			'population' => [],
             'modelStatus' => $modelStatus,
             'query' => $query,
         ])->toArray();

--- a/src/BlueCore/Business/Managers/DatasourceManager.php
+++ b/src/BlueCore/Business/Managers/DatasourceManager.php
@@ -233,40 +233,140 @@ class DatasourceManager extends Service {
 		}
 	}
 
-	public function populate( $auto = false )
+	public function populate($auto = false): array
 	{
-		if (!file_exists($this->_generatorDir)) {
-			return;
+		$result = Arr::make([
+			'ok' => true,
+			'changed' => false,
+			'stage' => 'discovery',
+			'total' => 0,
+			'populated' => 0,
+			'failed' => 0,
+			'results' => [],
+			'nextAction' => null,
+			'error' => null,
+		]);
+
+		if (Flag::isFalse($this->generatorDirectoryExists())) {
+			$result->set('stage', 'complete');
+
+			return $result->toArray();
 		}
 
-		$generators = $this->loadGenerators();
-		if ( Arr::has($generators, 'RootSeeder.php', true) ) {
-			$classname = $this->findClassName( $this->_generatorDir . 'RootSeeder.php' );
-			if ( $classname ) {
-				include_once($this->_generatorDir . 'RootSeeder.php');
-				$object = \App::makeInstance($classname);
-				if ( method_exists($object, 'seeders') ) {
-					$generators = Arr::make(call_user_func([$object, 'seeders']))
-						->map(fn ($generator) => Str::endsWith($generator, '.php') ? $generator : $generator . '.php')
-						->toArray();
+		try {
+			$generators = $this->orderedGenerators($this->loadGenerators());
+		} catch (\Throwable $exception) {
+			return $this->failedPopulationResult($result, 'RootSeeder.php', $exception);
+		}
+
+		$result->set('total', Arr::size($generators));
+		$result->set('stage', 'population');
+		$outcomes = Arr::make([]);
+
+		foreach ($generators as $generator) {
+			$outcome = Arr::make([
+				'ok' => false,
+				'name' => $generator,
+				'status' => 'pending',
+				'error' => null,
+				'exception' => null,
+			]);
+
+			try {
+				$classname = $this->findClassName($this->_generatorDir . $generator);
+				if (Val::isEmpty($classname)) {
+					throw new \RuntimeException('Population class could not be resolved.');
 				}
+
+				$this->includeGenerator($this->_generatorDir . $generator);
+				$object = $this->generatorInstance($classname);
+				if (Flag::isFalse(Func::isCallable([$object, 'populate']))) {
+					throw new \RuntimeException('Population class must expose populate().');
+				}
+
+				Func::make([$object, 'populate'])->call($auto);
+				$outcome->set('ok', true);
+				$outcome->set('status', 'populated');
+			} catch (\Throwable $exception) {
+				$outcome->set('status', 'failed');
+				$outcome->set('error', $exception->getMessage());
+				$outcome->set('exception', $exception::class);
+			}
+
+			$outcomes->push($outcome->toArray());
+			if (Flag::isFalse($outcome->get('ok'))) {
+				break;
 			}
 		}
 
-		foreach ( $generators as $generator ) {
-			$classname = '';
+		$failures = $outcomes
+			->filter(fn ($outcome) => Flag::isFalse(Arr::getPath($outcome, 'ok', false)))
+			->values();
+		$populated = $outcomes
+			->filter(fn ($outcome) => Flag::parseBool(Arr::getPath($outcome, 'ok', false)))
+			->values();
+		$result->set('results', $outcomes->toArray());
+		$result->set('populated', $populated->count());
+		$result->set('failed', $failures->count());
+		$result->set('changed', Arr::isNotEmpty($populated->toArray()));
+		$result->set('ok', Arr::isEmpty($failures->toArray()));
+		$result->set('stage', Arr::isEmpty($failures->toArray()) ? 'complete' : 'population');
 
-			if ( strpos($generator, '.') !== 0 ) {
-				$generator = Str::endsWith($generator, '.php') ? $generator : $generator . '.php';
-				
-				$classname = $this->findClassName( $this->_generatorDir . $generator );
-				if ( $classname ) {
-					include_once($this->_generatorDir . $generator);
-					$object = \App::makeInstance($classname);
-					call_user_func([$object, 'populate'], $auto);
-				}
-			}
+		if (Arr::isNotEmpty($failures->toArray())) {
+			$failure = Arr::getPath($failures->toArray(), '0', []);
+			$result->set('nextAction', 'review_population_failure');
+			$result->set('error', Arr::getPath($failure, 'error', 'Datasource population failed.'));
 		}
+
+		return $result->toArray();
+	}
+
+	protected function orderedGenerators(array $generators): array
+	{
+		$generators = Arr::make($generators)
+			->filter(fn ($generator) => Str::pos((string)$generator, '.') !== 0)
+			->map(fn ($generator) => Str::endsWith((string)$generator, '.php') ? $generator : $generator . '.php')
+			->values()
+			->toArray();
+
+		if (Flag::isFalse(Arr::has($generators, 'RootSeeder.php', true))) {
+			return $generators;
+		}
+
+		$classname = $this->findClassName($this->_generatorDir . 'RootSeeder.php');
+		if (Val::isEmpty($classname)) {
+			throw new \RuntimeException('Root seeder class could not be resolved.');
+		}
+
+		$this->includeGenerator($this->_generatorDir . 'RootSeeder.php');
+		$object = $this->generatorInstance($classname);
+		if (Flag::isFalse(Func::isCallable([$object, 'seeders']))) {
+			return $generators;
+		}
+
+		return Arr::make(Func::make([$object, 'seeders'])->call())
+			->map(fn ($generator) => Str::endsWith((string)$generator, '.php') ? $generator : $generator . '.php')
+			->values()
+			->toArray();
+	}
+
+	private function failedPopulationResult(Arr $result, string $generator, \Throwable $exception): array
+	{
+		$result->set('ok', false);
+		$result->set('stage', 'population');
+		$result->set('total', 1);
+		$result->set('failed', 1);
+		$result->set('nextAction', 'review_population_failure');
+		$result->set('error', $exception->getMessage());
+		$result->set('results', [[
+			'ok' => false,
+			'name' => $generator,
+			'status' => 'failed',
+			'error' => $exception->getMessage(),
+			'exception' => $exception::class,
+		]]);
+
+		return $result->toArray();
 	}
 
 	protected function getDeltasFromDB(&$iteration, ?string $batch = null): array
@@ -327,9 +427,24 @@ class DatasourceManager extends Service {
 		return $default;
 	}
 
-	private function loadGenerators()
+	protected function loadGenerators(): array
 	{
 		return scandir($this->_generatorDir);
+	}
+
+	protected function generatorDirectoryExists(): bool
+	{
+		return Flag::parseBool(Arr::getPath(Path::readiness($this->_generatorDir), 'exists', false));
+	}
+
+	protected function includeGenerator(string $path): void
+	{
+		include_once($path);
+	}
+
+	protected function generatorInstance(string $classname): object
+	{
+		return \App::makeInstance($classname);
 	}
 
 	protected function loadDeltas( $reverse = SCANDIR_SORT_ASCENDING )

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -506,6 +506,26 @@ class AddOnManagerTest extends TestCase
         $this->assertSame(['001_initial.php'], $datasource->appliedFor('demo'));
     }
 
+    public function testPopulationFailurePreventsHooksAndRegistrationWrite(): void
+    {
+        $this->writeDefinition('demo');
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $datasource->failPopulation('DemoSeeder.php failed.');
+        $manager = new TestableAddOnManager($model, $datasource);
+
+        $result = $manager->install('demo');
+
+        $this->assertFalse($result['ok']);
+        $this->assertFalse($result['changed']);
+        $this->assertSame('datasource', $result['stage']);
+        $this->assertSame('review_population_failure', $result['nextAction']);
+        $this->assertSame('DemoSeeder.php failed.', $result['error']);
+        $this->assertSame('DemoSeeder.php', $result['population']['results'][0]['name']);
+        $this->assertSame(1, $datasource->populationRuns);
+        $this->assertSame([], $model->records);
+    }
+
     public function testFailedTeardownPreservesRegistrationForRetry(): void
     {
         $this->writeDefinition('demo');
@@ -764,6 +784,7 @@ class FakeDatasourceManager
     private array $published = [];
     private array $applied = [];
     private ?string $failedMigration = null;
+    private ?string $populationError = null;
 
     public function __construct(private bool $failRollback = false)
     {
@@ -792,6 +813,11 @@ class FakeDatasourceManager
     public function appliedFor(string $batch): array
     {
         return $this->applied[$batch] ?? [];
+    }
+
+    public function failPopulation(?string $message): void
+    {
+        $this->populationError = $message;
     }
 
     public function runMigrations(string $batch): array
@@ -843,9 +869,41 @@ class FakeDatasourceManager
         ];
     }
 
-    public function populate(): void
+    public function populate(): array
     {
         $this->populationRuns++;
+
+        if (\BlueFission\Val::isNotEmpty($this->populationError)) {
+            return [
+                'ok' => false,
+                'changed' => false,
+                'stage' => 'population',
+                'total' => 1,
+                'populated' => 0,
+                'failed' => 1,
+                'results' => [[
+                    'ok' => false,
+                    'name' => 'DemoSeeder.php',
+                    'status' => 'failed',
+                    'error' => $this->populationError,
+                    'exception' => \RuntimeException::class,
+                ]],
+                'nextAction' => 'review_population_failure',
+                'error' => $this->populationError,
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'changed' => false,
+            'stage' => 'complete',
+            'total' => 0,
+            'populated' => 0,
+            'failed' => 0,
+            'results' => [],
+            'nextAction' => null,
+            'error' => null,
+        ];
     }
 
     public function revertBatch(string $batch): void

--- a/tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Business\Managers;
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use PHPUnit\Framework\TestCase;
+
+class DatasourceManagerPopulationTest extends TestCase
+{
+    public function testMissingGeneratorDirectoryReturnsStructuredNoOp(): void
+    {
+        $result = (new ExecutablePopulationManager([], directoryExists: false))->populate();
+
+        $this->assertTrue($result['ok']);
+        $this->assertFalse($result['changed']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertSame(0, $result['total']);
+        $this->assertSame([], $result['results']);
+    }
+
+    public function testRootSeederOrderProducesStructuredSuccess(): void
+    {
+        $manager = new ExecutablePopulationManager([
+            'RootSeeder.php',
+            'FirstSeeder.php',
+            'SecondSeeder.php',
+        ], rootOrder: ['SecondSeeder', 'FirstSeeder.php']);
+
+        $result = $manager->populate(true);
+
+        $this->assertTrue($result['ok']);
+        $this->assertTrue($result['changed']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertSame(2, $result['populated']);
+        $this->assertSame(['SecondSeeder.php', 'FirstSeeder.php'], $manager->populated());
+        $this->assertSame([true, true], $manager->autoValues());
+    }
+
+    public function testGeneratorFailureStopsLaterPopulationAndPreservesDiagnostics(): void
+    {
+        $manager = new ExecutablePopulationManager([
+            'FirstSeeder.php',
+            'FailingSeeder.php',
+            'AfterSeeder.php',
+        ]);
+        $manager->failOn('FailingSeeder.php');
+
+        $result = $manager->populate();
+
+        $this->assertFalse($result['ok']);
+        $this->assertTrue($result['changed']);
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame(1, $result['populated']);
+        $this->assertSame(1, $result['failed']);
+        $this->assertSame('review_population_failure', $result['nextAction']);
+        $this->assertSame('FailingSeeder.php failed.', $result['error']);
+        $this->assertSame(['FirstSeeder.php', 'FailingSeeder.php'], $manager->populated());
+        $this->assertSame('failed', $result['results'][1]['status']);
+        $this->assertSame(\RuntimeException::class, $result['results'][1]['exception']);
+    }
+}
+
+class ExecutablePopulationManager extends DatasourceManager
+{
+    private array $completed = [];
+    private array $auto = [];
+    private ?string $failedGenerator = null;
+
+    public function __construct(
+        private array $available,
+        private bool $directoryExists = true,
+        private array $rootOrder = []
+    ) {
+        $this->_generatorDir = 'virtual' . DIRECTORY_SEPARATOR;
+    }
+
+    public function failOn(?string $generator): void
+    {
+        $this->failedGenerator = $generator;
+    }
+
+    public function populated(): array
+    {
+        return $this->completed;
+    }
+
+    public function autoValues(): array
+    {
+        return $this->auto;
+    }
+
+    protected function generatorDirectoryExists(): bool
+    {
+        return $this->directoryExists;
+    }
+
+    protected function loadGenerators(): array
+    {
+        return Arr::make(['.', '..'])->merge($this->available)->toArray();
+    }
+
+    protected function findClassName($file): ?string
+    {
+        return basename((string)$file);
+    }
+
+    protected function includeGenerator(string $path): void
+    {
+    }
+
+    protected function generatorInstance(string $classname): object
+    {
+        if ($classname === 'RootSeeder.php' && Arr::isNotEmpty($this->rootOrder)) {
+            return new TestRootSeeder($this->rootOrder);
+        }
+
+        return new TestPopulationGenerator(
+            $classname,
+            $this->failedGenerator === $classname,
+            function (string $name, bool $auto): void {
+                $this->completed[] = $name;
+                $this->auto[] = $auto;
+            }
+        );
+    }
+}
+
+class TestRootSeeder
+{
+    public function __construct(private array $order)
+    {
+    }
+
+    public function seeders(): array
+    {
+        return $this->order;
+    }
+}
+
+class TestPopulationGenerator
+{
+    public function __construct(
+        private string $name,
+        private bool $fails,
+        private $onPopulate
+    ) {
+    }
+
+    public function populate(bool $auto): void
+    {
+        ($this->onPopulate)($this->name, $auto);
+
+        if ($this->fails) {
+            throw new \RuntimeException("{$this->name} failed.");
+        }
+    }
+}


### PR DESCRIPTION
## Intent

Return fail-closed, structured datasource population outcomes during add-on installation.

This branch builds on PR #63's structured migration contract. It targets `main`; after #63 merges, this PR should be rebased and its diff will narrow to population behavior only.

## User Stories / Acceptance Criteria

- Report aggregate and per-generator population outcomes.
- Preserve root-seeder ordering.
- Stop after the first material generator failure and preserve exception diagnostics.
- Keep migration and population result blocks distinct.
- Prevent hooks and registration writes after population failure.
- Use review guidance rather than claiming arbitrary seeders are retry-idempotent.

## Key Files Changed

- `src/BlueCore/Business/Managers/DatasourceManager.php`
- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `docs/extension-registration-contracts.md`

## How To Test

- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `composer ci`

## QA Checklist

- [x] Focused suite passes: 32 tests, 161 assertions
- [x] Full suite passes: 94 tests, 349 assertions
- [x] Missing generator directories return a structured no-op
- [x] Root-seeder order is preserved
- [x] Failure stops later generators and prevents registration writes

## Approval Conditions

- PR #63 lands first, followed by a rebase onto current `main`.
- Review confirms the result shape is consistent with migration lifecycle results.
- Review confirms the next action does not imply automatic retry safety.
- Opt-in database-backed population evidence is completed in an approved environment.

Closes #65
