### PR TITLE
Prepare v0.1.2 alpha release contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ BlueCore provides core functionality and architecture for modular, scalable web 
 BlueCore requires PHP 8.2 or newer. Install the current alpha release through Composer:
 
 ```bash
-composer require bluefission/bluecore:^0.1.0-alpha
+composer require bluefission/bluecore:^0.1.2@alpha
 ```
 
 The alpha line is intended for integration testing while the public API is finalized. Pin an explicit alpha constraint in reproducible environments.

--- a/docs/releases/v0.1.2-alpha.md
+++ b/docs/releases/v0.1.2-alpha.md
@@ -1,0 +1,16 @@
+# BlueCore v0.1.2-alpha
+
+This alpha release consolidates the reviewed add-on installer and lifecycle contracts introduced after `v0.1.1-alpha`.
+
+## Compatibility
+
+- PHP 8.2 and 8.3 remain supported.
+- DevElation `^1.3.41` remains the minimum supported dependency line.
+- Composer projects should use `bluefission/bluecore:^0.1.2@alpha` when adopting this release.
+- Add-on primary files may return registration factories. Hosts execute active factories once through the normal registration boundary.
+- Add-on lifecycle operations preserve persisted collection records, apply pending datasource changes explicitly, and report migration, population, hook, and contribution outcomes as structured results.
+- Clean Composer installs place project and add-on packages in their canonical topology in one transaction. A second reinstall is not part of the supported workflow.
+
+## Release Gate
+
+The tag must be created from reviewed `main` only after all included pull requests are merged. Before tagging, run strict Composer validation, lint, PHPUnit, the clean installer integration matrix, and a dependency audit. After publishing the prerelease, verify that Packagist resolves the tag to the same commit before announcing the constraint as consumable.

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -94,10 +94,16 @@ final class ComposerMetadataTest extends TestCase
     public function testReleaseDocumentationUsesAlphaConstraint(): void
     {
         $readme = Str::make(File::readContents($this->rootFile('README.md')));
+        $release = Str::make(
+            File::readContents($this->rootFile('docs/releases/v0.1.2-alpha.md'))
+        );
 
         $this->assertTrue(
-            $readme->has('composer require bluefission/bluecore:^0.1.0-alpha')
+            $readme->has('composer require bluefission/bluecore:^0.1.2@alpha')
         );
+        $this->assertTrue($release->has('bluefission/bluecore:^0.1.2@alpha'));
+        $this->assertTrue($release->has('DevElation `^1.3.41`'));
+        $this->assertTrue($release->has('Packagist resolves the tag to the same commit'));
     }
 
     public function testContinuousIntegrationCoversSupportedPhpVersions(): void


### PR DESCRIPTION
## Intent

Prepare the public compatibility and verification contract for the `v0.1.2-alpha` release. This PR is release-facing only and must land after the installer and lifecycle PR stack included in that tag.

Addresses #73. The issue remains open until the tag is published and its exact source reference is verified on Packagist.

## User Stories / Acceptance Criteria

- Composer consumers have one explicit alpha constraint for the reviewed release.
- Release notes summarize the reusable installer and add-on lifecycle compatibility changes.
- The release contract requires the tag to originate from reviewed `main`.
- Packagist visibility and commit identity are verified before the constraint is announced as consumable.

## Key Files Changed

- `README.md`: updates the documented candidate constraint to `^0.1.2@alpha`.
- `docs/releases/v0.1.2-alpha.md`: records compatibility changes and the release gate.
- `tests/ComposerMetadataTest.php`: protects the constraint, dependency line, and Packagist verification language.

## How To Test

```bash
composer ci
COMPOSER_BINARY=/path/to/composer.phar php tests/Integration/project-installer-parity.php
composer audit
```

Local results:

- `composer ci`: 85 tests, 282 assertions.
- Project installer source/dist parity: passed with the Composer PHAR.
- `composer audit`: not completed locally because Packagist DNS resolution timed out; rerun in CI or a connected release environment.

## QA Checklist

- [x] Strict Composer validation passes.
- [x] PHP lint passes.
- [x] PHPUnit passes.
- [x] Existing source/dist installer parity fixture passes.
- [ ] Dependency audit passes in a connected environment.
- [ ] All included installer and lifecycle PRs are merged and green on the resulting `main`.
- [ ] `v0.1.2-alpha` is approved, tagged from `main`, and verified on Packagist.

## Approval Conditions

- Review confirms `v0.1.2-alpha` is the intended next immutable prerelease.
- Merge this PR last in the release stack.
- Do not announce the Composer constraint as available until Packagist resolves the exact release commit.
