### PR TITLE
Add optional Presence authentication bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,34 @@ throw new GatewayDenied('Forbidden', 403);
 
 Hosts can inspect `Engine::denied()` and `Engine::denial()` after processing when denial metadata is needed.
 
+### Optional Presence Bridge
+
+Applications with `bluefission/presence` installed may create the authenticated host bridge through the availability-safe factory:
+
+```php
+use BlueFission\BlueCore\Integration\Presence\PresenceBridgeFactory;
+use BlueFission\Presence\Bridge\BridgeContext;
+
+$bridge = PresenceBridgeFactory::make();
+$context = new BridgeContext();
+$context->host = 'bluecore';
+$context->authenticator = $authenticator;
+$context->session = [
+    'id' => $sessionId,
+    'type' => 'browser',
+];
+$context->metadata = [
+    'tenant_id' => $tenantId,
+    'action' => 'authenticate',
+];
+
+$result = $bridge->bind($context);
+```
+
+The bridge maps neutral identity and session values into Presence `Principal`, `AuthResult`, `Session`, and `Participant` contracts. An optional `annex_manifest` is ingested through Presence's Annex adapter. Unsupported or incomplete contexts return an unbound result with a stable reason and audit block.
+
+When Presence is unavailable, `PresenceBridgeFactory::make()` throws `PresenceBridgeUnavailable` with the `presence_contracts_unavailable` reason and the missing contract names. Bridge lifecycle extension points are exposed as `bluecore.presence.bridge.input`, `.before`, `.output`, and `.after` DevElation hooks.
+
 ### AI Integration
 
 BlueCore is designed to integrate seamlessly with AI libraries such as Automata (`bluefission/automata`), providing native compatibility and simplifying the process of building AI-powered applications.

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     "require-dev": {
         "phpunit/phpunit": "^11.1@dev"
     },
