### PR TITLE
Expose passive add-on metadata contributions

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -14,6 +14,15 @@ An extension can describe its contribution through a `RegistrationPlan`:
 
 Registrars implement `BlueFission\BlueCore\Contracts\IApplicationRegistrar` and receive both the application instance and a mutable `RegistrationPlan`.
 
+## Passive Contributions
+
+`loadActivatedContributions($name)` discovers optional `mapping/<name>.php`
+snapshots from active add-ons. Each file must return an array containing passive
+data only; callable and object values are rejected and never invoked. Results retain
+add-on identity, missing or failed status, diagnostics, and a deterministic revision
+that changes with the active contribution snapshot. BlueCore does not cache these
+results or validate domain-specific schemas.
+
 ## Add-on Lifecycle
 
 Add-on lifecycle managers implement `IAddOnLifecycleManager`:

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -9,6 +9,7 @@ use BlueFission\Data\Storage\Storage;
 use BlueFission\Func;
 use BlueFission\Net\HTTP;
 use BlueFission\Flag;
+use BlueFission\Security\Hash;
 use BlueFission\BlueCore\Registration\RegistrationPlan;
 use BlueFission\BlueCore\Contracts\IAddOnLifecycleManager;
 use BlueFission\Services\Application;
@@ -288,6 +289,164 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
         }
 
         return $results->toArray();
