### PR TITLE
Verify persisted add-on activation state

### DIFF
--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -194,9 +194,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
 
     public function activate($addOnId): array
     {
-        $this->_model->write(['addon_id' => $addOnId, 'is_active' => 1]);
-
-        return $this->lifecycleResult('activate', (string)$addOnId, $this->_model->status(), $this->_model->query());
+        return $this->updateActivation($addOnId, true);
     }
 
     public function activateAll(): array
@@ -245,9 +243,51 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
 
     public function deactivate($addOnId): array
     {
-        $this->_model->write(['addon_id' => $addOnId, 'is_active' => 0]);
+        return $this->updateActivation($addOnId, false);
+    }
 
-        return $this->lifecycleResult('deactivate', (string)$addOnId, $this->_model->status(), $this->_model->query());
+    private function updateActivation($addOnId, bool $active): array
+    {
+        $action = $active ? 'activate' : 'deactivate';
+        $this->_model->write([
+            'addon_id' => $addOnId,
+            'is_active' => $active ? 1 : 0,
+        ]);
+
+        $result = $this->lifecycleResult(
+            $action,
+            (string)$addOnId,
+            $this->_model->status(),
+            $this->_model->query()
+        );
+
+        if (Flag::isFalse($result['ok'])) {
+            return $result;
+        }
+
+        $this->_model->clear()->read(['addon_id' => $addOnId]);
+        $record = Arr::make((array)$this->_model->data());
+        $verified = $this->_model->status() === Storage::STATUS_SUCCESS
+            && $record->hasKey('is_active')
+            && Flag::parseBool($record->get('is_active')) === $active;
+
+        $result['verification'] = Arr::make([
+            'ok' => $verified,
+            'is_active' => $record->get('is_active'),
+            'modelStatus' => $this->_model->status(),
+        ])->toArray();
+
+        if (Flag::isFalse($verified)) {
+            $message = 'Add-on activation state was not persisted.';
+            $result['ok'] = false;
+            $result['changed'] = false;
+            $result['stage'] = 'verification';
+            $result['nextAction'] = "retry_{$action}";
+            $result['error'] = $message;
+            $result['messages'] = [$message];
+        }
+
+        return $result;
     }
 
     public function migrate($addOnId): array

--- a/src/BlueCore/Model/BaseModel.php
+++ b/src/BlueCore/Model/BaseModel.php
@@ -103,6 +103,10 @@ class BaseModel extends Obj implements IData, JsonSerializable {
 	 */
 	public function field(string $field, $value = null): mixed
 	{
+		if (Val::isNotNull($value) && Val::isEmpty($value)) {
+			$value = Val::make($value);
+		}
+
 		return $this->_dataObject->field($field, $value);
 	}
 

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -704,6 +704,39 @@ PHP,
         $this->assertSame('Persisted add-on row is missing addon_id.', $result['results'][1]['error']);
     }
 
