### PR TITLE
Harden add-on lifecycle path resolution

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -286,7 +286,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
 
     public function showAllAddOns()
     {
-        $addonsPath = resolve_path('addons');
+        $addonsPath = $this->resolveProjectPath('addons');
         if (!is_dir($addonsPath)) {
             return [];
         }
@@ -470,7 +470,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
     {
         $addOnName = $this->normalizeAddOnIdentifier($addOn->name, 'name');
         $relative = 'mapping' . DIRECTORY_SEPARATOR . $name . '.php';
-        $canonicalRoot = Path::normalize(resolve_path('addons' . DIRECTORY_SEPARATOR . $addOnName));
+        $canonicalRoot = Path::normalize($this->resolveProjectPath('addons' . DIRECTORY_SEPARATOR . $addOnName));
         $configuredRoot = Path::normalize((string)$addOn->path);
         $candidates = Arr::make([]);
 
@@ -690,7 +690,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             return $result->toArray();
         }
 
-        $addOnRoot = Path::normalize(resolve_path('addons' . DIRECTORY_SEPARATOR . $name));
+        $addOnRoot = Path::normalize($this->resolveProjectPath('addons' . DIRECTORY_SEPARATOR . $name));
         $configuredRoot = Path::normalize((string)$addOn->path);
         $configured = Val::isEmpty($configuredRoot)
             ? null
@@ -797,7 +797,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
     protected function getAddOnData($name)
     {
         $name = $this->normalizeAddOnIdentifier($name, 'name');
-        $definitionPath = resolve_path('addons' . DIRECTORY_SEPARATOR . $name  . DIRECTORY_SEPARATOR . 'definition.json');
+        $definitionPath = $this->resolveProjectPath('addons' . DIRECTORY_SEPARATOR . $name  . DIRECTORY_SEPARATOR . 'definition.json');
         if (!(new File())->isReachable($definitionPath)) {
             throw new \InvalidArgumentException("Add-on definition not found for {$name}.");
         }
@@ -929,8 +929,8 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
 
     protected function addOnPath(string $name): string
     {
-        $root = realpath(resolve_path('addons'));
-        $path = realpath(resolve_path('addons' . DIRECTORY_SEPARATOR . $name));
+        $root = realpath($this->resolveProjectPath('addons'));
+        $path = realpath($this->resolveProjectPath('addons' . DIRECTORY_SEPARATOR . $name));
 
         if (Val::isEmpty($root) || Val::isEmpty($path)) {
             throw new \InvalidArgumentException("Add-on path not found for {$name}.");
@@ -1025,6 +1025,16 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
     protected function datasourceManager(): mixed
     {
         return instance('datasource');
+    }
+
+    protected function resolveProjectPath(string $path): string
+    {
+        return Path::resolveProjectPath(
+            $path,
+            fallbackResolver: new Func(
+                static fn (string $relativePath): string => (string)resolve_path($relativePath)
+            )
+        );
     }
 
     protected function captureOutput(callable $operation): string
@@ -1128,7 +1138,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
                 array_splice( $path, 2, 0, 'logic' ); // splice in at position 2
 
                 $file = implode(DIRECTORY_SEPARATOR, $path);
-                $file = resolve_path($file);
+                $file = $this->resolveProjectPath($file);
             }
             if (file_exists($file)) {
                 require_once($file);

--- a/src/Helpers/global.php
+++ b/src/Helpers/global.php
@@ -131,29 +131,11 @@ if (!function_exists('whisper')) {
 if(!function_exists('resolve_path')) {
 	function resolve_path($pathInProject, ?string $applicationRoot = null, ?string $legacyProjectRoot = null)
 	{
-	    $rootPath = rtrim($applicationRoot ?? APP_ROOT, DIRECTORY_SEPARATOR);
-	    $projectPath = rtrim($legacyProjectRoot ?? PROJECT_ROOT, DIRECTORY_SEPARATOR);
-	    $relativePath = Path::normalize((string)$pathInProject);
-
-	    $candidate = Path::normalize($rootPath . DIRECTORY_SEPARATOR . $relativePath);
-	    $fallback = Path::normalize($projectPath . DIRECTORY_SEPARATOR . $relativePath);
-	    $hasWildcard = Str::matchPattern($relativePath, '/[*?\[]/');
-
-	    if (!$hasWildcard && (
-	        FileSystem::fileExists($candidate)
-	        || FileSystem::directoryExists($candidate)
-	    )) {
-	        return $candidate;
-	    }
-
-	    if ($hasWildcard) {
-	        $matches = glob($candidate);
-	        if (!Flag::isFalse($matches) && Arr::isNotEmpty($matches)) {
-	            return $candidate;
-	        }
-	    }
-
-	    return $fallback;
+	    return Path::resolveProjectPath(
+	        $pathInProject,
+	        $applicationRoot,
+	        $legacyProjectRoot
+	    );
 	}
 }
 

--- a/src/Utils/Path.php
+++ b/src/Utils/Path.php
@@ -4,7 +4,9 @@ namespace BlueFission\Utils;
 
 use BlueFission\Arr;
 use BlueFission\Data\Directory;
+use BlueFission\Data\FileSystem;
 use BlueFission\Flag;
+use BlueFission\Func;
 use BlueFission\Str;
 use BlueFission\Val;
 
@@ -38,6 +40,50 @@ class Path extends Directory
     public static function parentPath($path)
     {
         return dirname(self::normalize($path));
+    }
+
+    public static function resolveProjectPath(
+        $pathInProject,
+        ?string $applicationRoot = null,
+        ?string $legacyProjectRoot = null,
+        ?Func $fallbackResolver = null
+    ): string {
+        $applicationRoot ??= defined('APP_ROOT') ? (string)constant('APP_ROOT') : (string)getcwd();
+        $legacyProjectRoot ??= defined('PROJECT_ROOT')
+            ? (string)constant('PROJECT_ROOT')
+            : $applicationRoot;
+
+        $relativePath = self::normalize((string)$pathInProject);
+        $candidate = self::normalize(
+            $applicationRoot . DIRECTORY_SEPARATOR . $relativePath
+        );
+        $fallback = self::normalize(
+            $legacyProjectRoot . DIRECTORY_SEPARATOR . $relativePath
+        );
+        $hasWildcard = Str::matchPattern($relativePath, '/[*?\[]/');
+
+        if (!$hasWildcard && (
+            FileSystem::fileExists($candidate)
+            || FileSystem::directoryExists($candidate)
+        )) {
+            return $candidate;
+        }
+
+        if ($hasWildcard) {
+            $matches = glob($candidate);
+            if (!Flag::isFalse($matches) && Arr::isNotEmpty($matches)) {
+                return $candidate;
+            }
+        }
+
+        if (Val::isNotNull($fallbackResolver)) {
+            $resolved = self::normalize((string)$fallbackResolver->call($relativePath));
+            if (Val::isNotEmpty($resolved)) {
+                return $resolved;
+            }
+        }
+
+        return $fallback;
     }
 
     public static function readiness($path): array

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -325,6 +325,33 @@ class AddOnManagerTest extends TestCase
         $this->assertSame(1, $result['failed']);
     }
 
+    public function testInstallAllDiscoversApplicationAddOnAndRunsItsDatasourceStage(): void
+    {
+        $this->writeDefinition('applicationowned');
+        $model = new FakeAddOnModel();
+        $datasource = new FakeDatasourceManager();
+        $manager = new TestableAddOnManager($model, $datasource);
+
+        $result = $manager->installAll();
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(1, $result['total']);
+        $this->assertSame(1, $result['succeeded']);
+        $this->assertSame(1, $datasource->migrationRuns);
+        $this->assertSame(
+            Path::normalize(
+                self::$root
+                . DIRECTORY_SEPARATOR . 'addons'
+                . DIRECTORY_SEPARATOR . 'applicationowned'
+                . DIRECTORY_SEPARATOR . 'datasources'
+                . DIRECTORY_SEPARATOR . 'structure'
+                . DIRECTORY_SEPARATOR
+            ),
+            $datasource->deltaDirectories[0]
+        );
+        $this->assertCount(1, $model->records);
+    }
+
     public function testPassiveContributionsIncludeOnlyActiveAddOnsAndExposeRevisionChanges(): void
     {
         $firstPath = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'first';
@@ -1147,6 +1174,8 @@ class FakeDatasourceManager
 {
     public int $migrationRuns = 0;
     public int $populationRuns = 0;
+    public array $deltaDirectories = [];
+    public array $generatorDirectories = [];
     private array $published = [];
     private array $applied = [];
     private ?string $failedMigration = null;
@@ -1158,10 +1187,12 @@ class FakeDatasourceManager
 
     public function setDeltaDirectory(string $directory): void
     {
+        $this->deltaDirectories[] = Path::normalize($directory);
     }
 
     public function setGeneratorDirectory(string $directory): void
     {
+        $this->generatorDirectories[] = Path::normalize($directory);
     }
 
     public function publish(string $migration): void

--- a/tests/Utils/PathTest.php
+++ b/tests/Utils/PathTest.php
@@ -2,6 +2,7 @@
 
 namespace BlueFission\Tests\Utils;
 
+use BlueFission\Func;
 use BlueFission\Utils\Path;
 use BlueFission\Utils\File;
 use PHPUnit\Framework\TestCase;
@@ -77,6 +78,63 @@ class PathTest extends TestCase
         $this->assertFalse($readiness['readable']);
         $this->assertFalse($readiness['writable']);
         $this->assertSame('not_directory', $readiness['reason']);
+    }
+
+    public function testProjectPathResolutionPrefersExistingApplicationDirectoryBeforeHostFallback(): void
+    {
+        $applicationRoot = Path::ensureDir(
+            $this->tmpDir . DIRECTORY_SEPARATOR . 'application'
+        );
+        $projectRoot = Path::ensureDir(
+            $this->tmpDir . DIRECTORY_SEPARATOR . 'project'
+        );
+        $applicationAddOns = Path::ensureDir(
+            $applicationRoot . DIRECTORY_SEPARATOR . 'addons'
+        );
+        $resolver = new Func(
+            static fn (string $path): string => Path::normalize(
+                $projectRoot . DIRECTORY_SEPARATOR . $path
+            )
+        );
+
+        $resolved = Path::resolveProjectPath(
+            'addons',
+            $applicationRoot,
+            $projectRoot,
+            $resolver
+        );
+
+        $this->assertSame(Path::normalize($applicationAddOns), $resolved);
+    }
+
+    public function testProjectPathResolutionPreservesHostFallbackWhenApplicationCandidateIsMissing(): void
+    {
+        $applicationRoot = Path::ensureDir(
+            $this->tmpDir . DIRECTORY_SEPARATOR . 'application'
+        );
+        $projectRoot = Path::ensureDir(
+            $this->tmpDir . DIRECTORY_SEPARATOR . 'project'
+        );
+        $customRoot = Path::ensureDir(
+            $this->tmpDir . DIRECTORY_SEPARATOR . 'custom'
+        );
+        $resolver = new Func(
+            static fn (string $path): string => Path::normalize(
+                $customRoot . DIRECTORY_SEPARATOR . $path
+            )
+        );
+
+        $resolved = Path::resolveProjectPath(
+            'addons',
+            $applicationRoot,
+            $projectRoot,
+            $resolver
+        );
+
+        $this->assertSame(
+            Path::normalize($customRoot . DIRECTORY_SEPARATOR . 'addons'),
+            $resolved
+        );
     }
 
     private function removeDir($dir): void


### PR DESCRIPTION
## Intent

Make application-first project path resolution a reusable BlueCore utility and use it throughout add-on discovery and lifecycle operations, while preserving compatible host and legacy project fallbacks.

## User stories / acceptance criteria

- Existing files and directories under `APP_ROOT` win before a host fallback resolver is accepted.
- Host-provided resolution remains available when no application-root candidate exists.
- Legacy `PROJECT_ROOT` fallback remains the final default.
- Add-on discovery, definitions, mappings, primary files, and loading use the same path policy.
- `installAll()` discovers an application-owned add-on and runs its datasource stage before installation is recorded.
- The global `resolve_path()` helper delegates to the same DevElation-backed `Path` implementation.

## Key files changed

- `src/Utils/Path.php`
- `src/Helpers/global.php`
- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/Utils/PathTest.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## How to test

```bash
composer ci
composer test:installer
```

Focused verification:

```bash
vendor/bin/phpunit --do-not-cache-result tests/Utils/PathTest.php tests/Helpers/ResolvePathHelperTest.php tests/BlueCore/Business/Managers/AddOnManagerTest.php
```

## QA checklist

- [x] Focused resolver/helper/add-on suite passes: 50 tests, 237 assertions.
- [x] Full suite passes: 110 tests, 449 assertions.
- [x] Source/dist project-installer parity passes.
- [x] Existing application directories override a file-only fallback resolver.
- [x] Custom host resolution remains available when the application candidate is missing.
- [x] Add-on datasource directory selection and migration execution are covered.

## Approval conditions

- Confirm the shared application/host/project fallback order is backward compatible.
- Confirm add-on lifecycle call sites should use the package path utility rather than calling a host helper directly.
- Confirm the datasource-stage evidence covers the package-owned lifecycle boundary.

Closes #79
