### PR TITLE
add DevElation lifecycle hook contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The `MenuItem` and `Menu` classes represent individual items and collections of 
 
 The `Engine` class sets up and starts the BlueFission application, loading configurations and auto-discovering helpers and mappings. It serves as the main entry point for initializing and running the application.
 
+Engine lifecycle actions and framework filters follow the stable contracts documented in [DevElation Hooks](docs/develation-hooks.md).
+
 ## Intention and Target Framework
 
 ### Flexibility and Extensibility

--- a/docs/develation-hooks.md
+++ b/docs/develation-hooks.md
@@ -1,0 +1,66 @@
+# DevElation Hooks
+
+BlueCore exposes stable DevElation hooks at framework lifecycle boundaries so applications and add-ons can extend behavior without replacing framework internals. Hooks are inactive until `DevElation::up()` is called.
+
+## Contract
+
+Hook names use `bluecore.<area>.<operation>.<phase>`.
+
+- Actions are observational. They receive the documented arguments and do not replace framework values.
+- Filters transform one documented value. Each callback must return a value compatible with the filter contract.
+- Lower numeric priorities run before higher priorities, following DevElation ordering.
+- Hook callbacks should avoid re-entering the lifecycle operation that dispatched them.
+- Security checks remain authoritative. Hooks must not be used to bypass validation, authorization, or gateway denial.
+
+## Engine actions
+
+Owner: `Engine`. All payloads are observational references: callbacks may inspect them but must not mutate protected Engine state or replace control flow. Engine payloads contain framework state, so callbacks must avoid logging configuration values, request credentials, or session contents.
+
+| Constant and hook | Phase | Payload | Failure semantics |
+| --- | --- | --- | --- |
+| `Engine::HOOK_BOOTSTRAP_BEFORE`<br>`bluecore.engine.bootstrap.before` | Before bootstrap | `Engine $engine` | Runs before bootstrap work. Callback exceptions stop bootstrap. |
+| `Engine::HOOK_BOOTSTRAP_AFTER`<br>`bluecore.engine.bootstrap.after` | After bootstrap | `Engine $engine` | Runs only after successful bootstrap. |
+| `Engine::HOOK_BOOTSTRAP_FAILED`<br>`bluecore.engine.bootstrap.failed` | Bootstrap failure | `Throwable $exception, Engine $engine` | Observes an exception before it is rethrown. |
+| `Engine::HOOK_PROCESS_BEFORE`<br>`bluecore.engine.process.before` | Before request processing | `Engine $engine` | Runs before gateway processing. Callback exceptions stop processing. |
+| `Engine::HOOK_PROCESS_AFTER`<br>`bluecore.engine.process.after` | After request processing | `Engine $engine` | Runs after success or controlled gateway denial. |
+| `Engine::HOOK_PROCESS_DENIED`<br>`bluecore.engine.process.denied` | Controlled denial | `GatewayDenied $denial, Engine $engine` | Observes a fail-closed denial; it cannot clear it. |
+| `Engine::HOOK_PROCESS_FAILED`<br>`bluecore.engine.process.failed` | Processing failure | `Throwable $exception, Engine $engine` | Observes an unexpected exception before it is rethrown. |
+| `Engine::HOOK_RUN_BEFORE`<br>`bluecore.engine.run.before` | Before execution | `Engine $engine` | Runs only when processing has not been denied. Callback exceptions stop execution. |
+| `Engine::HOOK_RUN_AFTER`<br>`bluecore.engine.run.after` | After execution | `Engine $result, Engine $engine` | Runs only after successful execution. |
+| `Engine::HOOK_RUN_DENIED`<br>`bluecore.engine.run.denied` | Execution skipped | `GatewayDenied $denial, Engine $engine` | Observes the denial that prevented execution. |
+| `Engine::HOOK_RUN_FAILED`<br>`bluecore.engine.run.failed` | Execution failure | `Throwable $exception, Engine $engine` | Observes an unexpected exception before it is rethrown. |
+
+The `after` action is dispatched only when the operation completes normally. A gateway denial is a handled process outcome, so `process.denied` is followed by `process.after`; `run.denied` is dispatched when execution is intentionally skipped.
+
+## Gateway filter
+
+Owner: `DynamicGateway`. `DynamicGateway::FILTER_ARGUMENTS` identifies `bluecore.gateway.dynamic.arguments`. It runs during gateway request processing and receives the mutable request argument value. It must return a native array or a DevElation `Arr`; invalid results fail processing with `UnexpectedValueException` before controller execution. Because DevElation passes each filter result directly to the next callback, callbacks in a shared filter chain should accept `array|Arr`. BlueCore normalizes the final result to a native array before the next gateway or controller receives it.
+
+Filters may add or normalize ordinary request arguments, but they must not remove or override authorization, CSRF, path-containment, or other fail-closed evidence.
+
+During the alpha compatibility period, the previous dynamic-gateway filter is applied first and the neutral BlueCore filter is applied second. New integrations should register only `DynamicGateway::FILTER_ARGUMENTS`.
+
+```php
+use BlueFission\Arr;
+use BlueFission\BlueCore\Engine;
+use BlueFission\BlueCore\Gateway\DynamicGateway;
+use BlueFission\DevElation;
+
+DevElation::up();
+
+DevElation::filter(
+    DynamicGateway::FILTER_ARGUMENTS,
+    fn(array $arguments): Arr => Arr::make($arguments)->set('trace_enabled', true)
+);
+
+DevElation::action(
+    Engine::HOOK_RUN_AFTER,
+    function (Engine $result, Engine $engine): void {
+        // Observe completed execution without replacing framework control flow.
+    }
+);
+```
+
+## Integration hooks
+
+The optional authentication bridge also exposes stable input/output filters and before/after actions through its public hook constants. Their value contracts are documented by the bridge types and tests.