+    }
+
+    public function loadActivatedContributions(string $name): array
+    {
+        $name = Str::lower(Str::trim($name));
+        if (Val::isEmpty($name) || !Str::matchPattern($name, '/^[a-z0-9][a-z0-9._-]*$/')) {
+            throw new \InvalidArgumentException('Contribution names must be safe file identifiers.');
+        }
+
+        $entries = Arr::make([]);
+        foreach ($this->_model->getActivatedAddOns() as $record) {
+            $addOn = new AddOn;
+            $addOn->assign($record);
+            $entries->push($this->loadContribution($addOn, $name));
+        }
+
+        $failed = $entries
+            ->filter(fn ($entry) => Str::match((string)Arr::getPath($entry, 'status'), 'failed'))
+            ->values();
+        $loaded = $entries
+            ->filter(fn ($entry) => Str::match((string)Arr::getPath($entry, 'status'), 'loaded'))
+            ->values();
+        $missing = $entries
+            ->filter(fn ($entry) => Str::match((string)Arr::getPath($entry, 'status'), 'missing'))
+            ->values();
+        $snapshot = $entries->toArray();
+
+        return Arr::make([
+            'ok' => Arr::isEmpty($failed->toArray()),
+            'name' => $name,
+            'revision' => Hash::value(HTTP::jsonEncode($snapshot), 'sha256'),
+            'total' => Arr::size($snapshot),
+            'loaded' => $loaded->count(),
+            'missing' => $missing->count(),
+            'failed' => $failed->count(),
+            'results' => $snapshot,
+        ])->toArray();
+    }
+
+    protected function loadContribution(AddOn $addOn, string $name): array
+    {
+        $resolution = $this->resolveContributionFile($addOn, $name);
+        $entry = Arr::make([
+            'ok' => true,
+            'addonId' => $addOn->addon_id,
+            'addon' => $addOn->name,
+            'name' => $name,
+            'status' => $resolution['status'],
+            'path' => $resolution['path'],
+            'attempted' => $resolution['attempted'],
+            'data' => [],
+            'error' => $resolution['error'],
+            'exception' => null,
+        ]);
+
+        if (Str::match($resolution['status'], 'missing')) {
+            return $entry->toArray();
+        }
+
+        if (Flag::isFalse($resolution['ok'])) {
+            $entry->set('ok', false);
+            $entry->set('status', 'failed');
+
+            return $entry->toArray();
+        }
+
+        try {
+            $data = $this->includeContribution($resolution['path']);
+            if (!Arr::is($data) || Flag::isFalse($this->isPassiveContribution($data))) {
+                throw new \UnexpectedValueException(
+                    'Contribution files must return arrays containing only passive data.'
+                );
+            }
+
+            $entry->set('status', 'loaded');
+            $entry->set('data', Arr::make($data)->toArray());
+        } catch (\Throwable $exception) {
+            $entry->set('ok', false);
+            $entry->set('status', 'failed');
+            $entry->set('error', $exception->getMessage());
+            $entry->set('exception', $exception::class);
+        }
+
+        return $entry->toArray();
+    }
+
+    protected function includeContribution(string $path): mixed
+    {
+        return include($path);
+    }
+
+    private function resolveContributionFile(AddOn $addOn, string $name): array
+    {
+        $addOnName = $this->normalizeAddOnIdentifier($addOn->name, 'name');
+        $relative = 'mapping' . DIRECTORY_SEPARATOR . $name . '.php';
+        $canonicalRoot = Path::normalize(resolve_path('addons' . DIRECTORY_SEPARATOR . $addOnName));
+        $configuredRoot = Path::normalize((string)$addOn->path);
+        $candidates = Arr::make([]);
+
+        if (Val::isNotEmpty($configuredRoot)) {
+            $candidates->push(Path::normalize($configuredRoot . DIRECTORY_SEPARATOR . $relative));
+        }
+
+        $canonical = Path::normalize($canonicalRoot . DIRECTORY_SEPARATOR . $relative);
+        if (Val::isEmpty($configuredRoot) || Flag::isFalse($candidates->has($canonical))) {
+            $candidates->push($canonical);
+        }
+
+        foreach ($candidates as $candidate) {
+            if (!(new File())->isReachable($candidate)) {
+                continue;
+            }
+
+            if (Flag::isFalse($this->primaryFileIsContained($candidate, $canonicalRoot))) {
+                return Arr::make([
+                    'ok' => false,
+                    'status' => 'unsafe',
+                    'path' => null,
+                    'attempted' => $candidates->toArray(),
+                    'error' => 'Contribution file escapes its configured add-on root.',
+                ])->toArray();
+            }
+
+            return Arr::make([
+                'ok' => true,
+                'status' => 'resolved',
+                'path' => Path::normalize(realpath($candidate)),
+                'attempted' => $candidates->toArray(),
+                'error' => null,
+            ])->toArray();
+        }
+
+        return Arr::make([
+            'ok' => true,
+            'status' => 'missing',
+            'path' => null,
+            'attempted' => $candidates->toArray(),
+            'error' => null,
+        ])->toArray();
+    }
+
+    private function isPassiveContribution(mixed $value): bool
+    {
+        if (Func::isCallable($value) || is_object($value) || is_resource($value)) {
+            return false;
+        }
+
+        if (!Arr::is($value)) {
+            return true;
+        }
+
+        foreach ($value as $item) {
+            if (Flag::isFalse($this->isPassiveContribution($item))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     protected function loadAddOn(AddOn $addOn): array

--- a/src/BlueCore/Contracts/IAddOnLifecycleManager.php
+++ b/src/BlueCore/Contracts/IAddOnLifecycleManager.php
@@ -15,4 +15,5 @@ interface IAddOnLifecycleManager
         ?Application $application = null,
         ?RegistrationPlan $plan = null
     ): array;
+    public function loadActivatedContributions(string $name): array;
 }

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -238,6 +238,80 @@ class AddOnManagerTest extends TestCase
         $this->assertNotEmpty($result['error']);
     }
 