+    public function testDeactivateVerifiesPersistedInactiveState(): void
+    {
+        $model = new FakeAddOnModel([
+            ['addon_id' => 8, 'is_active' => 1],
+        ], returnArrays: true);
+        $manager = new TestableAddOnManager($model);
+
+        $result = $manager->deactivate(8);
+
+        $this->assertTrue($result['ok']);
+        $this->assertTrue($result['changed']);
+        $this->assertTrue($result['verification']['ok']);
+        $this->assertSame(0, $result['verification']['is_active']);
+        $this->assertSame(0, $model->records[0]['is_active']);
+    }
+
+    public function testBulkDeactivationReportsSuccessfulWriteWithoutPersistenceAsFailure(): void
+    {
+        $model = new FakeAddOnModel([
+            ['addon_id' => 9, 'is_active' => 1],
+        ], returnArrays: true, ignoreActivationWritesForIds: [9]);
+        $manager = new TestableAddOnManager($model);
+
+        $result = $manager->deactivateAll();
+
+        $this->assertFalse($result['ok']);
+        $this->assertFalse($result['changed']);
+        $this->assertSame(1, $result['failed']);
+        $this->assertSame('verification', $result['results'][0]['stage']);
+        $this->assertSame('retry_deactivate', $result['results'][0]['nextAction']);
+        $this->assertSame('Add-on activation state was not persisted.', $result['results'][0]['error']);
+    }
+
     #[DataProvider('collectionContainerProvider')]
     public function testBulkLifecyclePreservesCollectionRowsAndNamespaceRoundTrips(string $container): void
     {
@@ -1027,7 +1060,8 @@ class FakeAddOnModel
         array $addons = [],
         private bool $returnArrays = false,
         private ?string $containerClass = null,
-        private array $failWritesForIds = []
+        private array $failWritesForIds = [],
+        private array $ignoreActivationWritesForIds = []
     )
     {
         $this->records = array_map(static fn($addon) => (array)$addon, $addons);
@@ -1043,6 +1077,11 @@ class FakeAddOnModel
             : 'Success.';
 
         if ($this->currentStatus !== 'Success.') {
+            return;
+        }
+
+        if (array_key_exists('is_active', $record)
+            && in_array($id, $this->ignoreActivationWritesForIds, true)) {
             return;
         }
 

--- a/tests/BlueCore/Model/ModelSQLiteTest.php
+++ b/tests/BlueCore/Model/ModelSQLiteTest.php
@@ -58,6 +58,25 @@ class ModelSQLiteTest extends TestCase
         $this->assertSame('second', $rows[1]['name']);
     }
 
+    public function testFalseyScalarAssignmentsArePersisted(): void
+    {
+        $writer = new TestSQLiteModel($this->database);
+        $writer->write(['name' => 'switch', 'status' => 'active', 'is_active' => 1]);
+        $recordId = $writer->id();
+
+        $writer->write([
+            'record_id' => $recordId,
+            'status' => '',
+            'is_active' => 0,
+        ]);
+
+        $reader = new TestSQLiteModel($this->database);
+        $reader->read(['record_id' => $recordId]);
+
+        $this->assertSame('', $reader->field('status'));
+        $this->assertSame(0, (int)$reader->field('is_active'));
+    }
+
     public function testSQLiteStoreBoundaryNamesDevElationStorageAndLocalResponsibilities(): void
     {
         $boundary = SQLiteModelStore::boundary();
@@ -94,6 +113,7 @@ class TestSQLiteModel extends ModelSQLite
         'record_id',
         'name',
         'status',
+        'is_active',
     ];
 
     public function storeDiagnostics(): array


### PR DESCRIPTION
## Intent summary

Preserve falsey model values through the DevElation storage boundary and verify durable add-on activation state before lifecycle operations report success.

Closes #81.

## User stories / acceptance criteria

- Model assignment persists non-null falsey values such as `0` and an empty string.
- Activation and deactivation read back `is_active` after a successful write.
- Missing or mismatched persisted state returns `ok=false`, `changed=false`, a verification stage, and a retry action.
- Bulk lifecycle results propagate persistence verification failures.

## Key files changed

- `src/BlueCore/Model/BaseModel.php`
- `src/BlueCore/Business/Managers/AddOnManager.php`
- `tests/BlueCore/Model/ModelSQLiteTest.php`
- `tests/BlueCore/Business/Managers/AddOnManagerTest.php`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/Model/ModelSQLiteTest.php tests/BlueCore/Business/Managers/AddOnManagerTest.php
composer ci
composer test:installer
```

## QA checklist

- [x] Focused lifecycle and SQLite tests pass: 47 tests, 238 assertions.
- [x] Full suite passes: 110 tests, 454 assertions.
- [x] Composer validation and PHP lint pass.
- [x] Installer source/dist parity passes.
- [x] No service credentials or optional infrastructure are required.

## Approval conditions

- CI passes on head `8b0dcf0d3083748f3842707a5aae3059b7eaba97`.
- Review confirms the verification result remains compatible with existing lifecycle result consumers.
- Review confirms wrapping non-null empty values at the model field boundary is appropriate pending the corresponding upstream setter-dispatch correction.