--- a/docs/develation-hooks.md
+++ b/docs/develation-hooks.md
@@ -9,7 +9,7 @@ Hook names use `bluecore.<area>.<operation>.<phase>`.
 - Actions are observational. They receive the documented arguments and do not replace framework values.
 - Filters transform one documented value. Each callback must return a value compatible with the filter contract.
 - Lower numeric priorities run before higher priorities, following DevElation ordering.
-- Hook callbacks should avoid re-entering the lifecycle operation that dispatched them.
+- Re-entry is suppressed per Engine and hook name by default. `Engine::hookRecursionDepth()` provides an explicit opt-in bounded by `Engine::MAX_HOOK_RECURSION_DEPTH`.
 - Security checks remain authoritative. Hooks must not be used to bypass validation, authorization, or gateway denial.
 
 ## Engine actions
@@ -20,17 +20,25 @@ Owner: `Engine`. All payloads are observational references: callbacks may inspec
 | --- | --- | --- | --- |
 | `Engine::HOOK_BOOTSTRAP_BEFORE`<br>`bluecore.engine.bootstrap.before` | Before bootstrap | `Engine $engine` | Runs before bootstrap work. Callback exceptions stop bootstrap. |
 | `Engine::HOOK_BOOTSTRAP_AFTER`<br>`bluecore.engine.bootstrap.after` | After bootstrap | `Engine $engine` | Runs only after successful bootstrap. |
-| `Engine::HOOK_BOOTSTRAP_FAILED`<br>`bluecore.engine.bootstrap.failed` | Bootstrap failure | `Throwable $exception, Engine $engine` | Observes an exception before it is rethrown. |
+| `Engine::HOOK_BOOTSTRAP_FAILED`<br>`bluecore.engine.bootstrap.failed` | Bootstrap failure | `LifecycleFailure $failure` | Observes sanitized failure metadata before the original exception is rethrown. |
 | `Engine::HOOK_PROCESS_BEFORE`<br>`bluecore.engine.process.before` | Before request processing | `Engine $engine` | Runs before gateway processing. Callback exceptions stop processing. |
 | `Engine::HOOK_PROCESS_AFTER`<br>`bluecore.engine.process.after` | After request processing | `Engine $engine` | Runs after success or controlled gateway denial. |
 | `Engine::HOOK_PROCESS_DENIED`<br>`bluecore.engine.process.denied` | Controlled denial | `GatewayDenied $denial, Engine $engine` | Observes a fail-closed denial; it cannot clear it. |
-| `Engine::HOOK_PROCESS_FAILED`<br>`bluecore.engine.process.failed` | Processing failure | `Throwable $exception, Engine $engine` | Observes an unexpected exception before it is rethrown. |
+| `Engine::HOOK_PROCESS_FAILED`<br>`bluecore.engine.process.failed` | Processing failure | `LifecycleFailure $failure` | Observes sanitized failure metadata before the original exception is rethrown. |
 | `Engine::HOOK_RUN_BEFORE`<br>`bluecore.engine.run.before` | Before execution | `Engine $engine` | Runs only when processing has not been denied. Callback exceptions stop execution. |
 | `Engine::HOOK_RUN_AFTER`<br>`bluecore.engine.run.after` | After execution | `Engine $result, Engine $engine` | Runs only after successful execution. |
 | `Engine::HOOK_RUN_DENIED`<br>`bluecore.engine.run.denied` | Execution skipped | `GatewayDenied $denial, Engine $engine` | Observes the denial that prevented execution. |
-| `Engine::HOOK_RUN_FAILED`<br>`bluecore.engine.run.failed` | Execution failure | `Throwable $exception, Engine $engine` | Observes an unexpected exception before it is rethrown. |
+| `Engine::HOOK_RUN_FAILED`<br>`bluecore.engine.run.failed` | Execution failure | `LifecycleFailure $failure` | Observes sanitized failure metadata before the original exception is rethrown. |
 
 The `after` action is dispatched only when the operation completes normally. A gateway denial is a handled process outcome, so `process.denied` is followed by `process.after`; `run.denied` is dispatched when execution is intentionally skipped.
+
+`LifecycleFailure` exposes only the hook, operation, dispatcher name, exception class, and numeric exception code. It intentionally omits the exception message, trace, request, configuration, session, and mutable Engine instance. Failure hooks never recursively redispatch themselves at the default depth.
+
+```php
+$engine->hookRecursionDepth(Engine::HOOK_PROCESS_BEFORE, 2);
+```
+
+The configured depth is local to that Engine instance and hook. Values must be between 1 and 8; depth 1 is the non-recursive default. Failure hooks cannot opt into recursive dispatch.
 
 ## Gateway filter
 
