### PR TITLE
Preserve engine binding ownership

### DIFF
--- a/docs/extension-registration-contracts.md
+++ b/docs/extension-registration-contracts.md
@@ -14,6 +14,20 @@ An extension can describe its contribution through a `RegistrationPlan`:
 
 Registrars implement `BlueFission\BlueCore\Contracts\IApplicationRegistrar` and receive both the application instance and a mutable `RegistrationPlan`.
 
+### Application-owned resolution
+
+Registration phases must resolve dependencies from the `Engine` instance that
+owns the lifecycle. `Engine::makeInstance()` selects the active concrete Engine
+class, while `resolveForPhase($contract, $phase)` applies root interface bindings
+and retains the contract, implementation, lifecycle phase, and original failure
+in a structured `RegistrationResolutionException` diagnostic.
+
+This avoids relying on process-wide first-instance ordering when more than one
+named DevElation `Application` or application subclass exists. Registrars that
+already receive an application instance should keep using that instance for
+binding and phase-aware resolution. The broader DevElation instance-selection
+contract is tracked in [DevElation #246](https://github.com/BlueFissionTech/develation/issues/246).
+
 ## Passive Contributions
 
 `loadActivatedContributions($name)` discovers optional `mapping/<name>.php`

--- a/src/BlueCore/Engine.php
+++ b/src/BlueCore/Engine.php
@@ -8,6 +8,9 @@ use BlueFission\Behavioral\Behaviors\Event;
 use BlueFission\Utils\Loader;
 use BlueFission\BlueCore\Security;
 use BlueFission\BlueCore\Gateway\GatewayDenied;
+use BlueFission\BlueCore\Registration\RegistrationResolutionException;
+use BlueFission\Arr;
+use BlueFission\Str;
 use BlueFission\Val;
 
 /**
@@ -18,6 +21,13 @@ use BlueFission\Val;
  * @package BlueFission\BlueCore
  */
 class Engine extends Application {
+
+	/**
+	 * The active Engine instance for each concrete application class.
+	 *
+	 * @var array<class-string, Engine>
+	 */
+	private static array $_activeInstances = [];
 
 	/**
 	 * The loader object
@@ -55,6 +65,84 @@ class Engine extends Application {
 	private $_session;
 
 	private ?GatewayDenied $_gatewayDenial = null;
+
+	public function __construct($config = [])
+	{
+		parent::__construct($config);
+
+		self::$_activeInstances[static::class] = $this;
+	}
+
+	/**
+	 * Return the active instance for the concrete Engine class.
+	 */
+	public static function instance()
+	{
+		$calledClass = static::class;
+		$instances = Arr::make(self::$_activeInstances);
+
+		if ($instances->hasKey($calledClass)) {
+			return $instances->get($calledClass);
+		}
+
+		$instance = parent::getInstance($calledClass);
+		if (!$instance instanceof $calledClass) {
+			throw new \LogicException("Application instance '{$calledClass}' is not compatible with the active Engine class.");
+		}
+
+		self::$_activeInstances[$calledClass] = $instance;
+
+		return $instance;
+	}
+
+	/**
+	 * Resolve a dependency from the active concrete Engine instance.
+	 */
+	public static function makeInstance(string $class)
+	{
+		return static::instance()->resolveForPhase($class, 'static');
+	}
+
+	public function resolve(string $class)
+	{
+		return $this->resolveForPhase($class);
+	}
+
+	/**
+	 * Resolve a root contract while retaining lifecycle-phase diagnostics.
+	 */
+	public function resolveForPhase(string $class, string $phase = 'runtime')
+	{
+		$contract = Str::trim($class);
+		$lifecyclePhase = Str::trim($phase);
+		$bindings = Arr::make($this->_bindings);
+		$implementation = $bindings->hasKey($contract)
+			? $bindings->get($contract)
+			: $contract;
+
+		if (Val::isEmpty($contract) || Val::isEmpty($lifecyclePhase)) {
+			throw new \InvalidArgumentException('Dependency contract and lifecycle phase cannot be empty.');
+		}
+
+		if (!Str::is($implementation) || Val::isEmpty($implementation)) {
+			throw RegistrationResolutionException::forBinding(
+				$contract,
+				$lifecyclePhase,
+				$implementation
+			);
+		}
+
+		try {
+			return parent::resolve($implementation);
+		} catch (\Throwable $exception) {
+			throw RegistrationResolutionException::forBinding(
+				$contract,
+				$lifecyclePhase,
+				$implementation,
+				$exception
+			);
+		}
+	}
 
 	public function process()
 	{

--- a/src/BlueCore/Registration/RegistrationResolutionException.php
+++ b/src/BlueCore/Registration/RegistrationResolutionException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BlueFission\BlueCore\Registration;
+
+use BlueFission\Arr;
+use BlueFission\Str;
+use BlueFission\Val;
+
+final class RegistrationResolutionException extends \RuntimeException
+{
+    private array $diagnostic;
+
+    public static function forBinding(
+        string $contract,
+        string $phase,
+        mixed $implementation,
+        ?\Throwable $previous = null
+    ): self {
+        $implementationName = Str::is($implementation) && Val::isNotEmpty($implementation)
+            ? $implementation
+            : null;
+        $target = Val::isNotNull($implementationName)
+            ? " using '{$implementationName}'"
+            : '';
+
+        return new self(
+            "Unable to resolve '{$contract}' during '{$phase}'{$target}.",
+            [
+                'contract' => $contract,
+                'phase' => $phase,
+                'implementation' => $implementationName,
+                'exception_class' => Val::isNotNull($previous) ? $previous::class : null,
+                'exception' => $previous?->getMessage(),
+            ],
+            $previous
+        );
+    }
+
+    public function diagnostic(): array
+    {
+        return Arr::make($this->diagnostic)->toArray();
+    }
+
+    private function __construct(string $message, array $diagnostic, ?\Throwable $previous)
+    {
+        $this->diagnostic = $diagnostic;
+
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/tests/BlueCore/EngineBindingResolutionTest.php
+++ b/tests/BlueCore/EngineBindingResolutionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore;
+
+use BlueFission\BlueCore\Engine;
+use BlueFission\BlueCore\Registration\RegistrationResolutionException;
+use BlueFission\Services\Application;
+use PHPUnit\Framework\TestCase;
+
+interface EngineBindingContract
+{
+}
+
+final class EngineBindingImplementation implements EngineBindingContract
+{
+}
+
+final class AlternateEngineBindingImplementation implements EngineBindingContract
+{
+}
+
+final class FirstTestEngine extends Engine
+{
+}
+
+final class SecondTestEngine extends Engine
+{
+}
+
+final class EngineBindingResolutionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $this->resetStaticProperty(Application::class, '_instances');
+        $this->resetStaticProperty(Engine::class, '_activeInstances');
+    }
+
+    public function testApplicationFirstConstructionDoesNotStealEngineBindingResolution(): void
+    {
+        new Application(['name' => 'application-first']);
+        $engine = new Engine(['name' => 'binding-owner']);
+        $engine->bind(EngineBindingContract::class, EngineBindingImplementation::class);
+
+        $resolved = Engine::makeInstance(EngineBindingContract::class);
+
+        $this->assertSame($engine, Engine::instance());
+        $this->assertInstanceOf(EngineBindingImplementation::class, $resolved);
+    }
+
+    public function testConcreteEngineClassesRetainIndependentBindingOwnership(): void
+    {
+        $first = new FirstTestEngine(['name' => 'first-engine']);
+        $second = new SecondTestEngine(['name' => 'second-engine']);
+        $first->bind(EngineBindingContract::class, EngineBindingImplementation::class);
+        $second->bind(EngineBindingContract::class, AlternateEngineBindingImplementation::class);
+
+        $this->assertInstanceOf(
+            EngineBindingImplementation::class,
+            FirstTestEngine::makeInstance(EngineBindingContract::class)
+        );
+        $this->assertInstanceOf(
+            AlternateEngineBindingImplementation::class,
+            SecondTestEngine::makeInstance(EngineBindingContract::class)
+        );
+    }
+
+    public function testRootBindingRemainsVisibleAcrossRegistrationPhases(): void
+    {
+        $engine = new Engine(['name' => 'phase-progression']);
+        $engine->bind(EngineBindingContract::class, EngineBindingImplementation::class);
+
+        $resolved = $engine->resolveForPhase(EngineBindingContract::class, 'arguments');
+
+        $this->assertInstanceOf(EngineBindingImplementation::class, $resolved);
+    }
+
+    public function testNamedEngineReuseRetainsBindingsForLaterBootPhases(): void
+    {
+        $engine = new Engine(['name' => 'reboot-engine']);
+        $engine->bind(EngineBindingContract::class, EngineBindingImplementation::class);
+
+        $reused = Engine::getInstance('reboot-engine');
+        $resolved = $reused->resolveForPhase(EngineBindingContract::class, 'reboot');
+
+        $this->assertSame($engine, $reused);
+        $this->assertInstanceOf(EngineBindingImplementation::class, $resolved);
+    }
+
+    public function testResolutionFailureNamesTheContractAndLifecyclePhase(): void
+    {
+        $engine = new Engine(['name' => 'diagnostic-engine']);
+
+        try {
+            $engine->resolveForPhase(EngineBindingContract::class, 'boot');
+            $this->fail('Expected an unresolved interface to fail.');
+        } catch (RegistrationResolutionException $exception) {
+            $this->assertSame(EngineBindingContract::class, $exception->diagnostic()['contract']);
+            $this->assertSame('boot', $exception->diagnostic()['phase']);
+            $this->assertSame(EngineBindingContract::class, $exception->diagnostic()['implementation']);
+            $this->assertSame(\Error::class, $exception->diagnostic()['exception_class']);
+            $this->assertStringContainsString(EngineBindingContract::class, $exception->getMessage());
+            $this->assertStringContainsString('boot', $exception->getMessage());
+        }
+    }
+
+    private function resetStaticProperty(string $class, string $property): void
+    {
+        $reflection = new \ReflectionProperty($class, $property);
+        $reflection->setValue(null, []);
+    }
+}


### PR DESCRIPTION
## Intent summary

Preserve dependency-binding ownership across BlueCore registration phases by resolving root contracts from the active concrete Engine rather than an unrelated process-wide Application instance.

Closes #85.

## User stories / acceptance criteria

- An interface bound on an Engine resolves from that same Engine during later registration and boot phases.
- Application-first construction does not steal static Engine resolution.
- Separate concrete Engine classes retain independent active instances and binding maps.
- Root interface bindings are applied before reflection attempts to instantiate the contract.
- Resolution failures retain the contract, implementation, lifecycle phase, original exception class, and message.
- Named Engine reuse preserves bindings for reboot-style lifecycle progression.
- The broader DevElation Application instance-selection contract remains tracked in [DevElation #246](https://github.com/BlueFissionTech/develation/issues/246).

## Key files changed

- `src/BlueCore/Engine.php`
- `src/BlueCore/Registration/RegistrationResolutionException.php`
- `tests/BlueCore/EngineBindingResolutionTest.php`
- `docs/extension-registration-contracts.md`

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/EngineBindingResolutionTest.php
composer ci
composer test:installer
```

## QA checklist

- [x] Focused Engine binding suite passes: 5 tests, 13 assertions.
- [x] Full suite passes: 119 tests, 505 assertions.
- [x] Strict Composer validation and PHP lint pass.
- [x] Project-installer source/distribution parity passes.
- [x] No optional infrastructure or credentials are required.
- [x] No parallel dependency container was introduced.

## Approval conditions

- Confirm concrete Engine classes should own their active instance and static resolution context.
- Confirm root contract bindings should be applied before DevElation reflection.
- Confirm phase-aware diagnostics preserve enough evidence for registration and boot failure handling.
- Confirm the compatibility layer remains appropriate until the upstream instance-selection contract is released.
