### PR TITLE
Prepare v0.1.3-alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ BlueCore provides core functionality and architecture for modular, scalable web 
 BlueCore requires PHP 8.2 or newer. Install the current alpha release through Composer:
 
 ```bash
-composer require bluefission/bluecore:^0.1.2@alpha
+composer require bluefission/bluecore:^0.1.3@alpha
 ```
 
 The alpha line is intended for integration testing while the public API is finalized. Pin an explicit alpha constraint in reproducible environments.

--- a/docs/releases/v0.1.3-alpha.md
+++ b/docs/releases/v0.1.3-alpha.md
@@ -1,0 +1,28 @@
+# BlueCore v0.1.3-alpha
+
+This alpha release consolidates the reviewed framework contracts introduced after `v0.1.2-alpha`.
+
+## Compatibility
+
+- PHP 8.2 and 8.3 remain supported.
+- DevElation `^1.3.41` remains the minimum supported dependency line.
+- Composer projects should use `bluefission/bluecore:^0.1.3@alpha` when adopting this release.
+
+## Framework Changes
+
+- Application-first path resolution now consistently covers add-on discovery, definitions, mappings, primary files, and lifecycle operations while preserving host and legacy fallbacks.
+- Add-on activation and deactivation verify persisted state before reporting success, including non-null falsey model values.
+- Optional installation orchestration supports injected validation, approval policy, stages, metadata, checkpoint storage, structured outcomes, and completed-stage resume protection.
+- Installation context and approval evidence remain opaque. BlueCore does not prescribe required project fields, defaults, skips, permissions, product transitions, or a concrete installation stage graph.
+- Engine registration preserves binding ownership across lifecycle phases, resolves root contracts before reflection, and returns phase-aware diagnostics on resolution failures.
+
+## Upgrade Guidance
+
+- Existing hosts do not need to adopt the installation orchestration API.
+- Hosts that use add-on lifecycle results should continue treating `ok`, `changed`, evidence, and retry guidance as the stable result boundary.
+- Hosts with custom path resolvers should retain them as fallbacks; existing application-root files and directories now take precedence.
+- Dependency bindings should be registered on the concrete Engine instance that owns the registration and boot lifecycle.
+
+## Release Gate
+
+The tag must be created from reviewed `main` only after all included pull requests are merged. Before tagging, run strict Composer validation, lint, PHPUnit, the clean installer integration matrix where the environment permits, and a dependency audit. After publishing the prerelease, verify that Packagist resolves the tag to the same commit before announcing the constraint as consumable.

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -96,13 +96,13 @@ final class ComposerMetadataTest extends TestCase
     {
         $readme = Str::make(File::readContents($this->rootFile('README.md')));
         $release = Str::make(
-            File::readContents($this->rootFile('docs/releases/v0.1.2-alpha.md'))
+            File::readContents($this->rootFile('docs/releases/v0.1.3-alpha.md'))
         );
 
         $this->assertTrue(
-            $readme->has('composer require bluefission/bluecore:^0.1.2@alpha')
+            $readme->has('composer require bluefission/bluecore:^0.1.3@alpha')
         );
-        $this->assertTrue($release->has('bluefission/bluecore:^0.1.2@alpha'));
+        $this->assertTrue($release->has('bluefission/bluecore:^0.1.3@alpha'));
         $this->assertTrue($release->has('DevElation `^1.3.41`'));
         $this->assertTrue($release->has('Packagist resolves the tag to the same commit'));
     }


### PR DESCRIPTION
## Intent summary

Advance the documented alpha release to v0.1.3-alpha after merging the reviewed path resolution, add-on persistence verification, optional lifecycle orchestration, and Engine binding ownership contracts.

Closes #87.

## User stories / acceptance criteria

- Composer guidance uses bluefission/bluecore:^0.1.3@alpha.
- Release notes preserve BlueCore's flexible framework boundary and provide upgrade guidance.
- The release contract test verifies the new documentation and Packagist requirements.

## Key files changed

- README.md
- docs/releases/v0.1.3-alpha.md
- tests/ComposerMetadataTest.php

## How to test

composer ci
composer audit --locked
composer test:installer

## QA checklist

- [x] Strict Composer validation and lint pass.
- [x] Full suite passes: 131 tests, 559 assertions.
- [x] Dependency audit reports no advisories.
- [x] Constituent installer changes passed source/dist parity before merge.
- [ ] Local parity replay is currently blocked by a nested Composer install timeout; exact-head CI remains required.

## Approval conditions

- Required CI is green on exact head 06c96e698544f92fdb829f7820f6e5715e1b95bc.
- Review confirms the release notes do not prescribe product-specific onboarding policy.
- The merged main commit is tagged v0.1.3-alpha and Packagist resolves that tag before downstream notification.