@@ -64,3 +72,4 @@ DevElation::action(
 ## Integration hooks
 
 The optional authentication bridge also exposes stable input/output filters and before/after actions through its public hook constants. Their value contracts are documented by the bridge types and tests.
+

--- a/docs/develation-hooks.md
+++ b/docs/develation-hooks.md
@@ -72,4 +72,3 @@ DevElation::action(
 ## Integration hooks
 
 The optional authentication bridge also exposes stable input/output filters and before/after actions through its public hook constants. Their value contracts are documented by the bridge types and tests.
-

--- a/src/BlueCore/Engine.php
+++ b/src/BlueCore/Engine.php
@@ -5,6 +5,7 @@ use BlueFission\Services\Application;
 use BlueFission\Services\Service;
 use BlueFission\Services\Response;
 use BlueFission\Behavioral\Behaviors\Event;
+use BlueFission\DevElation as Dev;
 use BlueFission\Utils\Loader;
 use BlueFission\BlueCore\Security;
 use BlueFission\BlueCore\Gateway\GatewayDenied;
@@ -12,6 +13,7 @@ use BlueFission\BlueCore\Registration\RegistrationResolutionException;
 use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
+use Throwable;
 
 /**
  * Class Engine
@@ -21,6 +23,18 @@ use BlueFission\Val;
  * @package BlueFission\BlueCore
  */
 class Engine extends Application {
+
+	public const HOOK_BOOTSTRAP_BEFORE = 'bluecore.engine.bootstrap.before';
+	public const HOOK_BOOTSTRAP_AFTER = 'bluecore.engine.bootstrap.after';
+	public const HOOK_BOOTSTRAP_FAILED = 'bluecore.engine.bootstrap.failed';
+	public const HOOK_PROCESS_BEFORE = 'bluecore.engine.process.before';
+	public const HOOK_PROCESS_AFTER = 'bluecore.engine.process.after';
+	public const HOOK_PROCESS_DENIED = 'bluecore.engine.process.denied';
+	public const HOOK_PROCESS_FAILED = 'bluecore.engine.process.failed';
+	public const HOOK_RUN_BEFORE = 'bluecore.engine.run.before';
+	public const HOOK_RUN_AFTER = 'bluecore.engine.run.after';
+	public const HOOK_RUN_DENIED = 'bluecore.engine.run.denied';
+	public const HOOK_RUN_FAILED = 'bluecore.engine.run.failed';
 
 	/**
 	 * The active Engine instance for each concrete application class.
@@ -147,12 +161,19 @@ class Engine extends Application {
 	public function process()
 	{
 		$this->_gatewayDenial = null;
+		Dev::do(self::HOOK_PROCESS_BEFORE, [$this]);
 
 		try {
 			parent::process();
 		} catch (GatewayDenied $denial) {
 			$this->_gatewayDenial = $denial;
+			Dev::do(self::HOOK_PROCESS_DENIED, [$denial, $this]);
+		} catch (Throwable $exception) {
+			Dev::do(self::HOOK_PROCESS_FAILED, [$exception, $this]);
+			throw $exception;
 		}
+
+		Dev::do(self::HOOK_PROCESS_AFTER, [$this]);
 
 		return $this;
 	}
@@ -160,10 +181,22 @@ class Engine extends Application {
 	public function run()
 	{
 		if ($this->denied()) {
+			Dev::do(self::HOOK_RUN_DENIED, [$this->_gatewayDenial, $this]);
 			return $this;
 		}
 
-		return parent::run();
+		Dev::do(self::HOOK_RUN_BEFORE, [$this]);
+
+		try {
+			$result = parent::run();
+		} catch (Throwable $exception) {
+			Dev::do(self::HOOK_RUN_FAILED, [$exception, $this]);
+			throw $exception;
+		}
+
+		Dev::do(self::HOOK_RUN_AFTER, [$result, $this]);
+
+		return $result;
 	}
 
 	public function denied(): bool
@@ -182,24 +215,32 @@ class Engine extends Application {
 	 * @return Engine
 	 */
 	public function bootstrap() {
+		Dev::do(self::HOOK_BOOTSTRAP_BEFORE, [$this]);
 
-		Security::init();
+		try {
+			Security::init();
 
-		$this->_loader = Loader::instance();
+			$this->_loader = Loader::instance();
 
-		$this->dispatch('OnAppInitialized');
+			$this->dispatch('OnAppInitialized');
 		
-		$this->loadConfiguration();
+			$this->loadConfiguration();
 
-		$this->autoDiscoverHelpers();
+			$this->autoDiscoverHelpers();
 
-		$this->autoDiscoverMapping();
+			$this->autoDiscoverMapping();
 
-		$this->dispatch('OnAppLoaded');
+			$this->dispatch('OnAppLoaded');
 
-		$this->assetDir(store('asset_dir'));
+			$this->assetDir(store('asset_dir'));
 
-		$this->_session = instance('session');
+			$this->_session = instance('session');
+		} catch (Throwable $exception) {
+			Dev::do(self::HOOK_BOOTSTRAP_FAILED, [$exception, $this]);
+			throw $exception;
+		}
+
+		Dev::do(self::HOOK_BOOTSTRAP_AFTER, [$this]);
 		
 		return $this;
 	}

--- a/src/BlueCore/Engine.php
+++ b/src/BlueCore/Engine.php
@@ -9,10 +9,13 @@ use BlueFission\DevElation as Dev;
 use BlueFission\Utils\Loader;
 use BlueFission\BlueCore\Security;
 use BlueFission\BlueCore\Gateway\GatewayDenied;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\BlueCore\Registration\RegistrationResolutionException;
 use BlueFission\Arr;
+use BlueFission\Num;
 use BlueFission\Str;
 use BlueFission\Val;
+use InvalidArgumentException;
 use Throwable;
 
 /**
@@ -35,6 +38,13 @@ class Engine extends Application {
 	public const HOOK_RUN_AFTER = 'bluecore.engine.run.after';
 	public const HOOK_RUN_DENIED = 'bluecore.engine.run.denied';
 	public const HOOK_RUN_FAILED = 'bluecore.engine.run.failed';
+	public const MAX_HOOK_RECURSION_DEPTH = 8;
+
+	private const NON_RECURSIVE_HOOKS = [
+		self::HOOK_BOOTSTRAP_FAILED,
+		self::HOOK_PROCESS_FAILED,
+		self::HOOK_RUN_FAILED,
+	];
 
 	/**
 	 * The active Engine instance for each concrete application class.
@@ -79,6 +89,10 @@ class Engine extends Application {
 	private $_session;
 
 	private ?GatewayDenied $_gatewayDenial = null;
+
+	private array $_activeHookDepths = [];
+
+	private array $_hookDepthLimits = [];
 
 	public function __construct($config = [])
 	{
@@ -161,19 +175,19 @@ class Engine extends Application {
 	public function process()
 	{
 		$this->_gatewayDenial = null;
-		Dev::do(self::HOOK_PROCESS_BEFORE, [$this]);
+		$this->dispatchHook(self::HOOK_PROCESS_BEFORE, [$this]);
 
 		try {
 			parent::process();
 		} catch (GatewayDenied $denial) {
 			$this->_gatewayDenial = $denial;
-			Dev::do(self::HOOK_PROCESS_DENIED, [$denial, $this]);
+			$this->dispatchHook(self::HOOK_PROCESS_DENIED, [$denial, $this]);
 		} catch (Throwable $exception) {
-			Dev::do(self::HOOK_PROCESS_FAILED, [$exception, $this]);
+			$this->dispatchFailureHook(self::HOOK_PROCESS_FAILED, 'process', $exception);
 			throw $exception;
 		}
 
-		Dev::do(self::HOOK_PROCESS_AFTER, [$this]);
+		$this->dispatchHook(self::HOOK_PROCESS_AFTER, [$this]);
 
 		return $this;
 	}
@@ -181,20 +195,20 @@ class Engine extends Application {
 	public function run()
 	{
 		if ($this->denied()) {
-			Dev::do(self::HOOK_RUN_DENIED, [$this->_gatewayDenial, $this]);
+			$this->dispatchHook(self::HOOK_RUN_DENIED, [$this->_gatewayDenial, $this]);
 			return $this;
 		}
 
-		Dev::do(self::HOOK_RUN_BEFORE, [$this]);
+		$this->dispatchHook(self::HOOK_RUN_BEFORE, [$this]);
 
 		try {
 			$result = parent::run();
 		} catch (Throwable $exception) {
-			Dev::do(self::HOOK_RUN_FAILED, [$exception, $this]);
+			$this->dispatchFailureHook(self::HOOK_RUN_FAILED, 'run', $exception);
 			throw $exception;
 		}
 
-		Dev::do(self::HOOK_RUN_AFTER, [$result, $this]);
+		$this->dispatchHook(self::HOOK_RUN_AFTER, [$result, $this]);
 
 		return $result;
 	}
@@ -215,7 +229,7 @@ class Engine extends Application {
 	 * @return Engine
 	 */
 	public function bootstrap() {
-		Dev::do(self::HOOK_BOOTSTRAP_BEFORE, [$this]);
+		$this->dispatchHook(self::HOOK_BOOTSTRAP_BEFORE, [$this]);
 
 		try {
 			Security::init();
@@ -236,13 +250,65 @@ class Engine extends Application {
 
 			$this->_session = instance('session');
 		} catch (Throwable $exception) {
-			Dev::do(self::HOOK_BOOTSTRAP_FAILED, [$exception, $this]);
+			$this->dispatchFailureHook(self::HOOK_BOOTSTRAP_FAILED, 'bootstrap', $exception);
 			throw $exception;
 		}
 
-		Dev::do(self::HOOK_BOOTSTRAP_AFTER, [$this]);
+		$this->dispatchHook(self::HOOK_BOOTSTRAP_AFTER, [$this]);
 		
 		return $this;
+	}
+
+	public function hookRecursionDepth(string $hook, int $depth = 1): self
+	{
+		if (!Str::startsWith($hook, 'bluecore.engine.')) {
+			throw new InvalidArgumentException('Engine hook recursion can only be configured for Engine-owned hooks.');
+		}
+
+		if ($depth < 1 || $depth > self::MAX_HOOK_RECURSION_DEPTH) {
+			throw new InvalidArgumentException(
+				'Engine hook recursion depth must be between 1 and ' . self::MAX_HOOK_RECURSION_DEPTH . '.'
+			);
+		}
+
+		if ($depth > 1 && Arr::has(self::NON_RECURSIVE_HOOKS, $hook)) {
+			throw new InvalidArgumentException('Engine failure hooks cannot opt into recursive dispatch.');
+		}
+
+		$this->_hookDepthLimits[$hook] = $depth;
+
+		return $this;
+	}
+
+	private function dispatchHook(string $hook, array $arguments = []): void
+	{
+		$currentDepth = (int)($this->_activeHookDepths[$hook] ?? 0);
+		$allowedDepth = (int)($this->_hookDepthLimits[$hook] ?? 1);
+
+		if ($currentDepth >= $allowedDepth) {
+			return;
+		}
+
+		$this->_activeHookDepths[$hook] = (int)Num::make($currentDepth)->increment()->val();
+
+		try {
+			Dev::do($hook, $arguments);
+		} finally {
+			$remainingDepth = (int)Num::make($this->_activeHookDepths[$hook])->decrement()->val();
+
+			if ($remainingDepth <= 0) {
+				unset($this->_activeHookDepths[$hook]);
+			} else {
+				$this->_activeHookDepths[$hook] = $remainingDepth;
+			}
+		}
+	}
+
+	private function dispatchFailureHook(string $hook, string $operation, Throwable $exception): void
+	{
+		$this->dispatchHook($hook, [
+			new LifecycleFailure($hook, $operation, (string)$this->name(), $exception),
+		]);
 	}
 
 	/**
@@ -380,3 +446,4 @@ class Engine extends Application {
 		return $this;
 	}
 }
+

--- a/src/BlueCore/Engine.php
+++ b/src/BlueCore/Engine.php
@@ -446,4 +446,3 @@ class Engine extends Application {
 		return $this;
 	}
 }
-

--- a/src/BlueCore/Gateway/DynamicGateway.php
+++ b/src/BlueCore/Gateway/DynamicGateway.php
@@ -1,15 +1,36 @@
 <?php
 namespace BlueFission\BlueCore\Gateway;
 
+use BlueFission\Arr;
 use BlueFission\Services\Gateway;
 use BlueFission\Services\Request;
 use BlueFission\DevElation as Dev;
+use UnexpectedValueException;
 
 class DynamicGateway extends Gateway {
 
+    public const FILTER_ARGUMENTS = 'bluecore.gateway.dynamic.arguments';
+    public const LEGACY_FILTER_ARGUMENTS = 'opus_gateway.dynamic.process';
+
     public function __construct() {}
 
-    public function process(Request $request, &$arguments) {
-        $arguments = Dev::apply('opus_gateway.dynamic.process', $arguments);
+    public function process(Request $request, &$arguments): void {
+        $arguments = $this->applyArgumentsFilter(self::LEGACY_FILTER_ARGUMENTS, $arguments);
+        $arguments = $this->applyArgumentsFilter(self::FILTER_ARGUMENTS, $arguments);
+    }
+
+    private function applyArgumentsFilter(string $name, mixed $arguments): array
+    {
+        $filtered = Dev::apply($name, $arguments);
+
+        if ($filtered instanceof Arr) {
+            return $filtered->toArray(true);
+        }
+
+        if (!Arr::is($filtered)) {
+            throw new UnexpectedValueException("Dynamic gateway filter '{$name}' must return an array or Arr.");
+        }
+
+        return Arr::toArray($filtered, true);
     }
 }

--- a/src/BlueCore/Hooks/LifecycleFailure.php
+++ b/src/BlueCore/Hooks/LifecycleFailure.php
@@ -52,4 +52,3 @@ final class LifecycleFailure extends Obj
         return $this->_data['exception_code'];
     }
 }
-

--- a/src/BlueCore/Hooks/LifecycleFailure.php
+++ b/src/BlueCore/Hooks/LifecycleFailure.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BlueFission\BlueCore\Hooks;
+
+use BlueFission\Arr;
+use BlueFission\Num;
+use BlueFission\Obj;
+use BlueFission\Str;
+use Throwable;
+
+final class LifecycleFailure extends Obj
+{
+    public function __construct(
+        string $hook,
+        string $operation,
+        string $dispatcher,
+        Throwable $exception
+    ) {
+        parent::__construct();
+
+        $this->_data = Arr::make([
+            'hook' => Str::make($hook)->trim()->val(),
+            'operation' => Str::make($operation)->trim()->val(),
+            'dispatcher' => Str::make($dispatcher)->trim()->val(),
+            'exception_type' => $exception::class,
+            'exception_code' => Num::make($exception->getCode())->val(),
+        ]);
+    }
+
+    public function hook(): string
+    {
+        return $this->_data['hook'];
+    }
+
+    public function operation(): string
+    {
+        return $this->_data['operation'];
+    }
+
+    public function dispatcher(): string
+    {
+        return $this->_data['dispatcher'];
+    }
+
+    public function exceptionType(): string
+    {
+        return $this->_data['exception_type'];
+    }
+
+    public function exceptionCode(): int|float
+    {
+        return $this->_data['exception_code'];
+    }
+}
+

--- a/tests/BlueCore/EngineHookTest.php
+++ b/tests/BlueCore/EngineHookTest.php
@@ -333,4 +333,3 @@ class HookFailingBootstrapEngine extends Engine
         throw new RuntimeException('configuration failure');
     }
 }
-

--- a/tests/BlueCore/EngineHookTest.php
+++ b/tests/BlueCore/EngineHookTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore;
+
+use BlueFission\BlueCore\Engine;
+use BlueFission\BlueCore\Gateway\GatewayDenied;
+use BlueFission\DevElation as Dev;
+use BlueFission\Services\Gateway;
+use BlueFission\Services\Request;
+use BlueFission\Str;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class EngineHookTest extends TestCase
+{
+    private array $server;
+
+    private array $argv;
+
+    private string|false $appKey;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->server = $_SERVER;
+        $this->argv = $GLOBALS['argv'] ?? [];
+        $this->appKey = getenv('APP_KEY');
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $GLOBALS['argv'] = [__FILE__];
+        putenv('APP_KEY=engine-hook-test-key');
+        $this->resetDevElation();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDevElation();
+        $_SERVER = $this->server;
+        $GLOBALS['argv'] = $this->argv;
+        putenv($this->appKey === false ? 'APP_KEY' : 'APP_KEY=' . $this->appKey);
+
+        parent::tearDown();
+    }
+
+    public function testEngineActionsFollowLifecycleAndPriorityOrder(): void
+    {
+        $events = [];
+        Dev::up();
+        Dev::action(Engine::HOOK_PROCESS_BEFORE, function () use (&$events): void {
+            $events[] = 'process-late';
+        }, 20);
+        Dev::action(Engine::HOOK_PROCESS_BEFORE, function () use (&$events): void {
+            $events[] = 'process-early';
+        }, 5);
+        Dev::action(Engine::HOOK_PROCESS_AFTER, function () use (&$events): void {
+            $events[] = 'process-after';
+        });
+        Dev::action(Engine::HOOK_RUN_BEFORE, function () use (&$events): void {
+            $events[] = 'run-before';
+        });
+        Dev::action(Engine::HOOK_RUN_AFTER, function (Engine $result, Engine $engine) use (&$events): void {
+            $this->assertSame($engine, $result);
+            $events[] = 'run-after';
+        });
+
+        $engine = $this->engine('/hooks');
+        $engine->map('get', 'hooks', fn(): string => 'hooked');
+
+        ob_start();
+        $result = $engine->args()->process()->run();
+        $response = ob_get_clean();
+
+        $this->assertSame($engine, $result);
+        $this->assertSame('hooked', $response);
+        $this->assertSame([
+            'process-early',
+            'process-late',
+            'process-after',
+            'run-before',
+            'run-after',
+        ], $events);
+    }
+
+    public function testEngineActionsRemainInactiveUntilDevElationIsEnabled(): void
+    {
+        $events = [];
+        Dev::action(Engine::HOOK_PROCESS_BEFORE, function () use (&$events): void {
+            $events[] = 'process-before';
+        });
+
+        $engine = $this->engine('/inactive');
+        $engine->map('get', 'inactive', fn(): string => 'inactive');
+
+        ob_start();
+        $engine->args()->process()->run();
+        ob_end_clean();
+
+        $this->assertSame([], $events);
+    }
+
+    public function testGatewayDenialDispatchesHandledOutcomeActions(): void
+    {
+        $events = [];
+        Dev::up();
+        $this->recordActions($events, [
+            Engine::HOOK_PROCESS_BEFORE => 'process-before',
+            Engine::HOOK_PROCESS_DENIED => 'process-denied',
+            Engine::HOOK_PROCESS_AFTER => 'process-after',
+            Engine::HOOK_RUN_DENIED => 'run-denied',
+        ]);
+
+        $engine = $this->engine('/denied');
+        $engine->gateway('deny-hooks', HookDenyingGateway::class);
+        $engine->map('get', 'denied', fn(): string => 'unreachable')->gateway('deny-hooks');
+
+        $engine->args()->process()->run();
+
+        $this->assertTrue($engine->denied());
+        $this->assertSame([
+            'process-before',
+            'process-denied',
+            'process-after',
+            'run-denied',
+        ], $events);
+    }
+
+    public function testProcessFailureDispatchesFailedWithoutAfter(): void
+    {
+        $events = [];
+        Dev::up();
+        $this->recordActions($events, [
+            Engine::HOOK_PROCESS_BEFORE => 'process-before',
+            Engine::HOOK_PROCESS_FAILED => 'process-failed',
+            Engine::HOOK_PROCESS_AFTER => 'process-after',
+        ]);
+
+        $engine = $this->engine('/process-failure');
+        $engine->gateway('fail-hooks', HookFailingGateway::class);
+        $engine->map('get', 'process-failure', fn(): string => 'unreachable')->gateway('fail-hooks');
+
+        try {
+            $engine->args()->process();
+            $this->fail('The failing gateway did not throw.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('gateway failure', $exception->getMessage());
+        }
+
+        $this->assertSame(['process-before', 'process-failed'], $events);
+    }
+
+    public function testRunFailureDispatchesFailedWithoutAfter(): void
+    {
+        $events = [];
+        Dev::up();
+        $this->recordActions($events, [
+            Engine::HOOK_RUN_BEFORE => 'run-before',
+            Engine::HOOK_RUN_FAILED => 'run-failed',
+            Engine::HOOK_RUN_AFTER => 'run-after',
+        ]);
+
+        $engine = $this->engine('/run-failure');
+        $engine->map('get', 'run-failure', function (): string {
+            throw new RuntimeException('controller failure');
+        });
+        $engine->args()->process();
+
+        try {
+            $engine->run();
+            $this->fail('The failing controller did not throw.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('controller failure', $exception->getMessage());
+        }
+
+        $this->assertSame(['run-before', 'run-failed'], $events);
+    }
+
+    public function testBootstrapFailureDispatchesFailedWithoutAfter(): void
+    {
+        $events = [];
+        Dev::up();
+        $this->recordActions($events, [
+            Engine::HOOK_BOOTSTRAP_BEFORE => 'bootstrap-before',
+            Engine::HOOK_BOOTSTRAP_FAILED => 'bootstrap-failed',
+            Engine::HOOK_BOOTSTRAP_AFTER => 'bootstrap-after',
+        ]);
+
+        $engine = new HookFailingBootstrapEngine([
+            'name' => 'bootstrap-hook-test-' . Str::rand('', 12),
+        ]);
+
+        try {
+            $engine->bootstrap();
+            $this->fail('The failing bootstrap did not throw.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('configuration failure', $exception->getMessage());
+        }
+
+        $this->assertSame(['bootstrap-before', 'bootstrap-failed'], $events);
+    }
+
+    private function engine(string $uri): Engine
+    {
+        $_SERVER['REQUEST_URI'] = $uri;
+
+        return new Engine(['name' => 'engine-hook-test-' . Str::rand('', 12)]);
+    }
+
+    private function recordActions(array &$events, array $actions): void
+    {
+        foreach ($actions as $hook => $label) {
+            Dev::action($hook, function () use (&$events, $label): void {
+                $events[] = $label;
+            });
+        }
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
+    }
+}
+
+class HookDenyingGateway extends Gateway
+{
+    public function process(Request $request, &$arguments): void
+    {
+        throw new GatewayDenied('Denied by test gateway.', 403);
+    }
+}
+
+class HookFailingGateway extends Gateway
+{
+    public function process(Request $request, &$arguments): void
+    {
+        throw new RuntimeException('gateway failure');
+    }
+}
+
+class HookFailingBootstrapEngine extends Engine
+{
+    public function loadConfiguration(): void
+    {
+        throw new RuntimeException('configuration failure');
+    }
+}

--- a/tests/BlueCore/EngineHookTest.php
+++ b/tests/BlueCore/EngineHookTest.php
@@ -4,6 +4,7 @@ namespace BlueFission\Tests\BlueCore;
 
 use BlueFission\BlueCore\Engine;
 use BlueFission\BlueCore\Gateway\GatewayDenied;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\DevElation as Dev;
 use BlueFission\Services\Gateway;
 use BlueFission\Services\Request;
@@ -128,12 +129,14 @@ class EngineHookTest extends TestCase
     public function testProcessFailureDispatchesFailedWithoutAfter(): void
     {
         $events = [];
+        $failure = null;
         Dev::up();
-        $this->recordActions($events, [
-            Engine::HOOK_PROCESS_BEFORE => 'process-before',
-            Engine::HOOK_PROCESS_FAILED => 'process-failed',
-            Engine::HOOK_PROCESS_AFTER => 'process-after',
-        ]);
+        $this->recordActions($events, [Engine::HOOK_PROCESS_BEFORE => 'process-before']);
+        Dev::action(Engine::HOOK_PROCESS_FAILED, function (LifecycleFailure $context) use (&$events, &$failure): void {
+            $events[] = 'process-failed';
+            $failure = $context;
+        });
+        $this->recordActions($events, [Engine::HOOK_PROCESS_AFTER => 'process-after']);
 
         $engine = $this->engine('/process-failure');
         $engine->gateway('fail-hooks', HookFailingGateway::class);
@@ -147,6 +150,12 @@ class EngineHookTest extends TestCase
         }
 
         $this->assertSame(['process-before', 'process-failed'], $events);
+        $this->assertInstanceOf(LifecycleFailure::class, $failure);
+        $this->assertSame(Engine::HOOK_PROCESS_FAILED, $failure->hook());
+        $this->assertSame('process', $failure->operation());
+        $this->assertSame($engine->name(), $failure->dispatcher());
+        $this->assertSame(RuntimeException::class, $failure->exceptionType());
+        $this->assertSame(0, $failure->exceptionCode());
     }
 
     public function testRunFailureDispatchesFailedWithoutAfter(): void
@@ -197,6 +206,80 @@ class EngineHookTest extends TestCase
         }
 
         $this->assertSame(['bootstrap-before', 'bootstrap-failed'], $events);
+    }
+
+    public function testEngineHookReentryIsSuppressedByDefault(): void
+    {
+        $invocations = 0;
+        Dev::up();
+        Dev::action(Engine::HOOK_PROCESS_BEFORE, function (Engine $engine) use (&$invocations): void {
+            $invocations++;
+            $engine->process();
+        });
+
+        $engine = $this->engine('/reentry-default');
+        $engine->map('get', 'reentry-default', fn(): string => 'ready');
+        $engine->args()->process();
+
+        $this->assertSame(1, $invocations);
+    }
+
+    public function testEngineHookReentryRequiresAnExplicitBoundedDepth(): void
+    {
+        $invocations = 0;
+        Dev::up();
+        Dev::action(Engine::HOOK_PROCESS_BEFORE, function (Engine $engine) use (&$invocations): void {
+            $invocations++;
+
+            if ($invocations < 3) {
+                $engine->process();
+            }
+        });
+
+        $engine = $this->engine('/reentry-opt-in');
+        $engine->map('get', 'reentry-opt-in', fn(): string => 'ready');
+        $engine->args()->hookRecursionDepth(Engine::HOOK_PROCESS_BEFORE, 2)->process();
+
+        $this->assertSame(2, $invocations);
+    }
+
+    public function testFailureHookDoesNotRedispatchItself(): void
+    {
+        $invocations = 0;
+        Dev::up();
+
+        $engine = $this->engine('/failure-reentry');
+        $engine->gateway('fail-reentry-hooks', HookFailingGateway::class);
+        $engine->map('get', 'failure-reentry', fn(): string => 'unreachable')->gateway('fail-reentry-hooks');
+        $engine->args();
+
+        Dev::action(Engine::HOOK_PROCESS_FAILED, function () use (&$invocations, $engine): void {
+            $invocations++;
+
+            try {
+                $engine->process();
+            } catch (RuntimeException) {
+            }
+        });
+
+        try {
+            $engine->process();
+            $this->fail('The failing gateway did not throw.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('gateway failure', $exception->getMessage());
+        }
+
+        $this->assertSame(1, $invocations);
+    }
+
+    public function testFailureHooksCannotOptIntoRecursiveDispatch(): void
+    {
+        $engine = $this->engine('/failure-recursion-config');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('failure hooks');
+
+        $engine->hookRecursionDepth(Engine::HOOK_PROCESS_FAILED, 2);
     }
 
     private function engine(string $uri): Engine
@@ -250,3 +333,4 @@ class HookFailingBootstrapEngine extends Engine
         throw new RuntimeException('configuration failure');
     }
 }
+

--- a/tests/BlueCore/Gateway/DynamicGatewayHookTest.php
+++ b/tests/BlueCore/Gateway/DynamicGatewayHookTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace BlueFission\Tests\BlueCore\Gateway;
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Gateway\DynamicGateway;
+use BlueFission\DevElation as Dev;
+use BlueFission\Services\Request;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class DynamicGatewayHookTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetDevElation();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDevElation();
+
+        parent::tearDown();
+    }
+
+    public function testArgumentsRemainUnchangedWhileDevElationIsInactive(): void
+    {
+        Dev::filter(DynamicGateway::FILTER_ARGUMENTS, fn(array $arguments): array => [
+            ...$arguments,
+            'filtered' => true,
+        ]);
+        $arguments = ['request_id' => 'request-1'];
+
+        (new DynamicGateway())->process(new Request(), $arguments);
+
+        $this->assertSame(['request_id' => 'request-1'], $arguments);
+    }
+
+    public function testLegacyAndNeutralFiltersRunInDeterministicOrder(): void
+    {
+        Dev::up();
+        Dev::filter(
+            DynamicGateway::LEGACY_FILTER_ARGUMENTS,
+            fn(array $arguments): Arr => Arr::make($arguments)->push('legacy')
+        );
+        Dev::filter(
+            DynamicGateway::FILTER_ARGUMENTS,
+            fn(array|Arr $arguments): array => [
+                ...Arr::toArray($arguments, true),
+                'neutral-late',
+            ],
+            20
+        );
+        Dev::filter(
+            DynamicGateway::FILTER_ARGUMENTS,
+            fn(array $arguments): Arr => Arr::make($arguments)->push('neutral-early'),
+            5
+        );
+        $arguments = [];
+
+        (new DynamicGateway())->process(new Request(), $arguments);
+
+        $this->assertSame(['legacy', 'neutral-early', 'neutral-late'], $arguments);
+    }
+
+    public function testFilterMustReturnArrayCompatibleArguments(): void
+    {
+        Dev::up();
+        Dev::filter(DynamicGateway::FILTER_ARGUMENTS, fn(): string => 'invalid');
+        $arguments = [];
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(DynamicGateway::FILTER_ARGUMENTS);
+
+        (new DynamicGateway())->process(new Request(), $arguments);
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
+    }
+}


### PR DESCRIPTION
## Intent summary

Establish the first reviewable DevElation extension-contract slice for issue #90. This change adds neutral Engine lifecycle actions and migrates DynamicGateway arguments to a typed BlueCore-owned filter while retaining alpha compatibility.

Refs #90. This PR does not close the broader lifecycle inventory.

## User stories and acceptance criteria

- Applications and add-ons can observe bootstrap, process, run, denial, and failure boundaries through public owner constants.
- DevElation remains inactive by default and unchanged applications preserve current behavior.
- Engine-owned hook re-entry is suppressed by default, can be explicitly enabled per hook to a bounded depth, and cannot be enabled for failure hooks.
- Failure actions receive a sanitized typed `LifecycleFailure` context without exception messages, traces, request data, sessions, or mutable Engine state.
- Dynamic gateway filters run in priority order, accept native arrays or `Arr`, and fail before controller execution when a callback returns an invalid type.
- The previous dynamic-gateway filter remains available during the alpha compatibility period and runs before the neutral filter.
- Hook names, payloads, mutability, security constraints, and failure semantics are documented.

## Key files changed

- `src/BlueCore/Engine.php`
- `src/BlueCore/Hooks/LifecycleFailure.php`
- `src/BlueCore/Gateway/DynamicGateway.php`
- `docs/develation-hooks.md`
- focused Engine and DynamicGateway hook tests

## How to test

```bash
vendor/bin/phpunit --do-not-cache-result tests/BlueCore/EngineHookTest.php tests/BlueCore/Gateway/DynamicGatewayHookTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict
composer audit
```

## QA checklist

- [x] Focused hooks: 13 tests, 29 assertions
- [x] Full suite: 144 tests, 588 assertions
- [x] Composer manifest validates strictly
- [x] GitHub CI is green
- [x] No dependency or environment changes
- [ ] Live Composer advisory audit; Packagist DNS resolution timed out on two attempts

## Approval conditions

- Confirm the names and payload order are stable enough for the alpha line.
- Confirm controlled gateway denial remains fail-closed and cannot be cleared by an action.
- Confirm sanitized failure contexts and bounded re-entry semantics are sufficient for framework extensions.
- Confirm the compatibility order is appropriate: legacy filter first, neutral filter second.
- Confirm the documented extension surface is framework-neutral and reusable.
