### PR TITLE
add optional resumable installation orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,34 @@ Composer packages with the `opus-project` type install into `core/` by default. 
 
 Set `OPUS_STANDALONE=1` to install a project package under `vendor/` without promoting root overrides.
 
+### Resumable Installation Plans
+
+Application hosts can compose a versioned, resumable installation plan without moving product-specific onboarding into BlueCore. Each injected stage delegates to its existing lifecycle owner and declares the permissions it needs before execution:
+
+```php
+use BlueFission\BlueCore\Installation\InstallationExecutor;
+use BlueFission\BlueCore\Installation\JsonInstallationCheckpointStore;
+
+$executor = (new InstallationExecutor(
+    new JsonInstallationCheckpointStore($checkpointDirectory)
+))
+    ->stage('registration', fn ($plan) => $registrar->apply($registrationPlan), ['write_project'])
+    ->stage('addons', fn ($plan) => $addOns->installAll(), ['write_project', 'write_database'])
+    ->stage('migrations', fn ($plan) => $datasources->runMigrations($plan->id()), ['write_database'])
+    ->stage('population', fn ($plan) => $datasources->populate(), ['write_database']);
+
+$plan = $executor->prepare([
+    'project_name' => 'Example Application',
+    'defaults' => ['environment' => 'production'],
+    'skips' => ['population'],
+]);
+
+$plan->approve(['write_project', 'write_database']);
+$result = $executor->execute($plan);
+```
+
+The checkpoint records supplied values, accepted defaults, explicit skips, permission review, per-stage evidence, retry guidance, and terminal status. `resume($planId)` restores a failed or interrupted plan; completed successful stages are not repeated. Question rendering, branding, tenant creation, administrator provisioning, login transitions, and onboarding navigation remain host responsibilities.
+
 ## Usage
 
 ### Event Management

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Composer packages with the `opus-project` type install into `core/` by default. 
 
 Set `OPUS_STANDALONE=1` to install a project package under `vendor/` without promoting root overrides.
 
-### Resumable Installation Plans
+### Optional Installation Orchestration
 
-Application hosts can compose a versioned, resumable installation plan without moving product-specific onboarding into BlueCore. Each injected stage delegates to its existing lifecycle owner and declares the permissions it needs before execution:
+Application hosts can compose a resumable sequence without adopting a BlueCore-defined installation schema. The plan context, validation rules, approval evidence, stage metadata, ordering, and product transitions remain host-owned:
 
 ```php
 use BlueFission\BlueCore\Installation\InstallationExecutor;
@@ -42,20 +42,20 @@ use BlueFission\BlueCore\Installation\JsonInstallationCheckpointStore;
 $executor = (new InstallationExecutor(
     new JsonInstallationCheckpointStore($checkpointDirectory)
 ))
-    ->stage('registration', fn ($plan) => $registrar->apply($registrationPlan), ['write_project'])
-    ->stage('addons', fn ($plan) => $addOns->installAll(), ['write_project', 'write_database'])
-    ->stage('migrations', fn ($plan) => $datasources->runMigrations($plan->id()), ['write_database'])
-    ->stage('population', fn ($plan) => $datasources->populate(), ['write_database']);
+    ->validator(fn (array $context) => $hostPolicy->validate($context))
+    ->requireApproval()
+    ->stage('registration', fn ($plan) => $registrar->apply($plan->context()), [
+        'owner' => 'host',
+    ])
+    ->stage('lifecycle', fn ($plan) => $lifecycle->apply($plan->context()));
 
-$plan = $executor->prepare([
-    'project_name' => 'Example Application',
-    'defaults' => ['environment' => 'production'],
-    'skips' => ['population'],
-]);
+$plan = $executor->prepare($hostDefinedContext);
 
-$plan->approve(['write_project', 'write_database']);
+$plan->approve($hostApprovalEvidence);
 $result = $executor->execute($plan);
 ```
+
+The checkpoint store and approval gate are optional. Without a checkpoint store, the executor can run an in-memory plan but cannot resume it later. BlueCore records structured stage outcomes and avoids repeating successful stages after a resume; it does not prescribe installation questions, required fields, defaults, skips, permissions, or a product-specific stage graph.
 
 The checkpoint records supplied values, accepted defaults, explicit skips, permission review, per-stage evidence, retry guidance, and terminal status. `resume($planId)` restores a failed or interrupted plan; completed successful stages are not repeated. Question rendering, branding, tenant creation, administrator provisioning, login transitions, and onboarding navigation remain host responsibilities.
 

--- a/src/BlueCore/Contracts/IInstallationCheckpointStore.php
+++ b/src/BlueCore/Contracts/IInstallationCheckpointStore.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace BlueFission\BlueCore\Contracts;
+
+interface IInstallationCheckpointStore
+{
+    public function load(string $planId): ?array;
+
+    public function save(string $planId, array $checkpoint): void;
+
+    public function delete(string $planId): void;
+}