+    public function testPassiveContributionsIncludeOnlyActiveAddOnsAndExposeRevisionChanges(): void
+    {
+        $firstPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'first';
+        $secondPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'second';
+        File::ensureFile(
+            $firstPath . DIRECTORY_SEPARATOR . 'mapping' . DIRECTORY_SEPARATOR . 'capabilities.php',
+            "<?php return ['tools' => ['first']];",
+            true
+        );
+        File::ensureFile(
+            $secondPath . DIRECTORY_SEPARATOR . 'mapping' . DIRECTORY_SEPARATOR . 'capabilities.php',
+            "<?php return ['tools' => ['second']];",
+            true
+        );
+        $model = new FakeAddOnModel([
+            ['addon_id' => 1, 'name' => 'first', 'path' => $firstPath, 'is_active' => 1],
+            ['addon_id' => 2, 'name' => 'second', 'path' => $secondPath, 'is_active' => 0],
+        ]);
+        $manager = new TestableAddOnManager($model);
+
+        $initial = $manager->loadActivatedContributions('capabilities');
+        $manager->activate(2);
+        $activated = $manager->loadActivatedContributions('capabilities');
+
+        $this->assertTrue($initial['ok']);
+        $this->assertSame(1, $initial['total']);
+        $this->assertSame('first', $initial['results'][0]['addon']);
+        $this->assertSame(['tools' => ['first']], $initial['results'][0]['data']);
+        $this->assertSame(2, $activated['total']);
+        $this->assertNotSame($initial['revision'], $activated['revision']);
+    }
+
+    public function testPassiveContributionsReportMissingMalformedAndFailedFiles(): void
+    {
+        $missingPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'missing';
+        $malformedPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'malformed';
+        $failedPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'failed';
+        Path::ensureDir($missingPath);
+        File::ensureFile(
+            $malformedPath . DIRECTORY_SEPARATOR . 'mapping' . DIRECTORY_SEPARATOR . 'capabilities.php',
+            "<?php return ['factory' => static function (): void {}];",
+            true
+        );
+        File::ensureFile(
+            $failedPath . DIRECTORY_SEPARATOR . 'mapping' . DIRECTORY_SEPARATOR . 'capabilities.php',
+            "<?php throw new RuntimeException('Contribution failed.');",
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel([
+            ['addon_id' => 1, 'name' => 'missing', 'path' => $missingPath, 'is_active' => 1],
+            ['addon_id' => 2, 'name' => 'malformed', 'path' => $malformedPath, 'is_active' => 1],
+            ['addon_id' => 3, 'name' => 'failed', 'path' => $failedPath, 'is_active' => 1],
+        ]));
+
+        $result = $manager->loadActivatedContributions('capabilities');
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(3, $result['total']);
+        $this->assertSame(1, $result['missing']);
+        $this->assertSame(2, $result['failed']);
+        $this->assertSame('missing', $result['results'][0]['status']);
+        $this->assertSame('failed', $result['results'][1]['status']);
+        $this->assertSame(\UnexpectedValueException::class, $result['results'][1]['exception']);
+        $this->assertSame('Contribution failed.', $result['results'][2]['error']);
+    }
+
+    public function testPassiveContributionNamesRejectPathTraversal(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $manager->loadActivatedContributions('../capabilities');
+    }
+
     public function testPrimaryFilePrefersReachableConfiguredCandidate(): void
     {
         $manager = new TestableAddOnManager(new FakeAddOnModel());


### PR DESCRIPTION
## Intent

Expose lifecycle-aware, passive add-on metadata contributions through a package-neutral discovery API.

This branch builds on PR #59's registration interface changes. It targets `main`; after #59 merges, this PR should be rebased and its diff will narrow to passive contribution behavior only.

## User Stories / Acceptance Criteria

- Discover named `mapping/<name>.php` snapshots from active add-ons only.
- Preserve add-on identity and per-file status in every result.
- Accept passive array/scalar data while rejecting callable, object, and resource values.
- Never invoke values returned by contribution files.
- Treat missing optional files as visible, nonfatal results.
- Preserve thrown and malformed-file diagnostics.
- Return a deterministic revision for cache invalidation after lifecycle or data changes.
- Leave domain schema validation outside BlueCore.

## Key Files Changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `src/BlueCore/Contracts/IAddOnLifecycleManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `docs/extension-registration-contracts.md`

## How To Test

- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `composer ci`

## QA Checklist

- [x] Focused suite passes: 29 tests, 130 assertions
- [x] Full suite passes: 91 tests, 318 assertions
- [x] Active/inactive transitions alter the snapshot revision
- [x] Missing, malformed, failed, and traversal cases are covered
- [x] Returned callables are rejected and never invoked

## Approval Conditions

- PR #59 lands first, followed by a rebase onto current `main`.
- Review confirms `loadActivatedContributions(string $name)` is sufficiently general.
- Review confirms including trusted PHP mapping files is an acceptable package boundary.
- Review confirms immutable snapshot results are preferable to domain-specific registration-plan sections.

Closes #67