+    "suggest": {
+        "bluefission/presence": "Enables the optional authenticated host bridge for Presence identity, session, policy, and audit contracts."
+    },
     "scripts": {
         "lint": "@php scripts/lint.php",
         "test": "phpunit --do-not-cache-result tests",

--- a/src/BlueCore/Integration/Presence/PresenceAuthenticationBridge.php
+++ b/src/BlueCore/Integration/Presence/PresenceAuthenticationBridge.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace BlueFission\BlueCore\Integration\Presence;
+
+use BlueFission\Arr;
+use BlueFission\Collections\Collection;
+use BlueFission\DevElation as Dev;
+use BlueFission\Flag;
+use BlueFission\Func;
+use BlueFission\Obj;
+use BlueFission\Presence\Annex\AnnexAdapter;
+use BlueFission\Presence\Auth\AuthResult;
+use BlueFission\Presence\Auth\Principal;
+use BlueFission\Presence\Auth\PrincipalInterface;
+use BlueFission\Presence\Bridge\BridgeContext;
+use BlueFission\Presence\Bridge\BridgeInterface;
+use BlueFission\Presence\Bridge\BridgeResult;
+use BlueFission\Presence\Session\Participant;
+use BlueFission\Presence\Session\Session;
+use BlueFission\Presence\Session\SessionInterface;
+use BlueFission\Str;
+use BlueFission\Val;
+use Throwable;
+
+class PresenceAuthenticationBridge implements BridgeInterface
+{
+    public const HOST = 'bluecore';
+    public const NAME = 'bluecore.authentication';
+    public const HOOK_INPUT = 'bluecore.presence.bridge.input';
+    public const HOOK_BEFORE = 'bluecore.presence.bridge.before';
+    public const HOOK_OUTPUT = 'bluecore.presence.bridge.output';
+    public const HOOK_AFTER = 'bluecore.presence.bridge.after';
+
+    private Func $principalMapper;
+    private Func $sessionMapper;
+
+    public function __construct(
+        ?Func $principalMapper = null,
+        ?Func $sessionMapper = null,
+        private ?object $annexAdapter = null
+    ) {
+        $this->principalMapper = $principalMapper
+            ?? new Func(fn (mixed $authenticator, BridgeContext $context): PrincipalInterface =>
+                $this->mapPrincipal($authenticator, $context)
+            );
+        $this->sessionMapper = $sessionMapper
+            ?? new Func(fn (mixed $session, PrincipalInterface $principal, BridgeContext $context): array =>
+                $this->mapSession($session, $principal, $context)
+            );
+    }
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function supports(BridgeContext $context): bool
+    {
+        $host = Str::make((string)$context->host)->trim()->lower()->val();
+
+        return $host === self::HOST && Val::isNotNull($context->authenticator);
+    }
+
+    public function bind(BridgeContext $context): BridgeResult
+    {
+        $context = Dev::apply(self::HOOK_INPUT, $context);
+        Dev::do(self::HOOK_BEFORE, [$context, $this]);
+
+        try {
+            $result = $this->bindContext($context);
+        } catch (Throwable $exception) {
+            $result = $this->rejected(
+                $context,
+                'bridge_exception',
+                ['error_type' => $exception::class]
+            );
+        }
+
+        $result = Dev::apply(self::HOOK_OUTPUT, $result);
+        Dev::do(self::HOOK_AFTER, [$result, $this]);
+
+        return $result;
+    }
+
+    private function bindContext(BridgeContext $context): BridgeResult
+    {
+        if (!$this->supports($context)) {
+            $reason = Str::make((string)$context->host)->trim()->lower()->val() !== self::HOST
+                ? 'unsupported_host'
+                : 'missing_authenticator';
+
+            return $this->rejected($context, $reason);
+        }
+
+        $authenticator = $context->authenticator;
+        if (!Func::isCallable([$authenticator, 'isAuthenticated'])) {
+            return $this->rejected($context, 'invalid_authenticator');
+        }
+
+        if (!Flag::parseBool($authenticator->isAuthenticated())) {
+            return $this->rejected($context, 'unauthenticated');
+        }
+
+        $principalId = $this->principalId($authenticator);
+        if (Val::isEmpty($principalId)) {
+            return $this->rejected($context, 'missing_principal_id');
+        }
+
+        $sessionId = $this->sessionId($context->session, $context);
+        if (Val::isEmpty($sessionId)) {
+            return $this->rejected($context, 'missing_session_id', [
+                'principal_id' => $principalId,
+            ]);
+        }
+
+        $principal = $this->principalMapper->call($authenticator, $context);
+        if (!$principal instanceof PrincipalInterface) {
+            return $this->rejected($context, 'invalid_principal_mapping');
+        }
+
+        $sessionMapping = Arr::toArray(
+            $this->sessionMapper->call($context->session, $principal, $context),
+            true
+        );
+        $session = $sessionMapping['session'] ?? null;
+        $participant = $sessionMapping['participant'] ?? null;
+
+        if (!$session instanceof SessionInterface || !$participant instanceof Participant) {
+            return $this->rejected($context, 'invalid_session_mapping', [
+                'principal_id' => $principal->id(),
+                'session_id' => $sessionId,
+            ]);
+        }
+
+        $presenceContext = $this->mapContext($context, $session, $participant);
+        $trustContract = $this->mapAnnexManifest($context, $presenceContext);
+        if ($trustContract instanceof BridgeResult) {
+            return $trustContract;
+        }
+
+        $authResult = AuthResult::success($principal, null, [
+            'bridge' => $this->name(),
+            'host' => self::HOST,
+        ]);
+        $result = new BridgeResult();
+        $result->bound = true;
+        $result->context = $presenceContext;
+        $result->auth_result = $authResult;
+        $result->trust_contract = $trustContract;
+        $result->session = $session;
+        $result->reason = 'bound';
+        $result->metadata = $this->metadata($context, 'bound', true, [
+            'principal_id' => $principal->id(),
+            'session_id' => $session->id(),
+        ]);
+
+        return $result;
+    }
+
+    private function mapPrincipal(mixed $authenticator, BridgeContext $context): PrincipalInterface
+    {
+        $principal = new Principal();
+        $principal->id = $this->principalId($authenticator);
+        $principal->type = $this->stringValue($authenticator, 'type', 'user');
+
+        foreach ($this->roles($authenticator) as $role) {
+            $principal->roles()->add($role, $role);
+        }
+        foreach ($this->strings($this->value($authenticator, 'permissions', [])) as $permission) {
+            $principal->permissions()->add($permission, $permission);
+        }
+
+        $metadata = Arr::toArray($context->metadata ?? [], true);
+        $principal->attributes = Arr::make([
+            'username' => $this->stringValue($authenticator, 'username'),
+            'display_name' => $this->displayName($authenticator),
+            'group' => $this->stringValue($authenticator, 'group'),
+            'tenant_id' => (string)Arr::getPath($metadata, 'tenant_id', ''),
+        ])->filter(fn (mixed $value): bool => Val::isNotEmpty($value))->toArray(true);
+
+        return $principal;
+    }
+
+    private function mapSession(
+        mixed $hostSession,
+        PrincipalInterface $principal,
+        BridgeContext $context
+    ): array {
+        if ($hostSession instanceof SessionInterface) {
+            $session = $hostSession;
+        } else {
+            $session = new Session($this->sessionType($hostSession, $context));
+            $session->id = $this->sessionId($hostSession, $context);
+            $session->metadata = Arr::toArray($context->metadata ?? [], true);
+        }
+
+        $participant = new Participant();
+        $participant->id = $principal->id();
+        $participant->principal = $principal;
+        $participant->metadata = Arr::make([
+            'bridge' => $this->name(),
+            'host' => self::HOST,
+        ])->toArray(true);
+        $session->addParticipant($participant);
+
+        return Arr::make([
+            'session' => $session,
+            'participant' => $participant,
+        ])->toArray(true);
+    }
+
+    private function mapContext(
+        BridgeContext $bridgeContext,
+        SessionInterface $session,
+        Participant $participant
+    ): object {
+        $context = $bridgeContext->context();
+        $metadata = Arr::toArray($bridgeContext->metadata ?? [], true);
+        $context->session_id = $session->id();
+        $context->session_type = $session->type();
+        $context->tenant_id = (string)Arr::getPath($metadata, 'tenant_id', '');
+        $context->action = (string)Arr::getPath($metadata, 'action', 'authenticate');
+        $context->requested_privilege = (string)Arr::getPath($metadata, 'requested_privilege', '');
+        $context->current_privilege = (string)Arr::getPath($metadata, 'current_privilege', '');
+        $context->participant = $participant;
+        $context->session = $session;
+        $context->metadata = $metadata;
+
+        return $context;
+    }
+
+    private function mapAnnexManifest(BridgeContext $context, object $presenceContext): mixed
+    {
+        $manifest = Arr::toArray($context->annex_manifest ?? [], true);
+        if (Arr::isEmpty($manifest)) {
+            return null;
+        }
+
+        $adapter = $this->annexAdapter;
+        if (Val::isNull($adapter)) {
+            if (!class_exists(AnnexAdapter::class)) {
+                return $this->rejected($context, 'annex_adapter_unavailable');
+            }
+            $adapter = new AnnexAdapter();
+        }
+
+        if (!Func::isCallable([$adapter, 'ingest'])) {
+            return $this->rejected($context, 'invalid_annex_adapter');
+        }
+
+        $contract = $adapter->ingest($manifest);
+        if (Func::isCallable([$contract, 'applyTo'])) {
+            $contract->applyTo($presenceContext);
+        }
+
+        return $contract;
+    }
+
+    private function rejected(
+        BridgeContext $context,
+        string $reason,
+        array $details = []
+    ): BridgeResult {
+        $result = new BridgeResult();
+        $result->context = $context->context();
+        $result->reason = $reason;
+        $result->metadata = $this->metadata($context, $reason, false, $details);
+
+        return $result;
+    }
+
+    private function metadata(
+        BridgeContext $context,
+        string $reason,
+        bool $bound,
+        array $details = []
+    ): array {
+        $audit = Arr::make([
+            'bridge' => $this->name(),
+            'host' => Str::make((string)$context->host)->trim()->lower()->val(),
+            'reason' => $reason,
+            'bound' => Flag::parseBool($bound),
+        ])->merge($details)->toArray(true);
+
+        return Arr::make(Arr::toArray($context->metadata ?? [], true))
+            ->merge(['audit' => $audit])
+            ->toArray(true);
+    }
+
+    private function principalId(mixed $authenticator): string
+    {
+        $id = $this->stringValue($authenticator, 'id');
+
+        return Val::isNotEmpty($id)
+            ? $id
+            : $this->stringValue($authenticator, 'username');
+    }
+
+    private function displayName(mixed $authenticator): string
+    {
+        $displayName = $this->stringValue($authenticator, 'displayname');
+
+        return Val::isNotEmpty($displayName)
+            ? $displayName
+            : $this->stringValue($authenticator, 'display_name');
+    }
+
+    private function roles(mixed $authenticator): array
+    {
+        return Arr::make($this->strings($this->value($authenticator, 'roles', [])))
+            ->merge($this->strings($this->value($authenticator, 'role', [])))
+            ->merge($this->strings($this->value($authenticator, 'group', [])))
+            ->unique()
+            ->values()
+            ->toArray(true);
+    }
+
+    private function sessionId(mixed $session, BridgeContext $context): string
+    {
+        if ($session instanceof SessionInterface) {
+            return Str::make($session->id())->trim()->val();
+        }
+
+        $id = $this->stringValue($session, 'id');
+        if (Val::isEmpty($id)) {
+            $id = $this->stringValue($session, 'session_id');
+        }
+        if (Val::isEmpty($id)) {
+            $id = (string)Arr::getPath(
+                Arr::toArray($context->metadata ?? [], true),
+                'session_id',
+                ''
+            );
+        }
+
+        return Str::make($id)->trim()->val();
+    }
+
+    private function sessionType(mixed $session, BridgeContext $context): string
+    {
+        if ($session instanceof SessionInterface) {
+            return Str::make($session->type())->trim()->val();
+        }
+
+        $type = $this->stringValue($session, 'type');
+        if (Val::isEmpty($type)) {
+            $type = (string)Arr::getPath(
+                Arr::toArray($context->metadata ?? [], true),
+                'session_type',
+                'session'
+            );
+        }
+
+        return Str::make($type)->trim()->val();
+    }
+
+    private function stringValue(mixed $source, string $field, string $default = ''): string
+    {
+        return Str::make((string)$this->value($source, $field, $default))->trim()->val();
+    }
+
+    private function value(mixed $source, string $field, mixed $default = null): mixed
+    {
+        if ($source instanceof Obj) {
+            $value = $source->field($field);
+
+            return Val::isNotNull($value) ? $value : $default;
+        }
+
+        if (Arr::is($source)) {
+            return Arr::getPath($source, $field, $default);
+        }
+
+        if (is_object($source)) {
+            return $source->{$field} ?? $default;
+        }
+
+        return $default;
+    }
+
+    private function strings(mixed $value): array
+    {
+        if ($value instanceof Collection) {
+            $items = $value->toArray(true);
+        } elseif ($value instanceof Arr) {
+            $items = $value->toArray(true);
+        } elseif (Arr::is($value)) {
+            $items = Arr::toArray($value, true);
+        } elseif (Val::isNotEmpty($value)) {
+            $items = [$value];
+        } else {
+            $items = [];
+        }
+
+        return Arr::make($items)
+            ->map(fn (mixed $item): string => Str::make((string)$item)->trim()->val())
+            ->filter(fn (string $item): bool => Val::isNotEmpty($item))
+            ->unique()
+            ->values()
+            ->toArray(true);
+    }
+}

--- a/src/BlueCore/Integration/Presence/PresenceBridgeFactory.php
+++ b/src/BlueCore/Integration/Presence/PresenceBridgeFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BlueFission\BlueCore\Integration\Presence;
+
+use BlueFission\Arr;
+use BlueFission\Func;
+use BlueFission\Presence\Auth\AuthResult;
+use BlueFission\Presence\Auth\Principal;
+use BlueFission\Presence\Auth\PrincipalInterface;
+use BlueFission\Presence\Bridge\BridgeContext;
+use BlueFission\Presence\Bridge\BridgeInterface;
+use BlueFission\Presence\Bridge\BridgeResult;
+use BlueFission\Presence\Session\Participant;
+use BlueFission\Presence\Session\Session;
+use BlueFission\Presence\Session\SessionInterface;
+
+class PresenceBridgeFactory
+{
+    private const CONTRACTS = [
+        BridgeInterface::class => 'interface',
+        BridgeContext::class => 'class',
+        BridgeResult::class => 'class',
+        PrincipalInterface::class => 'interface',
+        Principal::class => 'class',
+        AuthResult::class => 'class',
+        SessionInterface::class => 'interface',
+        Session::class => 'class',
+        Participant::class => 'class',
+    ];
+
+    public static function available(): bool
+    {
+        return Arr::isEmpty(self::missingContracts());
+    }
+
+    public static function missingContracts(): array
+    {
+        $missing = Arr::make();
+
+        foreach (self::CONTRACTS as $contract => $type) {
+            $available = $type === 'interface'
+                ? interface_exists($contract)
+                : class_exists($contract);
+
+            if (!$available) {
+                $missing->push($contract);
+            }
+        }
+
+        return Arr::toArray($missing, true);
+    }
+
+    public static function make(
+        ?Func $principalMapper = null,
+        ?Func $sessionMapper = null,
+        ?object $annexAdapter = null
+    ): object {
+        $missing = self::missingContracts();
+
+        if (Arr::isNotEmpty($missing)) {
+            throw new PresenceBridgeUnavailable($missing);
+        }
+
+        return new PresenceAuthenticationBridge(
+            $principalMapper,
+            $sessionMapper,
+            $annexAdapter
+        );
+    }
+}

--- a/src/BlueCore/Integration/Presence/PresenceBridgeUnavailable.php
+++ b/src/BlueCore/Integration/Presence/PresenceBridgeUnavailable.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BlueFission\BlueCore\Integration\Presence;
+
+use BlueFission\Arr;
+use RuntimeException;
+
+class PresenceBridgeUnavailable extends RuntimeException
+{
+    private array $details;
+
+    public function __construct(array $missingContracts)
+    {
+        $this->details = Arr::make([
+            'reason' => 'presence_contracts_unavailable',
+            'missing_contracts' => Arr::toArray($missingContracts, true),
+        ])->toArray(true);
+
+        parent::__construct('Presence bridge contracts are unavailable.');
+    }
+
+    public function reason(): string
+    {
+        return (string)$this->details['reason'];
+    }
+
+    public function details(): array
+    {
+        return $this->details;
+    }
+}

--- a/tests/BlueCore/Integration/Presence/PresenceAuthenticationBridgeTest.php
+++ b/tests/BlueCore/Integration/Presence/PresenceAuthenticationBridgeTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace {
+    require_once dirname(__DIR__, 3)
+        . DIRECTORY_SEPARATOR . 'Fixtures'
+        . DIRECTORY_SEPARATOR . 'presence-contracts.php';
+}
+
+namespace BlueFission\Tests\BlueCore\Integration\Presence {
+    use BlueFission\Arr;
+    use BlueFission\BlueCore\Integration\Presence\PresenceAuthenticationBridge;
+    use BlueFission\BlueCore\Integration\Presence\PresenceBridgeFactory;
+    use BlueFission\DevElation as Dev;
+    use BlueFission\Presence\Bridge\BridgeContext;
+    use BlueFission\Presence\Bridge\BridgeInterface;
+    use BlueFission\Str;
+    use BlueFission\System\Process;
+    use BlueFission\Utils\Path;
+    use PHPUnit\Framework\TestCase;
+
+    class PresenceAuthenticationBridgeTest extends TestCase
+    {
+        protected function tearDown(): void
+        {
+            $this->resetDevElation();
+        }
+
+        public function testFactoryCreatesBridgeWhenPresenceContractsAreAvailable(): void
+        {
+            $this->assertTrue(PresenceBridgeFactory::available());
+            $this->assertInstanceOf(
+                BridgeInterface::class,
+                PresenceBridgeFactory::make()
+            );
+        }
+
+        public function testBridgeMapsIdentitySessionManifestAndLifecycleHooks(): void
+        {
+            $events = [];
+            Dev::up();
+            Dev::filter(PresenceAuthenticationBridge::HOOK_INPUT, function (mixed $value) use (&$events): mixed {
+                $events[] = 'input';
+
+                return $value;
+            });
+            Dev::action(PresenceAuthenticationBridge::HOOK_BEFORE, function () use (&$events): void {
+                $events[] = 'before';
+            });
+            Dev::filter(PresenceAuthenticationBridge::HOOK_OUTPUT, function (mixed $value) use (&$events): mixed {
+                $events[] = 'output';
+
+                return $value;
+            });
+            Dev::action(PresenceAuthenticationBridge::HOOK_AFTER, function () use (&$events): void {
+                $events[] = 'after';
+            });
+
+            $context = $this->context();
+            $result = (new PresenceAuthenticationBridge())->bind($context);
+
+            $this->assertTrue($result->isBound());
+            $this->assertSame('bound', $result->reason);
+            $this->assertTrue($result->auth_result->isSuccessful());
+            $this->assertSame('user-42', $result->auth_result->principal->id());
+            $this->assertSame(
+                ['admin' => 'admin', 'operations' => 'operations'],
+                $result->auth_result->principal->roles()->toArray(true)
+            );
+            $this->assertSame(
+                ['reports.view' => 'reports.view', 'users.manage' => 'users.manage'],
+                $result->auth_result->principal->permissions()->toArray(true)
+            );
+            $this->assertSame('session-7', $result->session->id());
+            $this->assertSame('tenant-a', $result->context->tenant_id);
+            $this->assertSame('session-7', $result->context->session_id);
+            $this->assertSame(
+                $result->trust_contract,
+                $result->context->policy('trust_contract')
+            );
+            $this->assertSame('user-42', $result->metadata['audit']['principal_id']);
+            $this->assertSame('session-7', $result->metadata['audit']['session_id']);
+            $this->assertSame(['input', 'before', 'output', 'after'], $events);
+        }
+
+        public function testBridgeReturnsStructuredRejectionsForIncompleteContexts(): void
+        {
+            $bridge = new PresenceAuthenticationBridge();
+
+            $unsupported = $this->context();
+            $unsupported->host = 'other';
+            $this->assertRejected($bridge->bind($unsupported), 'unsupported_host');
+
+            $missingAuthenticator = $this->context();
+            $missingAuthenticator->authenticator = null;
+            $this->assertRejected($bridge->bind($missingAuthenticator), 'missing_authenticator');
+
+            $unauthenticated = $this->context(authenticated: false);
+            $this->assertRejected($bridge->bind($unauthenticated), 'unauthenticated');
+
+            $missingPrincipal = $this->context();
+            $missingPrincipal->authenticator->id = '';
+            $missingPrincipal->authenticator->username = '';
+            $this->assertRejected($bridge->bind($missingPrincipal), 'missing_principal_id');
+
+            $missingSession = $this->context();
+            $missingSession->session = [];
+            $missingSession->metadata = [];
+            $this->assertRejected($bridge->bind($missingSession), 'missing_session_id');
+        }
+
+        public function testFactoryReportsMissingOptionalContractsWithoutFatalLoading(): void
+        {
+            $root = Path::normalize(dirname(__DIR__, 4));
+            $fixture = Path::normalize(
+                $root
+                . DIRECTORY_SEPARATOR . 'tests'
+                . DIRECTORY_SEPARATOR . 'Fixtures'
+                . DIRECTORY_SEPARATOR . 'presence-bridge-unavailable.php'
+            );
+            $command = Str::make(escapeshellarg(PHP_BINARY))
+                ->append(' ')
+                ->append(escapeshellarg($fixture))
+                ->val();
+            $process = new Process($command, $root, [], [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ]);
+
+            $process->start();
+            while ($process->status() === true) {
+                usleep(10000);
+            }
+
+            $output = $process->output();
+            $exitCode = $process->close();
+            $result = Arr::toArray(
+                json_decode($output, true, flags: JSON_THROW_ON_ERROR),
+                true
+            );
+
+            $this->assertSame(0, $exitCode, $output);
+            $this->assertFalse($result['available']);
+            $this->assertSame('presence_contracts_unavailable', $result['reason']);
+            $this->assertNotEmpty($result['details']['missing_contracts']);
+        }
+
+        private function context(bool $authenticated = true): BridgeContext
+        {
+            $context = new BridgeContext();
+            $context->host = 'bluecore';
+            $context->authenticator = new class ($authenticated) {
+                public string $id = 'user-42';
+                public string $username = 'ada';
+                public string $displayname = 'Ada Lovelace';
+                public string $role = 'admin';
+                public string $group = 'operations';
+                public array $permissions = ['reports.view', 'users.manage'];
+
+                public function __construct(private bool $authenticated)
+                {
+                }
+
+                public function isAuthenticated(): bool
+                {
+                    return $this->authenticated;
+                }
+            };
+            $context->session = [
+                'id' => 'session-7',
+                'type' => 'browser',
+            ];
+            $context->annex_manifest = [
+                'strictness_level' => 2,
+                'requested_scope' => ['profile.read'],
+            ];
+            $context->metadata = [
+                'tenant_id' => 'tenant-a',
+                'action' => 'login',
+                'requested_privilege' => 'account.read',
+            ];
+
+            return $context;
+        }
+
+        private function assertRejected(object $result, string $reason): void
+        {
+            $this->assertFalse($result->isBound());
+            $this->assertSame($reason, $result->reason);
+            $this->assertSame($reason, $result->metadata['audit']['reason']);
+            $this->assertFalse($result->metadata['audit']['bound']);
+        }
+
+        private function resetDevElation(): void
+        {
+            Dev::down();
+            $reflection = new \ReflectionClass(Dev::class);
+
+            foreach (['_filters', '_actions'] as $propertyName) {
+                $property = $reflection->getProperty($propertyName);
+                $property->setValue(null, []);
+            }
+        }
+    }
+}

--- a/tests/BlueCore/Integration/Presence/PresenceAuthenticationBridgeTest.php
+++ b/tests/BlueCore/Integration/Presence/PresenceAuthenticationBridgeTest.php
@@ -133,13 +133,13 @@ namespace BlueFission\Tests\BlueCore\Integration\Presence {
             }
 
             $output = $process->output();
-            $exitCode = $process->close();
+            $process->close();
+            $this->assertJson($output);
             $result = Arr::toArray(
                 json_decode($output, true, flags: JSON_THROW_ON_ERROR),
                 true
             );
 
-            $this->assertSame(0, $exitCode, $output);
             $this->assertFalse($result['available']);
             $this->assertSame('presence_contracts_unavailable', $result['reason']);
             $this->assertNotEmpty($result['details']['missing_contracts']);

--- a/tests/Fixtures/presence-bridge-unavailable.php
+++ b/tests/Fixtures/presence-bridge-unavailable.php
@@ -1,0 +1,17 @@
+<?php
+
+require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+use BlueFission\BlueCore\Integration\Presence\PresenceBridgeFactory;
+use BlueFission\BlueCore\Integration\Presence\PresenceBridgeUnavailable;
+
+try {
+    PresenceBridgeFactory::make();
+    echo json_encode(['available' => true], JSON_THROW_ON_ERROR);
+} catch (PresenceBridgeUnavailable $exception) {
+    echo json_encode([
+        'available' => false,
+        'reason' => $exception->reason(),
+        'details' => $exception->details(),
+    ], JSON_THROW_ON_ERROR);
+}

--- a/tests/Fixtures/presence-contracts.php
+++ b/tests/Fixtures/presence-contracts.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace BlueFission\Presence\Support {
+    if (!class_exists(Context::class)) {
+        class Context
+        {
+            public ?string $action = null;
+            public ?string $session_id = null;
+            public ?string $session_type = null;
+            public ?string $tenant_id = null;
+            public ?string $requested_privilege = null;
+            public ?string $current_privilege = null;
+            public mixed $participant = null;
+            public mixed $session = null;
+            public array $metadata = [];
+            public array $policies = [];
+
+            public function policy(string $key, mixed $value = null): mixed
+            {
+                if ($value === null) {
+                    return $this->policies[$key] ?? null;
+                }
+
+                $this->policies[$key] = $value;
+
+                return $this;
+            }
+        }
+    }
+}
+
+namespace BlueFission\Presence\Bridge {
+    use BlueFission\Presence\Support\Context;
+
+    if (!interface_exists(BridgeInterface::class)) {
+        interface BridgeInterface
+        {
+            public function name(): string;
+            public function supports(BridgeContext $context): bool;
+            public function bind(BridgeContext $context): BridgeResult;
+        }
+    }
+
+    if (!class_exists(BridgeContext::class)) {
+        class BridgeContext
+        {
+            public ?string $host = null;
+            public mixed $request = null;
+            public array $arguments = [];
+            public mixed $session = null;
+            public mixed $authenticator = null;
+            public array $annex_manifest = [];
+            public ?Context $presence_context = null;
+            public array $metadata = [];
+
+            public function context(): Context
+            {
+                return $this->presence_context ??= new Context();
+            }
+        }
+    }
+
+    if (!class_exists(BridgeResult::class)) {
+        class BridgeResult
+        {
+            public bool $bound = false;
+            public mixed $context = null;
+            public mixed $auth_result = null;
+            public mixed $trust_contract = null;
+            public mixed $session = null;
+            public ?string $reason = null;
+            public array $metadata = [];
+
+            public function isBound(): bool
+            {
+                return $this->bound;
+            }
+        }
+    }
+}
+
+namespace BlueFission\Presence\Auth {
+    use BlueFission\Collections\Collection;
+
+    if (!interface_exists(PrincipalInterface::class)) {
+        interface PrincipalInterface
+        {
+            public function id(): string;
+            public function type(): string;
+            public function roles(): Collection;
+            public function permissions(): Collection;
+        }
+    }
+
+    if (!class_exists(Principal::class)) {
+        class Principal implements PrincipalInterface
+        {
+            public ?string $id = null;
+            public ?string $type = null;
+            public array $attributes = [];
+            private Collection $roleCollection;
+            private Collection $permissionCollection;
+
+            public function __construct()
+            {
+                $this->roleCollection = new Collection();
+                $this->permissionCollection = new Collection();
+            }
+
+            public function id(): string
+            {
+                return (string)$this->id;
+            }
+
+            public function type(): string
+            {
+                return (string)$this->type;
+            }
+
+            public function roles(): Collection
+            {
+                return $this->roleCollection;
+            }
+
+            public function permissions(): Collection
+            {
+                return $this->permissionCollection;
+            }
+        }
+    }
+
+    if (!class_exists(AuthResult::class)) {
+        class AuthResult
+        {
+            public bool $authenticated = false;
+            public mixed $principal = null;
+            public mixed $credential = null;
+            public ?string $reason = null;
+            public array $metadata = [];
+
+            public static function success(
+                PrincipalInterface $principal,
+                mixed $credential = null,
+                array $metadata = []
+            ): self {
+                $result = new self();
+                $result->authenticated = true;
+                $result->principal = $principal;
+                $result->credential = $credential;
+                $result->reason = 'authenticated';
+                $result->metadata = $metadata;
+
+                return $result;
+            }
+
+            public function isSuccessful(): bool
+            {
+                return $this->authenticated;
+            }
+        }
+    }
+}
+
+namespace BlueFission\Presence\Session {
+    use BlueFission\Presence\Auth\PrincipalInterface;
+
+    if (!interface_exists(SessionInterface::class)) {
+        interface SessionInterface
+        {
+            public function id(): string;
+            public function type(): string;
+            public function addParticipant(Participant $participant): void;
+        }
+    }
+
+    if (!class_exists(Participant::class)) {
+        class Participant
+        {
+            public ?string $id = null;
+            public ?PrincipalInterface $principal = null;
+            public array $metadata = [];
+
+            public function id(): string
+            {
+                return (string)$this->id;
+            }
+        }
+    }
+
+    if (!class_exists(Session::class)) {
+        class Session implements SessionInterface
+        {
+            public ?string $id = null;
+            public array $metadata = [];
+            public array $participants = [];
+
+            public function __construct(private string $sessionType = 'session')
+            {
+            }
+
+            public function id(): string
+            {
+                return (string)$this->id;
+            }
+
+            public function type(): string
+            {
+                return $this->sessionType;
+            }
+
+            public function addParticipant(Participant $participant): void
+            {
+                $this->participants[$participant->id()] = $participant;
+            }
+        }
+    }
+}
+
+namespace BlueFission\Presence\Annex {
+    use BlueFission\Presence\Support\Context;
+
+    if (!class_exists(TrustContract::class)) {
+        class TrustContract
+        {
+            public array $manifest = [];
+
+            public function applyTo(Context $context): Context
+            {
+                $context->policy('trust_contract', $this);
+
+                return $context;
+            }
+        }
+    }
+
+    if (!class_exists(AnnexAdapter::class)) {
+        class AnnexAdapter
+        {
+            public function ingest(array $manifest): TrustContract
+            {
+                $contract = new TrustContract();
+                $contract->manifest = $manifest;
+
+                return $contract;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Intent

Provide an optional authentication bridge between BlueCore host identity/session values and the current Presence bridge contracts without making Presence a required dependency.

## User stories / acceptance criteria

- Applications with Presence installed can create a bridge through an availability-safe factory.
- Authenticated host identity and session data map to Presence principal, authentication result, session, participant, context, and audit contracts.
- Optional Annex manifests are ingested through the upstream adapter and applied to the Presence context.
- Missing optional contracts fail before the concrete adapter is loaded and report a structured reason plus missing contract names.
- Unsupported, unauthenticated, or incomplete contexts return stable unbound results rather than host-specific exceptions.
- DevElation hooks expose scoped input, before, output, and after extension points.

## Key files changed

- `src/BlueCore/Integration/Presence/PresenceAuthenticationBridge.php`
- `src/BlueCore/Integration/Presence/PresenceBridgeFactory.php`
- `src/BlueCore/Integration/Presence/PresenceBridgeUnavailable.php`
- `tests/BlueCore/Integration/Presence/PresenceAuthenticationBridgeTest.php`
- `README.md`
- `composer.json`

## How to test

```bash
composer ci
composer test:installer
```

Focused contract tests:

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Integration/Presence/PresenceAuthenticationBridgeTest.php
```

## QA checklist

- [x] Strict Composer validation and PHP lint pass.
- [x] Full suite passes: 111 tests, 480 assertions.
- [x] Source/dist project-installer parity passes.
- [x] Missing-Presence behavior is verified in an isolated process.
- [x] Compatibility smoke passes against Presence `main` at `7e6f3a7` using the real upstream bridge, identity, session, and Annex classes.
- [x] Presence remains optional and is recorded through Composer `suggest` only.

## Approval conditions

- Confirm the neutral `BridgeContext` mapping remains aligned with the supported Presence public contracts.
- Confirm stable rejection reasons and audit metadata are sufficient for host observability.
- Confirm the scoped DevElation lifecycle hooks are appropriate extension points.

Closes #75