--- a/src/BlueCore/Installation/InstallationExecutor.php
+++ b/src/BlueCore/Installation/InstallationExecutor.php
@@ -13,13 +13,29 @@ use BlueFission\Val;
 class InstallationExecutor
 {
     private Collection $stages;
+    private ?Func $validator = null;
+    private bool $approvalRequired = false;
 
-    public function __construct(private IInstallationCheckpointStore $checkpoints)
+    public function __construct(private ?IInstallationCheckpointStore $checkpoints = null)
     {
         $this->stages = new Collection();
     }
 
-    public function stage(string $name, callable|Func $operation, array $permissions = []): self
+    public function validator(callable|Func $validator): self
+    {
+        $this->validator = $validator instanceof Func ? $validator : Func::make($validator);
+
+        return $this;
+    }
+
+    public function requireApproval(bool $required = true): self
+    {
+        $this->approvalRequired = $required;
+
+        return $this;
+    }
+
+    public function stage(string $name, callable|Func $operation, array $metadata = []): self
     {
         $name = Str::make($name)->trim()->val();
         if (Val::isEmpty($name)) {
@@ -29,28 +45,43 @@ class InstallationExecutor
         $this->stages->add([
             'name' => $name,
             'operation' => $operation instanceof Func ? $operation : Func::make($operation),
-            'permissions' => Arr::make($permissions)->values()->unique()->toArray(),
+            'metadata' => Arr::make($metadata)->toArray(),
         ], $name);
 
         return $this;
     }
 
-    public function prepare(array $packet): InstallationPlan
+    public function stages(): array
     {
-        $plan = new InstallationPlan($packet);
-        $permissions = Arr::make([]);
+        $definitions = new Collection();
         foreach ($this->stages as $stage) {
-            $stage = Arr::make($stage);
-            $permissions->merge($stage->get('permissions', []));
+            $record = Arr::make($stage);
+            $definitions->add([
+                'name' => $record->get('name'),
+                'metadata' => Arr::make($record->get('metadata', []))->toArray(),
+            ]);
         }
-        $plan->requestPermissions($permissions->values()->unique()->toArray());
-        $this->checkpoints->save($plan->id(), $plan->toArray());
+
+        return $definitions->toArray();
+    }
+
+    public function prepare(array $context = [], ?string $planId = null): InstallationPlan
+    {
+        $plan = new InstallationPlan($context, $planId);
+        if (Val::isNotNull($this->validator)) {
+            $plan->applyDiagnostics($this->validate($context));
+        }
+        $this->save($plan);
 
         return $plan;
     }
 
     public function resume(string $planId): ?InstallationPlan
     {
+        if (Val::isNull($this->checkpoints)) {
+            throw new \LogicException('A checkpoint store is required to resume an installation plan.');
+        }
+
         $checkpoint = $this->checkpoints->load($planId);
 
         return Val::isNull($checkpoint) ? null : InstallationPlan::restore($checkpoint);
@@ -58,25 +89,13 @@ class InstallationExecutor
 
     public function execute(InstallationPlan $plan): array
     {
-        $plan->start();
-        $this->checkpoints->save($plan->id(), $plan->toArray());
+        $plan->start($this->approvalRequired);
+        $this->save($plan);
 
         foreach ($this->stages as $stage) {
             $stage = Arr::make($stage);
             $name = (string)$stage->get('name');
             if ($plan->completedStage($name)) {
-                continue;
-            }
-
-            if ($plan->skipped($name)) {
-                $outcome = $this->outcome($name, [
-                    'ok' => true,
-                    'changed' => false,
-                    'skipped' => true,
-                    'evidence' => ['reason' => 'explicit_skip'],
-                ]);
-                $plan->checkpoint($name, $outcome);
-                $this->checkpoints->save($plan->id(), $plan->toArray());
                 continue;
             }
 
@@ -97,18 +116,58 @@ class InstallationExecutor
             $plan->checkpoint($name, $outcome);
             if (Flag::make(Arr::getPath($outcome, 'ok', false))->isFalse()) {
                 $plan->fail($name, $outcome);
-                $this->checkpoints->save($plan->id(), $plan->toArray());
+                $this->save($plan);
 
                 return $this->result($plan, false);
             }
 
-            $this->checkpoints->save($plan->id(), $plan->toArray());
+            $this->save($plan);
         }
 
         $plan->complete();
-        $this->checkpoints->save($plan->id(), $plan->toArray());
+        $this->save($plan);
 
         return $this->result($plan, true);
+    }
+
+    private function validate(array $context): array
+    {
+        try {
+            $result = $this->validator?->call($context);
+        } catch (\Throwable $exception) {
+            return [[
+                'reason' => 'validation_exception',
+                'message' => $exception->getMessage(),
+                'exception' => $exception::class,
+            ]];
+        }
+
+        if (Val::isNull($result) || Flag::make($result)->isTrue()) {
+            return [];
+        }
+        if (Flag::make($result)->isFalse()) {
+            return [[
+                'reason' => 'invalid_context',
+                'message' => 'The host rejected the installation context.',
+            ]];
+        }
+        if (Str::is($result)) {
+            return [['reason' => 'invalid_context', 'message' => $result]];
+        }
+        if (Arr::is($result)) {
+            return Arr::hasKey($result, 'message')
+                ? [Arr::make($result)->toArray()]
+                : Arr::make($result)->values()->toArray();
+        }
+
+        throw new \UnexpectedValueException('Installation validators must return null, bool, string, or diagnostics.');
+    }
+
+    private function save(InstallationPlan $plan): void
+    {
+        if (Val::isNotNull($this->checkpoints)) {
+            $this->checkpoints->save($plan->id(), $plan->toArray());
+        }
     }
 
     private function outcome(string $stage, mixed $raw): array

--- a/src/BlueCore/Installation/InstallationExecutor.php
+++ b/src/BlueCore/Installation/InstallationExecutor.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace BlueFission\BlueCore\Installation;
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Contracts\IInstallationCheckpointStore;
+use BlueFission\Collections\Collection;
+use BlueFission\Flag;
+use BlueFission\Func;
+use BlueFission\Str;
+use BlueFission\Val;
+
+class InstallationExecutor
+{
+    private Collection $stages;
+
+    public function __construct(private IInstallationCheckpointStore $checkpoints)
+    {
+        $this->stages = new Collection();
+    }
+
+    public function stage(string $name, callable|Func $operation, array $permissions = []): self
+    {
+        $name = Str::make($name)->trim()->val();
+        if (Val::isEmpty($name)) {
+            throw new \InvalidArgumentException('Installation stage name cannot be empty.');
+        }
+
+        $this->stages->add([
+            'name' => $name,
+            'operation' => $operation instanceof Func ? $operation : Func::make($operation),
+            'permissions' => Arr::make($permissions)->values()->unique()->toArray(),
+        ], $name);
+
+        return $this;
+    }
+
+    public function prepare(array $packet): InstallationPlan
+    {
+        $plan = new InstallationPlan($packet);
+        $permissions = Arr::make([]);
+        foreach ($this->stages as $stage) {
+            $stage = Arr::make($stage);
+            $permissions->merge($stage->get('permissions', []));
+        }
+        $plan->requestPermissions($permissions->values()->unique()->toArray());
+        $this->checkpoints->save($plan->id(), $plan->toArray());
+
+        return $plan;
+    }
+
+    public function resume(string $planId): ?InstallationPlan
+    {
+        $checkpoint = $this->checkpoints->load($planId);
+
+        return Val::isNull($checkpoint) ? null : InstallationPlan::restore($checkpoint);
+    }
+
+    public function execute(InstallationPlan $plan): array
+    {
+        $plan->start();
+        $this->checkpoints->save($plan->id(), $plan->toArray());
+
+        foreach ($this->stages as $stage) {
+            $stage = Arr::make($stage);
+            $name = (string)$stage->get('name');
+            if ($plan->completedStage($name)) {
+                continue;
+            }
+
+            if ($plan->skipped($name)) {
+                $outcome = $this->outcome($name, [
+                    'ok' => true,
+                    'changed' => false,
+                    'skipped' => true,
+                    'evidence' => ['reason' => 'explicit_skip'],
+                ]);
+                $plan->checkpoint($name, $outcome);
+                $this->checkpoints->save($plan->id(), $plan->toArray());
+                continue;
+            }
+
+            $operation = $stage->get('operation');
+            try {
+                $raw = $operation instanceof Func ? $operation->call($plan) : null;
+                $outcome = $this->outcome($name, $raw);
+            } catch (\Throwable $exception) {
+                $outcome = $this->outcome($name, [
+                    'ok' => false,
+                    'changed' => false,
+                    'error' => $exception->getMessage(),
+                    'exception' => $exception::class,
+                    'nextAction' => 'retry_'.$name,
+                ]);
+            }
+
+            $plan->checkpoint($name, $outcome);
+            if (Flag::make(Arr::getPath($outcome, 'ok', false))->isFalse()) {
+                $plan->fail($name, $outcome);
+                $this->checkpoints->save($plan->id(), $plan->toArray());
+
+                return $this->result($plan, false);
+            }
+
+            $this->checkpoints->save($plan->id(), $plan->toArray());
+        }
+
+        $plan->complete();
+        $this->checkpoints->save($plan->id(), $plan->toArray());
+
+        return $this->result($plan, true);
+    }
+
+    private function outcome(string $stage, mixed $raw): array
+    {
+        if (Flag::make($raw)->isBool()) {
+            $raw = ['ok' => $raw, 'changed' => $raw];
+        } elseif (Val::isNull($raw)) {
+            $raw = ['ok' => true, 'changed' => false];
+        } elseif (!Arr::is($raw)) {
+            $raw = [
+                'ok' => true,
+                'changed' => true,
+                'evidence' => ['result' => $raw],
+            ];
+        }
+
+        $outcome = Arr::make([
+            'stage' => $stage,
+            'ok' => false,
+            'changed' => false,
+            'skipped' => false,
+            'evidence' => [],
+            'error' => null,
+            'exception' => null,
+            'nextAction' => null,
+        ])->merge($raw);
+
+        if (Flag::make($outcome->get('ok'))->isFalse()
+            && Val::isEmpty($outcome->get('nextAction'))) {
+            $outcome->set('nextAction', 'retry_'.$stage);
+        }
+
+        return $outcome->toArray();
+    }
+
+    private function result(InstallationPlan $plan, bool $ok): array
+    {
+        $data = $plan->toArray();
+
+        return Arr::make([
+            'ok' => $ok,
+            'plan_id' => $plan->id(),
+            'status' => $plan->status(),
+            'outcomes' => Arr::getPath($data, 'outcomes', []),
+            'failure' => Arr::getPath($data, 'failure'),
+            'nextAction' => $ok ? null : Arr::getPath($data, 'failure.nextAction'),
+        ])->toArray();
+    }
+}

--- a/src/BlueCore/Installation/InstallationPlan.php
+++ b/src/BlueCore/Installation/InstallationPlan.php
@@ -7,7 +7,6 @@ use BlueFission\Behavioral\Behaviors\State;
 use BlueFission\Collections\Collection;
 use BlueFission\Date;
 use BlueFission\Flag;
-use BlueFission\Net\HTTP;
 use BlueFission\Obj;
 use BlueFission\Str;
 use BlueFission\Val;
@@ -16,7 +15,7 @@ class InstallationPlan extends Obj
 {
     public const VERSION = 1;
     public const STATUS_DRAFT = 'draft';
-    public const STATUS_REVIEW_READY = 'review_ready';
+    public const STATUS_READY = 'ready';
     public const STATUS_APPROVED = 'approved';
     public const STATUS_EXECUTING = 'executing';
     public const STATUS_COMPLETED = 'completed';
@@ -24,77 +23,40 @@ class InstallationPlan extends Obj
 
     private const BEHAVIORS = [
         self::STATUS_DRAFT => 'IsInstallationDraft',
-        self::STATUS_REVIEW_READY => 'IsInstallationReviewReady',
+        self::STATUS_READY => 'IsInstallationReady',
         self::STATUS_APPROVED => 'IsInstallationApproved',
         self::STATUS_EXECUTING => 'IsInstallationExecuting',
         self::STATUS_COMPLETED => 'IsInstallationCompleted',
         self::STATUS_FAILED => 'IsInstallationFailed',
     ];
 
-    public function __construct(array $packet = [])
+    public function __construct(array $context = [], ?string $id = null)
     {
         parent::__construct();
 
-        $values = Arr::make(Arr::getPath($packet, 'values', []));
-        $projectName = Str::make((string)Arr::getPath(
-            $packet,
-            'project_name',
-            $values->get('project_name', '')
-        ))->trim()->val();
-        if (Val::isNotEmpty($projectName)) {
-            $values->set('project_name', $projectName);
+        $planId = Str::make((string)$id)->trim()->val();
+        if (Val::isEmpty($planId)) {
+            $planId = Str::make('installation-')->append(Str::rand('', 16))->val();
         }
 
-        $diagnostics = new Collection();
-        $version = (int)Arr::getPath($packet, 'version', self::VERSION);
-        if ($version !== self::VERSION) {
-            $diagnostics->add([
-                'field' => 'version',
-                'reason' => 'unsupported_version',
-                'message' => 'The installation plan version is not supported.',
-            ]);
-        }
-        if (Val::isEmpty($projectName)) {
-            $diagnostics->add([
-                'field' => 'project_name',
-                'reason' => 'required',
-                'message' => 'Project name is required.',
-            ]);
-        }
-
-        $id = Str::make((string)Arr::getPath($packet, 'id', ''))->trim()->val();
-        if (Val::isEmpty($id)) {
-            $slug = Str::make(Val::isEmpty($projectName) ? 'installation' : $projectName)->slugify();
-            $fingerprint = Str::make((string)HTTP::jsonEncode($packet))->encrypt('sha1')->val();
-            $id = Str::make((string)$slug)->append('-')->append(Str::sub($fingerprint, 0, 12))->val();
-        }
-
-        $status = Arr::isEmpty($diagnostics->toArray())
-            ? self::STATUS_REVIEW_READY
-            : self::STATUS_DRAFT;
         $now = Date::now()->val();
-
         $this->_data = Arr::make([
-            'id' => $id,
+            'id' => $planId,
             'version' => self::VERSION,
-            'project_name' => $projectName,
-            'values' => $values->toArray(),
-            'defaults' => Arr::make(Arr::getPath($packet, 'defaults', []))->toArray(),
-            'skips' => Arr::make(Arr::getPath($packet, 'skips', []))->values()->unique()->toArray(),
-            'permissions' => Arr::make(Arr::getPath($packet, 'permissions', []))->values()->unique()->toArray(),
-            'granted_permissions' => Arr::make(Arr::getPath($packet, 'granted_permissions', []))->values()->unique()->toArray(),
-            'diagnostics' => $diagnostics->toArray(),
-            'status' => $status,
-            'checkpoints' => Arr::make(Arr::getPath($packet, 'checkpoints', []))->toArray(),
-            'outcomes' => Arr::make(Arr::getPath($packet, 'outcomes', []))->toArray(),
-            'created_at' => Arr::getPath($packet, 'created_at', $now),
+            'context' => Arr::make($context)->toArray(),
+            'diagnostics' => [],
+            'status' => self::STATUS_READY,
+            'approval_evidence' => [],
+            'checkpoints' => [],
+            'outcomes' => [],
+            'created_at' => $now,
             'updated_at' => $now,
-            'approved_at' => Arr::getPath($packet, 'approved_at'),
-            'completed_at' => Arr::getPath($packet, 'completed_at'),
-            'failure' => Arr::getPath($packet, 'failure'),
+            'approved_at' => null,
+            'completed_at' => null,
+            'failure' => null,
         ]);
 
-        $this->transition($status);
+        $this->transition(self::STATUS_READY, false);
     }
 
     protected function init()
@@ -107,11 +69,36 @@ class InstallationPlan extends Obj
 
     public static function restore(array $checkpoint): self
     {
-        $plan = new self($checkpoint);
-        $status = (string)Arr::getPath($checkpoint, 'status', '');
-        if (Arr::hasKey(self::BEHAVIORS, $status)) {
-            $plan->transition($status);
+        $version = (int)Arr::getPath($checkpoint, 'version', self::VERSION);
+        if ($version !== self::VERSION) {
+            throw new \InvalidArgumentException('The installation checkpoint version is not supported.');
         }
+
+        $plan = new self(
+            Arr::make(Arr::getPath($checkpoint, 'context', []))->toArray(),
+            (string)Arr::getPath($checkpoint, 'id', '')
+        );
+        $status = (string)Arr::getPath($checkpoint, 'status', self::STATUS_READY);
+        if (!Arr::hasKey(self::BEHAVIORS, $status)) {
+            $status = self::STATUS_READY;
+        }
+
+        $plan->_data = Arr::make([
+            'id' => $plan->id(),
+            'version' => self::VERSION,
+            'context' => Arr::make(Arr::getPath($checkpoint, 'context', []))->toArray(),
+            'diagnostics' => Arr::make(Arr::getPath($checkpoint, 'diagnostics', []))->toArray(),
+            'status' => $status,
+            'approval_evidence' => Arr::make(Arr::getPath($checkpoint, 'approval_evidence', []))->toArray(),
+            'checkpoints' => Arr::make(Arr::getPath($checkpoint, 'checkpoints', []))->toArray(),
+            'outcomes' => Arr::make(Arr::getPath($checkpoint, 'outcomes', []))->toArray(),
+            'created_at' => Arr::getPath($checkpoint, 'created_at', Date::now()->val()),
+            'updated_at' => Arr::getPath($checkpoint, 'updated_at', Date::now()->val()),
+            'approved_at' => Arr::getPath($checkpoint, 'approved_at'),
+            'completed_at' => Arr::getPath($checkpoint, 'completed_at'),
+            'failure' => Arr::getPath($checkpoint, 'failure'),
+        ]);
+        $plan->transition($status, false);
 
         return $plan;
     }
@@ -131,44 +118,30 @@ class InstallationPlan extends Obj
         return self::BEHAVIORS[$this->status()];
     }
 
+    public function context(): array
+    {
+        return Arr::make($this->_data->get('context', []))->toArray();
+    }
+
     public function diagnostics(): array
     {
         return Arr::make($this->_data->get('diagnostics', []))->toArray();
     }
 
-    public function values(): array
+    public function applyDiagnostics(array $diagnostics): self
     {
-        return Arr::make($this->_data->get('values', []))
-            ->merge($this->_data->get('defaults', []))
-            ->merge($this->_data->get('values', []))
-            ->toArray();
-    }
-
-    public function skipped(string $stage): bool
-    {
-        return Arr::has($this->_data->get('skips', []), $stage, true);
-    }
-
-    public function requestPermissions(array $permissions): self
-    {
-        $requested = Arr::make($this->_data->get('permissions', []))
-            ->merge($permissions)
-            ->values()
-            ->unique()
-            ->toArray();
-        $this->_data->set('permissions', $requested);
-        $this->touch();
+        $normalized = (new Collection($diagnostics))->toArray();
+        $this->_data->set('diagnostics', $normalized);
+        $this->transition(
+            Arr::isEmpty($normalized) ? self::STATUS_READY : self::STATUS_DRAFT
+        );
 
         return $this;
     }
 
-    public function approve(array $grantedPermissions): self
+    public function approve(array $evidence = []): self
     {
-        if (!Arr::has(
-            [self::STATUS_REVIEW_READY, self::STATUS_FAILED],
-            $this->status(),
-            true
-        )) {
+        if ($this->status() !== self::STATUS_READY) {
             throw new \LogicException('Installation plan is not ready for approval.');
         }
 
@@ -176,15 +149,7 @@ class InstallationPlan extends Obj
             throw new \LogicException('An invalid installation plan cannot be approved.');
         }
 
-        $granted = Arr::make($grantedPermissions)->values()->unique()->toArray();
-        $missing = Arr::make($this->_data->get('permissions', []))->diff($granted)->toArray();
-        if (Arr::isNotEmpty($missing)) {
-            throw new \LogicException(
-                'Installation permissions require review: '.Arr::make($missing)->join(', ')->val()
-            );
-        }
-
-        $this->_data->set('granted_permissions', $granted);
+        $this->_data->set('approval_evidence', Arr::make($evidence)->toArray());
         $this->_data->set('approved_at', Date::now()->val());
         $this->_data->set('failure', null);
         $this->transition(self::STATUS_APPROVED);
@@ -198,13 +163,25 @@ class InstallationPlan extends Obj
             throw new \LogicException('Only a failed installation plan can be retried.');
         }
 
-        return $this->approve($this->_data->get('granted_permissions', []));
+        $this->_data->set('failure', null);
+        $this->_data->set('approval_evidence', []);
+        $this->_data->set('approved_at', null);
+        $this->transition(self::STATUS_READY);
+
+        return $this;
     }
 
-    public function start(): self
+    public function start(bool $approvalRequired = false): self
     {
-        if ($this->status() !== self::STATUS_APPROVED) {
-            throw new \LogicException('Installation execution requires explicit approval.');
+        $allowed = $approvalRequired
+            ? [self::STATUS_APPROVED]
+            : [self::STATUS_READY, self::STATUS_APPROVED];
+        if (!Arr::has($allowed, $this->status(), true)) {
+            throw new \LogicException(
+                $approvalRequired
+                    ? 'Installation execution requires host approval.'
+                    : 'Installation plan is not ready for execution.'
+            );
         }
 
         $this->transition(self::STATUS_EXECUTING);
@@ -233,8 +210,7 @@ class InstallationPlan extends Obj
     {
         $checkpoint = Arr::getPath($this->_data->get('checkpoints', []), $stage, []);
 
-        return Flag::make(Arr::getPath($checkpoint, 'ok', false))->parseBool()
-            && !Flag::make(Arr::getPath($checkpoint, 'skipped', false))->parseBool();
+        return Flag::make(Arr::getPath($checkpoint, 'ok', false))->parseBool();
     }
 
     public function complete(): self
@@ -253,14 +229,16 @@ class InstallationPlan extends Obj
         return $this;
     }
 
-    private function transition(string $status): void
+    private function transition(string $status, bool $touch = true): void
     {
         foreach (self::BEHAVIORS as $behavior) {
             $this->halt($behavior);
         }
         $this->halt(State::DRAFT);
         $this->_data->set('status', $status);
-        $this->touch();
+        if ($touch) {
+            $this->touch();
+        }
         $this->perform(self::BEHAVIORS[$status]);
     }
 

--- a/src/BlueCore/Installation/InstallationPlan.php
+++ b/src/BlueCore/Installation/InstallationPlan.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace BlueFission\BlueCore\Installation;
+
+use BlueFission\Arr;
+use BlueFission\Behavioral\Behaviors\State;
+use BlueFission\Collections\Collection;
+use BlueFission\Date;
+use BlueFission\Flag;
+use BlueFission\Net\HTTP;
+use BlueFission\Obj;
+use BlueFission\Str;
+use BlueFission\Val;
+
+class InstallationPlan extends Obj
+{
+    public const VERSION = 1;
+    public const STATUS_DRAFT = 'draft';
+    public const STATUS_REVIEW_READY = 'review_ready';
+    public const STATUS_APPROVED = 'approved';
+    public const STATUS_EXECUTING = 'executing';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_FAILED = 'failed';
+
+    private const BEHAVIORS = [
+        self::STATUS_DRAFT => 'IsInstallationDraft',
+        self::STATUS_REVIEW_READY => 'IsInstallationReviewReady',
+        self::STATUS_APPROVED => 'IsInstallationApproved',
+        self::STATUS_EXECUTING => 'IsInstallationExecuting',
+        self::STATUS_COMPLETED => 'IsInstallationCompleted',
+        self::STATUS_FAILED => 'IsInstallationFailed',
+    ];
+
+    public function __construct(array $packet = [])
+    {
+        parent::__construct();
+
+        $values = Arr::make(Arr::getPath($packet, 'values', []));
+        $projectName = Str::make((string)Arr::getPath(
+            $packet,
+            'project_name',
+            $values->get('project_name', '')
+        ))->trim()->val();
+        if (Val::isNotEmpty($projectName)) {
+            $values->set('project_name', $projectName);
+        }
+
+        $diagnostics = new Collection();
+        $version = (int)Arr::getPath($packet, 'version', self::VERSION);
+        if ($version !== self::VERSION) {
+            $diagnostics->add([
+                'field' => 'version',
+                'reason' => 'unsupported_version',
+                'message' => 'The installation plan version is not supported.',
+            ]);
+        }
+        if (Val::isEmpty($projectName)) {
+            $diagnostics->add([
+                'field' => 'project_name',
+                'reason' => 'required',
+                'message' => 'Project name is required.',
+            ]);
+        }
+
+        $id = Str::make((string)Arr::getPath($packet, 'id', ''))->trim()->val();
+        if (Val::isEmpty($id)) {
+            $slug = Str::make(Val::isEmpty($projectName) ? 'installation' : $projectName)->slugify();
+            $fingerprint = Str::make((string)HTTP::jsonEncode($packet))->encrypt('sha1')->val();
+            $id = Str::make((string)$slug)->append('-')->append(Str::sub($fingerprint, 0, 12))->val();
+        }
+
+        $status = Arr::isEmpty($diagnostics->toArray())
+            ? self::STATUS_REVIEW_READY
+            : self::STATUS_DRAFT;
+        $now = Date::now()->val();
+
+        $this->_data = Arr::make([
+            'id' => $id,
+            'version' => self::VERSION,
+            'project_name' => $projectName,
+            'values' => $values->toArray(),
+            'defaults' => Arr::make(Arr::getPath($packet, 'defaults', []))->toArray(),
+            'skips' => Arr::make(Arr::getPath($packet, 'skips', []))->values()->unique()->toArray(),
+            'permissions' => Arr::make(Arr::getPath($packet, 'permissions', []))->values()->unique()->toArray(),
+            'granted_permissions' => Arr::make(Arr::getPath($packet, 'granted_permissions', []))->values()->unique()->toArray(),
+            'diagnostics' => $diagnostics->toArray(),
+            'status' => $status,
+            'checkpoints' => Arr::make(Arr::getPath($packet, 'checkpoints', []))->toArray(),
+            'outcomes' => Arr::make(Arr::getPath($packet, 'outcomes', []))->toArray(),
+            'created_at' => Arr::getPath($packet, 'created_at', $now),
+            'updated_at' => $now,
+            'approved_at' => Arr::getPath($packet, 'approved_at'),
+            'completed_at' => Arr::getPath($packet, 'completed_at'),
+            'failure' => Arr::getPath($packet, 'failure'),
+        ]);
+
+        $this->transition($status);
+    }
+
+    protected function init()
+    {
+        parent::init();
+        foreach (self::BEHAVIORS as $behavior) {
+            $this->behavior(new State($behavior));
+        }
+    }
+
+    public static function restore(array $checkpoint): self
+    {
+        $plan = new self($checkpoint);
+        $status = (string)Arr::getPath($checkpoint, 'status', '');
+        if (Arr::hasKey(self::BEHAVIORS, $status)) {
+            $plan->transition($status);
+        }
+
+        return $plan;
+    }
+
+    public function id(): string
+    {
+        return (string)$this->_data->get('id');
+    }
+
+    public function status(): string
+    {
+        return (string)$this->_data->get('status');
+    }
+
+    public function behaviorState(): string
+    {
+        return self::BEHAVIORS[$this->status()];
+    }
+
+    public function diagnostics(): array
+    {
+        return Arr::make($this->_data->get('diagnostics', []))->toArray();
+    }
+
+    public function values(): array
+    {
+        return Arr::make($this->_data->get('values', []))
+            ->merge($this->_data->get('defaults', []))
+            ->merge($this->_data->get('values', []))
+            ->toArray();
+    }
+
+    public function skipped(string $stage): bool
+    {
+        return Arr::has($this->_data->get('skips', []), $stage, true);
+    }
+
+    public function requestPermissions(array $permissions): self
+    {
+        $requested = Arr::make($this->_data->get('permissions', []))
+            ->merge($permissions)
+            ->values()
+            ->unique()
+            ->toArray();
+        $this->_data->set('permissions', $requested);
+        $this->touch();
+
+        return $this;
+    }
+
+    public function approve(array $grantedPermissions): self
+    {
+        if (!Arr::has(
+            [self::STATUS_REVIEW_READY, self::STATUS_FAILED],
+            $this->status(),
+            true
+        )) {
+            throw new \LogicException('Installation plan is not ready for approval.');
+        }
+
+        if (Arr::isNotEmpty($this->diagnostics())) {
+            throw new \LogicException('An invalid installation plan cannot be approved.');
+        }
+
+        $granted = Arr::make($grantedPermissions)->values()->unique()->toArray();
+        $missing = Arr::make($this->_data->get('permissions', []))->diff($granted)->toArray();
+        if (Arr::isNotEmpty($missing)) {
+            throw new \LogicException(
+                'Installation permissions require review: '.Arr::make($missing)->join(', ')->val()
+            );
+        }
+
+        $this->_data->set('granted_permissions', $granted);
+        $this->_data->set('approved_at', Date::now()->val());
+        $this->_data->set('failure', null);
+        $this->transition(self::STATUS_APPROVED);
+
+        return $this;
+    }
+
+    public function retry(): self
+    {
+        if ($this->status() !== self::STATUS_FAILED) {
+            throw new \LogicException('Only a failed installation plan can be retried.');
+        }
+
+        return $this->approve($this->_data->get('granted_permissions', []));
+    }
+
+    public function start(): self
+    {
+        if ($this->status() !== self::STATUS_APPROVED) {
+            throw new \LogicException('Installation execution requires explicit approval.');
+        }
+
+        $this->transition(self::STATUS_EXECUTING);
+
+        return $this;
+    }
+
+    public function checkpoint(string $stage, array $outcome): self
+    {
+        $checkpoints = Arr::make($this->_data->get('checkpoints', []));
+        $outcomes = Arr::make($this->_data->get('outcomes', []));
+        $record = Arr::make($outcome)
+            ->merge(['stage' => $stage, 'recorded_at' => Date::now()->val()])
+            ->toArray();
+
+        $checkpoints->set($stage, $record);
+        $outcomes->set($stage, $record);
+        $this->_data->set('checkpoints', $checkpoints->toArray());
+        $this->_data->set('outcomes', $outcomes->toArray());
+        $this->touch();
+
+        return $this;
+    }
+
+    public function completedStage(string $stage): bool
+    {
+        $checkpoint = Arr::getPath($this->_data->get('checkpoints', []), $stage, []);
+
+        return Flag::make(Arr::getPath($checkpoint, 'ok', false))->parseBool()
+            && !Flag::make(Arr::getPath($checkpoint, 'skipped', false))->parseBool();
+    }
+
+    public function complete(): self
+    {
+        $this->_data->set('completed_at', Date::now()->val());
+        $this->transition(self::STATUS_COMPLETED);
+
+        return $this;
+    }
+
+    public function fail(string $stage, array $failure): self
+    {
+        $this->_data->set('failure', Arr::make($failure)->merge(['stage' => $stage])->toArray());
+        $this->transition(self::STATUS_FAILED);
+
+        return $this;
+    }
+
+    private function transition(string $status): void
+    {
+        foreach (self::BEHAVIORS as $behavior) {
+            $this->halt($behavior);
+        }
+        $this->halt(State::DRAFT);
+        $this->_data->set('status', $status);
+        $this->touch();
+        $this->perform(self::BEHAVIORS[$status]);
+    }
+
+    private function touch(): void
+    {
+        $this->_data->set('updated_at', Date::now()->val());
+    }
+}

--- a/src/BlueCore/Installation/JsonInstallationCheckpointStore.php
+++ b/src/BlueCore/Installation/JsonInstallationCheckpointStore.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BlueFission\BlueCore\Installation;
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Contracts\IInstallationCheckpointStore;
+use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+use BlueFission\Val;
+
+class JsonInstallationCheckpointStore implements IInstallationCheckpointStore
+{
+    private string $directory;
+
+    public function __construct(string $directory)
+    {
+        $this->directory = Path::ensureDir($directory);
+    }
+
+    public function load(string $planId): ?array
+    {
+        $path = $this->path($planId);
+        if (!FileSystem::fileExists($path)) {
+            return null;
+        }
+
+        $decoded = HTTP::jsonDecode(File::readContents($path), true, null);
+        if (!Arr::is($decoded)) {
+            throw new \RuntimeException("Invalid installation checkpoint for {$planId}.");
+        }
+
+        return Arr::make($decoded)->toArray();
+    }
+
+    public function save(string $planId, array $checkpoint): void
+    {
+        $encoded = HTTP::jsonEncode(Arr::make($checkpoint)->toArray());
+        if (!Str::is($encoded)) {
+            throw new \RuntimeException("Unable to encode installation checkpoint for {$planId}.");
+        }
+
+        File::writeAtomic($this->path($planId), $encoded);
+    }
+
+    public function delete(string $planId): void
+    {
+        $path = $this->path($planId);
+        if (FileSystem::fileExists($path) && !File::deletePath($path)) {
+            throw new \RuntimeException("Unable to delete installation checkpoint for {$planId}.");
+        }
+    }
+
+    private function path(string $planId): string
+    {
+        $id = Str::make($planId)->trim()->val();
+        if (Val::isEmpty($id) || !Str::matchPattern($id, '/^[A-Za-z0-9._-]+$/')) {
+            throw new \InvalidArgumentException('Installation plan id contains unsupported characters.');
+        }
+
+        return Path::normalize($this->directory.DIRECTORY_SEPARATOR.$id.'.json');
+    }
+}

--- a/src/Utils/File.php
+++ b/src/Utils/File.php
@@ -3,12 +3,23 @@
 namespace BlueFission\Utils;
 
 use BlueFission\Data\File as BaseFile;
+use BlueFission\Data\FileSystem;
 use BlueFission\Arr;
 use BlueFission\Flag;
 use BlueFission\Val;
 
 class File extends BaseFile
 {
+    public static function deletePath($path): bool
+    {
+        $normalized = Path::normalize($path);
+        if (Val::isEmpty($normalized) || !FileSystem::fileExists($normalized)) {
+            return false;
+        }
+
+        return unlink($normalized);
+    }
+
     public static function ensureFile($path, $contents = '', $overwrite = false)
     {
         $normalized = Path::normalize($path);

--- a/tests/BlueCore/Installation/InstallationExecutorTest.php
+++ b/tests/BlueCore/Installation/InstallationExecutorTest.php
@@ -39,48 +39,86 @@ class InstallationExecutorTest extends TestCase
         rmdir($this->checkpointDirectory);
     }
 
-    public function testPlanMakesDefaultsSkipsAndValidationExplicit(): void
+    public function testPlanPreservesOpaqueHostContextWithoutUniversalFields(): void
     {
-        $executor = $this->executor();
-        $invalid = $executor->prepare([]);
+        $executor = new InstallationExecutor();
+        $context = [
+            'host_defined' => ['mode' => 'custom'],
+            'capabilities' => ['registration'],
+        ];
 
-        $this->assertSame(InstallationPlan::STATUS_DRAFT, $invalid->status());
-        $this->assertSame('required', $invalid->diagnostics()[0]['reason']);
+        $plan = $executor->prepare($context, 'opaque-plan');
 
-        $plan = $executor->prepare([
-            'project_name' => 'Materia Host',
-            'values' => ['environment' => 'production'],
-            'defaults' => ['region' => 'global', 'environment' => 'local'],
-            'skips' => ['population'],
-        ]);
-
-        $this->assertSame(InstallationPlan::STATUS_REVIEW_READY, $plan->status());
-        $this->assertSame('production', $plan->values()['environment']);
-        $this->assertSame('global', $plan->values()['region']);
-        $this->assertTrue($plan->skipped('population'));
+        $this->assertSame('opaque-plan', $plan->id());
+        $this->assertSame(InstallationPlan::STATUS_READY, $plan->status());
+        $this->assertSame($context, $plan->context());
+        $this->assertSame([], $plan->diagnostics());
         $this->assertTrue($plan->is($plan->behaviorState()));
+        $this->assertArrayNotHasKey('project_name', $plan->toArray());
+        $this->assertArrayNotHasKey('permissions', $plan->toArray());
+        $this->assertArrayNotHasKey('skips', $plan->toArray());
     }
 
-    public function testExecutionRequiresPermissionReviewBeforeSideEffects(): void
+    public function testHostValidatorOwnsContextRequirements(): void
     {
-        $calls = 0;
-        $executor = $this->executor()
-            ->stage('packages', function () use (&$calls): array {
-                $calls++;
-                return ['ok' => true, 'changed' => true];
-            }, ['write_project']);
-        $plan = $executor->prepare(['project_name' => 'Guarded Host']);
+        $executor = (new InstallationExecutor())->validator(
+            fn (array $context): array => Arr::hasKey($context, 'definition')
+                ? []
+                : [[
+                    'field' => 'definition',
+                    'reason' => 'required_by_host',
+                    'message' => 'A host definition is required.',
+                ]]
+        );
+
+        $invalid = $executor->prepare([]);
+        $valid = $executor->prepare(['definition' => ['type' => 'application']]);
+
+        $this->assertSame(InstallationPlan::STATUS_DRAFT, $invalid->status());
+        $this->assertSame('required_by_host', $invalid->diagnostics()[0]['reason']);
+        $this->assertSame(InstallationPlan::STATUS_READY, $valid->status());
+    }
+
+    public function testApprovalGateIsOptionalAndStoresOpaqueHostEvidence(): void
+    {
+        $unguardedCalls = 0;
+        $unguarded = (new InstallationExecutor())
+            ->stage('operation', function () use (&$unguardedCalls): bool {
+                $unguardedCalls++;
+                return true;
+            });
+        $unguardedResult = $unguarded->execute($unguarded->prepare());
+
+        $this->assertTrue($unguardedResult['ok']);
+        $this->assertSame(1, $unguardedCalls);
+
+        $guardedCalls = 0;
+        $guarded = (new InstallationExecutor())
+            ->requireApproval()
+            ->stage('operation', function () use (&$guardedCalls): bool {
+                $guardedCalls++;
+                return true;
+            }, ['owner' => 'host']);
+        $plan = $guarded->prepare();
 
         try {
-            $executor->execute($plan);
-            $this->fail('Execution should require approval.');
+            $guarded->execute($plan);
+            $this->fail('Execution should require host approval when the gate is enabled.');
         } catch (\LogicException $exception) {
-            $this->assertSame('Installation execution requires explicit approval.', $exception->getMessage());
+            $this->assertSame('Installation execution requires host approval.', $exception->getMessage());
         }
-        $this->assertSame(0, $calls);
+        $this->assertSame(0, $guardedCalls);
+        $this->assertSame(['name' => 'operation', 'metadata' => ['owner' => 'host']], $guarded->stages()[0]);
 
-        $this->expectException(\LogicException::class);
-        $plan->approve([]);
+        $plan->approve(['decision_id' => 'host-decision-1']);
+        $this->assertSame(
+            ['decision_id' => 'host-decision-1'],
+            Arr::getPath($plan->toArray(), 'approval_evidence')
+        );
+        $result = $guarded->execute($plan);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(1, $guardedCalls);
     }
 
     public function testCompletedStagesAreNotRepeatedDuringCheckpointResume(): void
@@ -95,16 +133,15 @@ class InstallationExecutorTest extends TestCase
                     'changed' => true,
                     'evidence' => ['owner' => 'package_installer'],
                 ];
-            }, ['write_project'])
+            })
             ->stage('migrations', function () use (&$migrationCalls): array {
                 $migrationCalls++;
                 return $migrationCalls === 1
                     ? ['ok' => false, 'error' => 'temporary failure']
                     : ['ok' => true, 'changed' => true, 'evidence' => ['applied' => 2]];
-            }, ['write_database']);
+            });
 
