### PR TITLE
Normalize optional add-on lifecycle hook outcomes

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -26,6 +26,12 @@ Add-on lifecycle managers implement `IAddOnLifecycleManager`:
 
 Lifecycle methods return structured arrays so callers can compose results, log decisions, and avoid process termination.
 
+Install and uninstall hooks are optional. When a reachable primary file has no
+compatible hook callable, the hook result is `ok=true`, `status=skipped`, and
+`optional=true`. A missing or unsafe configured primary file remains blocking, as
+does an exception thrown by a discovered hook. Blocking hook failures stop before
+registration state is written or removed and retain structured retry diagnostics.
+
 An active add-on primary file may return a callable registration factory. When
 the application and baseline registration plan are supplied together, BlueCore
 invokes that factory with `(Application $application, RegistrationPlan $plan)`

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -68,6 +68,14 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
         $addon->assign($data);
         $addon->path = $addOnPath;
 
+        $hookPreflight = $this->resolvePrimaryFile($addon);
+        if (Flag::isFalse($hookPreflight['ok'])) {
+            $hookResult = $this->callHook($addon, 'install');
+            $result['hooks'][] = $hookResult;
+
+            return $this->withHookFailure($result, $hookResult, 'install');
+        }
+
         $datasource = $this->datasourceManager();
         $datasource->setDeltaDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'structure' . DIRECTORY_SEPARATOR);
         $datasource->setGeneratorDirectory($addon->path . DIRECTORY_SEPARATOR . 'datasources' . DIRECTORY_SEPARATOR . 'generator' . DIRECTORY_SEPARATOR);
@@ -81,6 +89,10 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
         if (Arr::is($hookResult)) {
             $result['hooks'][] = $hookResult;
         }
+        if (Flag::isFalse(Arr::getPath($hookResult, 'ok', false))) {
+            return $this->withHookFailure($result, $hookResult, 'install');
+        }
+
         $this->_model->write($addon);
         $result['changed'] = true;
         $result['stage'] = 'complete';
@@ -115,6 +127,9 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             $hookResult = $this->callHook($addon, 'uninstall');
             if (Arr::is($hookResult)) {
                 $result['hooks'][] = $hookResult;
+            }
+            if (Flag::isFalse(Arr::getPath($hookResult, 'ok', false))) {
+                return $this->withHookFailure($result, $hookResult, 'uninstall');
             }
 
             $result['stage'] = 'definition';
@@ -345,18 +360,23 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
         $result = Arr::make([
             'ok' => false,
             'hook' => $hook,
+            'stage' => 'hook',
             'status' => 'pending',
+            'optional' => false,
             'strategy' => null,
             'callable' => null,
             'attempted' => [],
             'primaryFile' => $resolution['path'],
             'primaryFileResolution' => $resolution,
             'error' => null,
+            'exception' => null,
+            'nextAction' => null,
         ]);
 
         if (Flag::isFalse($resolution['ok'])) {
             $result->set('status', $resolution['status']);
             $result->set('error', $resolution['error']);
+            $result->set('nextAction', 'review_primary_file');
 
             return $result->toArray();
         }
@@ -377,19 +397,42 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
                 continue;
             }
 
-            Func::make($candidate)->call();
-            $result->set('ok', true);
-            $result->set('status', 'called');
-            $result->set('strategy', $candidate === $legacyHook ? 'legacy' : 'namespaced');
-            $result->set('callable', $candidate);
+            try {
+                Func::make($candidate)->call();
+                $result->set('ok', true);
+                $result->set('status', 'called');
+                $result->set('strategy', $candidate === $legacyHook ? 'legacy' : 'namespaced');
+                $result->set('callable', $candidate);
+            } catch (\Throwable $exception) {
+                $result->set('status', 'failed');
+                $result->set('strategy', $candidate === $legacyHook ? 'legacy' : 'namespaced');
+                $result->set('callable', $candidate);
+                $result->set('error', $exception->getMessage());
+                $result->set('exception', $exception::class);
+                $result->set('nextAction', 'retry_hook');
+            }
 
             return $result->toArray();
         }
 
-        $result->set('status', 'missing_callable');
-        $result->set('error', 'No compatible lifecycle hook callable was found.');
+		$result->set('ok', true);
+		$result->set('status', 'skipped');
+		$result->set('optional', true);
 
-        return $result->toArray();
+		return $result->toArray();
+	}
+
+    private function withHookFailure(array $result, array $hookResult, string $action): array
+    {
+        $result['ok'] = false;
+        $result['changed'] = false;
+        $result['stage'] = 'hook';
+        $result['nextAction'] = Arr::getPath($hookResult, 'nextAction', "retry_{$action}");
+        $result['error'] = Arr::getPath($hookResult, 'error', 'Add-on lifecycle hook failed.');
+        $result['messages'][] = $result['error'];
+        $result['modelStatus'] = $this->_model->status();
+
+        return $result;
     }
 
     protected function resolvePrimaryFile(AddOn $addOn): array

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -214,7 +214,7 @@ class AddOnManagerTest extends TestCase
         $this->assertSame(['namespaced', 'legacy'], $GLOBALS['bluecore_hook_calls']);
     }
 