-        $plan = $executor->prepare(['project_name' => 'Resumable Host']);
-        $plan->approve(['write_project', 'write_database']);
+        $plan = $executor->prepare(['host_defined' => true]);
         $first = $executor->execute($plan);
 
         $this->assertFalse($first['ok']);
@@ -124,28 +161,27 @@ class InstallationExecutorTest extends TestCase
         $this->assertSame(2, Arr::getPath($second, 'outcomes.migrations.evidence.applied'));
     }
 
-    public function testExplicitlySkippedStageProducesStructuredEvidence(): void
+    public function testHostStageCanReturnStructuredSkipEvidence(): void
     {
-        $calls = 0;
-        $executor = $this->executor()->stage('population', function () use (&$calls): bool {
-            $calls++;
-            return true;
-        });
-        $plan = $executor->prepare([
-            'project_name' => 'Skip Host',
-            'skips' => ['population'],
+        $executor = (new InstallationExecutor())->stage('optional', fn (): array => [
+            'ok' => true,
+            'changed' => false,
+            'skipped' => true,
+            'evidence' => ['reason' => 'host_policy'],
         ]);
-        $plan->approve([]);
 
-        $result = $executor->execute($plan);
+        $result = $executor->execute($executor->prepare());
 
         $this->assertTrue($result['ok']);
-        $this->assertSame(0, $calls);
-        $this->assertTrue(Arr::getPath($result, 'outcomes.population.skipped'));
-        $this->assertSame(
-            'explicit_skip',
-            Arr::getPath($result, 'outcomes.population.evidence.reason')
-        );
+        $this->assertTrue(Arr::getPath($result, 'outcomes.optional.skipped'));
+        $this->assertSame('host_policy', Arr::getPath($result, 'outcomes.optional.evidence.reason'));
+    }
+
+    public function testResumeRequiresAnExplicitCheckpointStore(): void
+    {
+        $this->expectException(\LogicException::class);
+
+        (new InstallationExecutor())->resume('missing');
     }
 
     private function executor(): InstallationExecutor

--- a/tests/BlueCore/Installation/InstallationExecutorTest.php
+++ b/tests/BlueCore/Installation/InstallationExecutorTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Installation;
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Installation\InstallationExecutor;
+use BlueFission\BlueCore\Installation\InstallationPlan;
+use BlueFission\BlueCore\Installation\JsonInstallationCheckpointStore;
+use BlueFission\Data\FileSystem;
+use BlueFission\Str;
+use BlueFission\Utils\File;
+use BlueFission\Utils\Path;
+use PHPUnit\Framework\TestCase;
+
+class InstallationExecutorTest extends TestCase
+{
+    private string $checkpointDirectory;
+
+    protected function setUp(): void
+    {
+        $this->checkpointDirectory = Path::ensureDir(
+            Path::normalize(
+                sys_get_temp_dir().DIRECTORY_SEPARATOR.'bluecore-installation-'.Str::rand('', 10)
+            )
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (!FileSystem::directoryExists($this->checkpointDirectory)) {
+            return;
+        }
+
+        foreach (glob($this->checkpointDirectory.DIRECTORY_SEPARATOR.'*') ?: [] as $path) {
+            if (FileSystem::fileExists($path)) {
+                File::deletePath($path);
+            }
+        }
+        rmdir($this->checkpointDirectory);
+    }
+
+    public function testPlanMakesDefaultsSkipsAndValidationExplicit(): void
+    {
+        $executor = $this->executor();
+        $invalid = $executor->prepare([]);
+
+        $this->assertSame(InstallationPlan::STATUS_DRAFT, $invalid->status());
+        $this->assertSame('required', $invalid->diagnostics()[0]['reason']);
+
+        $plan = $executor->prepare([
+            'project_name' => 'Materia Host',
+            'values' => ['environment' => 'production'],
+            'defaults' => ['region' => 'global', 'environment' => 'local'],
+            'skips' => ['population'],
+        ]);
+
+        $this->assertSame(InstallationPlan::STATUS_REVIEW_READY, $plan->status());
+        $this->assertSame('production', $plan->values()['environment']);
+        $this->assertSame('global', $plan->values()['region']);
+        $this->assertTrue($plan->skipped('population'));
+        $this->assertTrue($plan->is($plan->behaviorState()));
+    }
+
+    public function testExecutionRequiresPermissionReviewBeforeSideEffects(): void
+    {
+        $calls = 0;
+        $executor = $this->executor()
+            ->stage('packages', function () use (&$calls): array {
+                $calls++;
+                return ['ok' => true, 'changed' => true];
+            }, ['write_project']);
+        $plan = $executor->prepare(['project_name' => 'Guarded Host']);
+
+        try {
+            $executor->execute($plan);
+            $this->fail('Execution should require approval.');
+        } catch (\LogicException $exception) {
+            $this->assertSame('Installation execution requires explicit approval.', $exception->getMessage());
+        }
+        $this->assertSame(0, $calls);
+
+        $this->expectException(\LogicException::class);
+        $plan->approve([]);
+    }
+
+    public function testCompletedStagesAreNotRepeatedDuringCheckpointResume(): void
+    {
+        $packageCalls = 0;
+        $migrationCalls = 0;
+        $executor = $this->executor()
+            ->stage('packages', function () use (&$packageCalls): array {
+                $packageCalls++;
+                return [
+                    'ok' => true,
+                    'changed' => true,
+                    'evidence' => ['owner' => 'package_installer'],
+                ];
+            }, ['write_project'])
+            ->stage('migrations', function () use (&$migrationCalls): array {
+                $migrationCalls++;
+                return $migrationCalls === 1
+                    ? ['ok' => false, 'error' => 'temporary failure']
+                    : ['ok' => true, 'changed' => true, 'evidence' => ['applied' => 2]];
+            }, ['write_database']);
+
+        $plan = $executor->prepare(['project_name' => 'Resumable Host']);
+        $plan->approve(['write_project', 'write_database']);
+        $first = $executor->execute($plan);
+
+        $this->assertFalse($first['ok']);
+        $this->assertSame('retry_migrations', $first['nextAction']);
+        $this->assertSame(1, $packageCalls);
+        $this->assertSame(1, $migrationCalls);
+
+        $resumed = $executor->resume($plan->id());
+        $this->assertInstanceOf(InstallationPlan::class, $resumed);
+        $resumed->retry();
+        $second = $executor->execute($resumed);
+
+        $this->assertTrue($second['ok']);
+        $this->assertSame(InstallationPlan::STATUS_COMPLETED, $second['status']);
+        $this->assertSame(1, $packageCalls);
+        $this->assertSame(2, $migrationCalls);
+        $this->assertSame(2, Arr::getPath($second, 'outcomes.migrations.evidence.applied'));
+    }
+
+    public function testExplicitlySkippedStageProducesStructuredEvidence(): void
+    {
+        $calls = 0;
+        $executor = $this->executor()->stage('population', function () use (&$calls): bool {
+            $calls++;
+            return true;
+        });
+        $plan = $executor->prepare([
+            'project_name' => 'Skip Host',
+            'skips' => ['population'],
+        ]);
+        $plan->approve([]);
+
+        $result = $executor->execute($plan);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(0, $calls);
+        $this->assertTrue(Arr::getPath($result, 'outcomes.population.skipped'));
+        $this->assertSame(
+            'explicit_skip',
+            Arr::getPath($result, 'outcomes.population.evidence.reason')
+        );
+    }
+
+    private function executor(): InstallationExecutor
+    {
+        return new InstallationExecutor(
+            new JsonInstallationCheckpointStore($this->checkpointDirectory)
+        );
+    }
+}


### PR DESCRIPTION
## Intent summary

Add a reusable orchestration boundary for resumable lifecycle stages while keeping installation schema and product policy outside BlueCore. The executor accepts opaque host context and injected stages; validation, approval, and durable persistence are optional host choices.

Closes #83.

## User stories / acceptance criteria

- Framework consumers can compose ordered lifecycle stages with opaque metadata.
- Hosts may inject their own context validator without adopting universal required fields.
- Hosts may opt into approval gating and attach opaque approval evidence.
- Plans may execute entirely in memory or use an injected checkpoint store for resume.
- Successful stages are not repeated after a checkpoint resume.
- Stage outcomes include structured evidence, errors, and retry guidance.
- BlueCore does not define installation questions, project fields, defaults, skips, permissions, product transitions, or a concrete stage graph.

## Key files changed

- `src/BlueCore/Installation/InstallationPlan.php`: host-neutral plan state and checkpoint record.
- `src/BlueCore/Installation/InstallationExecutor.php`: injected validation, optional approval, optional persistence, and stage execution.
- `src/BlueCore/Installation/JsonInstallationCheckpointStore.php`: reusable file-backed checkpoint adapter.
- `src/BlueCore/Contracts/IInstallationCheckpointStore.php`: persistence port.
- `README.md`: optional orchestration example and framework boundary.
- `tests/BlueCore/Installation/InstallationExecutorTest.php`: policy-boundary and resume coverage.

## How to test

```bash
composer ci
composer test:installer
```

Local result: 120 tests, 525 assertions; installer source/dist parity passed.

## QA checklist

- [x] Opaque context has no universal project, permissions, or skip keys.
- [x] Validation policy is injected.
- [x] Approval and persistence are optional.
- [x] Resume skips completed successful stages.
- [x] Product-specific onboarding semantics remain outside BlueCore.
- [x] Composer validation, lint, unit tests, and installer parity pass.

## Approval conditions

- Review confirms the API adds flexible framework capacity rather than an application installation model.
- Review confirms existing lifecycle implementations are delegated to injected stages instead of duplicated.
- Required CI is green.