-    public function testMissingHookReturnsStructuredDiagnostics(): void
+    public function testMissingHookReturnsOptionalSkippedOutcome(): void
     {
         $manager = new TestableAddOnManager(new FakeAddOnModel());
         $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'missing';
@@ -229,13 +229,98 @@ class AddOnManagerTest extends TestCase
 
         $result = $manager->hook($addOn, 'install');
 
-        $this->assertFalse($result['ok']);
-        $this->assertSame('missing_callable', $result['status']);
+        $this->assertTrue($result['ok']);
+        $this->assertTrue($result['optional']);
+        $this->assertSame('skipped', $result['status']);
         $this->assertSame(
             ['Vendor\\Package\\missing_install', 'missing_install'],
             $result['attempted']
         );
-        $this->assertNotEmpty($result['error']);
+        $this->assertNull($result['error']);
+    }
+
+    public function testInstallBlocksBeforeDatasourceWhenPrimaryFileIsMissing(): void
+    {
+        $this->writeDefinition('missingprimary', createPrimaryFile: false);
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $manager = new TestableAddOnManager($model, $datasource);
+
+        $result = $manager->install('missingprimary');
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('hook', $result['stage']);
+        $this->assertSame('missing_primary_file', $result['hooks'][0]['status']);
+        $this->assertFalse($result['hooks'][0]['optional']);
+        $this->assertSame(0, $datasource->migrationRuns);
+        $this->assertSame([], $model->records);
+    }
+
+    public function testThrownInstallHookPreventsRegistrationWrite(): void
+    {
+        $this->writeDefinition('failinginstall');
+        File::ensureFile(
+            self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'failinginstall' . DIRECTORY_SEPARATOR . 'main.php',
+            "<?php function failinginstall_install(): void { throw new RuntimeException('Install hook failed.'); }",
+            true
+        );
+        $model = new FakeAddOnModel();
+        $manager = new TestableAddOnManager($model, new FakeDatasourceManager());
+
+        $result = $manager->install('failinginstall');
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('hook', $result['stage']);
+        $this->assertSame('failed', $result['hooks'][0]['status']);
+        $this->assertSame(\RuntimeException::class, $result['hooks'][0]['exception']);
+        $this->assertSame('retry_hook', $result['nextAction']);
+        $this->assertSame([], $model->records);
+    }
+
+    public function testThrownUninstallHookPreservesRegistration(): void
+    {
+        $this->writeDefinition('failinguninstall');
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'failinguninstall';
+        File::ensureFile(
+            $path . DIRECTORY_SEPARATOR . 'main.php',
+            "<?php function failinguninstall_uninstall(): void { throw new RuntimeException('Uninstall hook failed.'); }",
+            true
+        );
+        $model = new FakeAddOnModel([[
+            'addon_id' => 9,
+            'name' => 'failinguninstall',
+            'path' => $path,
+            'primary_file' => 'main.php',
+            'is_active' => 1,
+        ]]);
+        $manager = new TestableAddOnManager($model, new FakeDatasourceManager());
+
+        $result = $manager->uninstall(9);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('hook', $result['stage']);
+        $this->assertSame('Uninstall hook failed.', $result['error']);
+        $this->assertCount(1, $model->records);
+        $this->assertSame([], $model->deletes);
+    }
+
+    public function testInstallAllCountsNormalizedHookOutcomes(): void
+    {
+        $this->writeDefinition('batchgood');
+        $this->writeDefinition('batchfail');
+        File::ensureFile(
+            self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'batchfail' . DIRECTORY_SEPARATOR . 'main.php',
+            "<?php function batchfail_install(): void { throw new RuntimeException('Batch hook failed.'); }",
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel(), new FakeDatasourceManager());
+
+        $result = $manager->installAll();
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(1, $result['succeeded']);
+        $this->assertSame(1, $result['failed']);
     }
 
     public function testPrimaryFilePrefersReachableConfiguredCandidate(): void
@@ -610,7 +695,7 @@ PHP,
         $this->assertSame([], $model->records);
     }
 
-    private function writeDefinition(string $name): void
+    private function writeDefinition(string $name, bool $createPrimaryFile = true): void
     {
         File::ensureFile(
             self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . $name . DIRECTORY_SEPARATOR . 'definition.json',
@@ -621,6 +706,14 @@ PHP,
             ]),
             true
         );
+
+        if ($createPrimaryFile) {
+            File::ensureFile(
+                self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . $name . DIRECTORY_SEPARATOR . 'main.php',
+                '<?php',
+                true
+            );
+        }
     }
 
     private function removeDir($dir): void


### PR DESCRIPTION
## Intent

Normalize optional and blocking add-on hook outcomes so lifecycle aggregates report material success accurately.

This branch builds on PR #59's registration interface changes. It targets `main`; after #59 merges, this PR should be rebased and its diff will narrow to hook outcome behavior only.

## User Stories / Acceptance Criteria

- Treat absent install and uninstall callables as successful optional skips.
- Keep missing or unsafe configured primary files blocking.
- Preserve thrown hook exception class, message, stage, and next action.
- Preflight required primary files before datasource work.
- Prevent installation registration writes after hook failure.
- Preserve installed registration after uninstall hook failure.
- Derive bulk success and counts from normalized child results.

## Key Files Changed

- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `docs/extension-registration-contracts.md`

## How To Test

- `vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Business/Managers/AddOnManagerTest.php`
- `composer ci`

## QA Checklist

- [x] Focused suite passes: 30 tests, 137 assertions
- [x] Full suite passes: 92 tests, 325 assertions
- [x] Optional, missing-file, thrown install, thrown uninstall, and batch cases are covered
- [x] Failed hooks do not write or remove registration state

## Approval Conditions

- PR #59 lands first, followed by a rebase onto current `main`.
- Review confirms lifecycle callables are optional while configured primary files are required.
- Review confirms failed uninstall hooks preserve registration for operator review.
- Full CI passes on PHP 8.2 and 8.3.

Closes #70
