### PR TITLE
add registration and add-on lifecycle hooks

### DIFF
--- a/docs/develation-hooks.md
+++ b/docs/develation-hooks.md
@@ -48,10 +48,39 @@ Filters may add or normalize ordinary request arguments, but they must not remov
 
 During the alpha compatibility period, the previous dynamic-gateway filter is applied first and the neutral BlueCore filter is applied second. New integrations should register only `DynamicGateway::FILTER_ARGUMENTS`.
 
+## Registration plan hooks
+
+Owner: `RegistrationPlan`.
+
+| Constant and hook | Type | Payload or value | Contract |
+| --- | --- | --- | --- |
+| `RegistrationPlan::FILTER_ENTRY`<br>`bluecore.registration.plan.entry` | Filter | `RegistrationEntry` | May return a replacement entry for the same section. The name and definition may change; moving an entry between sections is rejected. |
+| `RegistrationPlan::HOOK_ENTRY_ADDED`<br>`bluecore.registration.plan.entry.added` | Action | `RegistrationEntry $entry, RegistrationPlan $plan` | Runs after a validated entry is stored. |
+| `RegistrationPlan::HOOK_ENTRY_FAILED`<br>`bluecore.registration.plan.entry.failed` | Action | `LifecycleFailure $failure` | Observes sanitized composition failure metadata before the original exception is rethrown. |
+
+Registration filters must return `RegistrationEntry`. Invalid types, empty names, and attempts to change the section fail before the plan is mutated. Re-entry into the same plan hook is suppressed; nested registration calls still execute with their unfiltered entry so the plan remains usable without recursively invoking the same callback.
+
+## Add-on registration hooks
+
+Owner: `AddOnManager`.
+
+| Constant and hook | Type | Payload or value | Contract |
+| --- | --- | --- | --- |
+| `AddOnManager::FILTER_REGISTRATION_PLAN`<br>`bluecore.addon.registration.plan` | Filter | `RegistrationPlan` | Transforms the shared plan before active registration factories run. Must return `RegistrationPlan`. |
+| `AddOnManager::HOOK_REGISTRATION_BEFORE`<br>`bluecore.addon.registration.before` | Action | `AddOn $addOn, Application $application, RegistrationPlan $plan, AddOnManager $manager` | Runs immediately before one active factory. |
+| `AddOnManager::HOOK_REGISTRATION_AFTER`<br>`bluecore.addon.registration.after` | Action | `AddOn $addOn, Application $application, RegistrationPlan $plan, AddOnManager $manager` | Runs after one factory completes successfully. |
+| `AddOnManager::HOOK_REGISTRATION_FAILED`<br>`bluecore.addon.registration.failed` | Action | `LifecycleFailure $failure` | Observes sanitized factory failure metadata. The structured registration result retains the existing operational diagnostics. |
+| `AddOnManager::FILTER_CONTRIBUTIONS`<br>`bluecore.addon.contributions` | Filter | `Arr` | Transforms the final passive contribution summary. Must return `Arr`. |
+
+Registration is guarded per add-on runtime key. A callback that re-enters active add-on loading receives a `registration_in_progress` status for the in-flight add-on, and its factory is not executed twice. Contribution filters run only after path containment and passive-data validation have completed; filters cannot make unsafe files eligible for loading.
+
 ```php
 use BlueFission\Arr;
+use BlueFission\BlueCore\Business\Managers\AddOnManager;
 use BlueFission\BlueCore\Engine;
 use BlueFission\BlueCore\Gateway\DynamicGateway;
+use BlueFission\BlueCore\Registration\RegistrationEntry;
+use BlueFission\BlueCore\Registration\RegistrationPlan;
 use BlueFission\DevElation;
 
 DevElation::up();
@@ -65,6 +94,20 @@ DevElation::action(
     Engine::HOOK_RUN_AFTER,
     function (Engine $result, Engine $engine): void {
         // Observe completed execution without replacing framework control flow.
+    }
+);
+
+DevElation::filter(
+    RegistrationPlan::FILTER_ENTRY,
+    function (RegistrationEntry $entry): RegistrationEntry {
+        return $entry;
+    }
+);
+
+DevElation::filter(
+    AddOnManager::FILTER_CONTRIBUTIONS,
+    function (Arr $summary): Arr {
+        return $summary;
     }
 );
 ```

--- a/src/BlueCore/Business/Managers/AddOnManager.php
+++ b/src/BlueCore/Business/Managers/AddOnManager.php
@@ -13,6 +13,8 @@ use BlueFission\Net\HTTP;
 use BlueFission\Flag;
 use BlueFission\Security\Hash;
 use BlueFission\BlueCore\Registration\RegistrationPlan;
+use BlueFission\BlueCore\Hooks\DispatchesLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\Services\Application;
 use BlueFission\Services\Service;
 use BlueFission\Utils\Loader;
@@ -26,10 +28,19 @@ use BlueFission\Val;
 
 class AddOnManager extends Service implements IAddOnLifecycleManager
 {
+    use DispatchesLifecycleHooks;
+
+    public const FILTER_REGISTRATION_PLAN = 'bluecore.addon.registration.plan';
+    public const FILTER_CONTRIBUTIONS = 'bluecore.addon.contributions';
+    public const HOOK_REGISTRATION_BEFORE = 'bluecore.addon.registration.before';
+    public const HOOK_REGISTRATION_AFTER = 'bluecore.addon.registration.after';
+    public const HOOK_REGISTRATION_FAILED = 'bluecore.addon.registration.failed';
+
     private $_loader;
     protected $_model;
     private array $_loadedAddOns = [];
     private array $_registeredAddOns = [];
+    private array $_registeringAddOns = [];
 
     public function __construct(MySQLLink $link)
     {
@@ -366,6 +377,16 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             );
         }
 
+        if ($plan instanceof RegistrationPlan) {
+            $plan = $this->applyLifecycleFilter(self::FILTER_REGISTRATION_PLAN, $plan);
+
+            if (!$plan instanceof RegistrationPlan) {
+                throw new \UnexpectedValueException(
+                    'Add-on registration plan filters must return a RegistrationPlan.'
+                );
+            }
+        }
+
         $addOns = $this->_model->getActivatedAddOns();
         $results = Arr::make([]);
 
@@ -395,10 +416,29 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
                 continue;
             }
 
+            if (Arr::hasKey($this->_registeringAddOns, $key)) {
+                $load['registration'] = $this->registrationResult('registration_in_progress');
+                $results->push($load);
+                continue;
+            }
+
+            $this->_registeringAddOns[$key] = true;
             try {
+                $this->dispatchLifecycleAction(self::HOOK_REGISTRATION_BEFORE, [
+                    $object,
+                    $application,
+                    $plan,
+                    $this,
+                ]);
                 Func::make($load['value'])->call($application, $plan);
                 $this->_registeredAddOns[$key] = true;
                 $load['registration'] = $this->registrationResult('registered', true);
+                $this->dispatchLifecycleAction(self::HOOK_REGISTRATION_AFTER, [
+                    $object,
+                    $application,
+                    $plan,
+                    $this,
+                ]);
             } catch (\Throwable $exception) {
                 $load['ok'] = false;
                 $load['stage'] = 'registration';
@@ -409,6 +449,16 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
                     false,
                     $exception
                 );
+                $this->dispatchLifecycleAction(self::HOOK_REGISTRATION_FAILED, [
+                    new LifecycleFailure(
+                        self::HOOK_REGISTRATION_FAILED,
+                        'register',
+                        (string)$object->name,
+                        $exception
+                    ),
+                ]);
+            } finally {
+                unset($this->_registeringAddOns[$key]);
             }
 
             $results->push($load);
@@ -442,7 +492,7 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             ->values();
         $snapshot = $entries->toArray();
 
-        return Arr::make([
+        $contributions = Arr::make([
             'ok' => Arr::isEmpty($failed->toArray()),
             'name' => $name,
             'revision' => Hash::value(HTTP::jsonEncode($snapshot), 'sha256'),
@@ -451,7 +501,16 @@ class AddOnManager extends Service implements IAddOnLifecycleManager
             'missing' => $missing->count(),
             'failed' => $failed->count(),
             'results' => $snapshot,
-        ])->toArray();
+        ]);
+        $contributions = $this->applyLifecycleFilter(self::FILTER_CONTRIBUTIONS, $contributions);
+
+        if (!$contributions instanceof Arr) {
+            throw new \UnexpectedValueException(
+                'Add-on contribution filters must return an Arr.'
+            );
+        }
+
+        return $contributions->toArray();
     }
 
     protected function loadContribution(AddOn $addOn, string $name): array

--- a/src/BlueCore/Hooks/DispatchesLifecycleHooks.php
+++ b/src/BlueCore/Hooks/DispatchesLifecycleHooks.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace BlueFission\BlueCore\Hooks;
+
+use BlueFission\Arr;
+use BlueFission\DevElation as Dev;
+use BlueFission\Num;
+
+trait DispatchesLifecycleHooks
+{
+    private array $_activeLifecycleHooks = [];
+
+    protected function dispatchLifecycleAction(string $hook, array $arguments = []): void
+    {
+        if (!$this->enterLifecycleHook($hook)) {
+            return;
+        }
+
+        try {
+            Dev::do($hook, $arguments);
+        } finally {
+            $this->leaveLifecycleHook($hook);
+        }
+    }
+
+    protected function applyLifecycleFilter(string $hook, mixed $value): mixed
+    {
+        if (!$this->enterLifecycleHook($hook)) {
+            return $value;
+        }
+
+        try {
+            return Dev::apply($hook, $value);
+        } finally {
+            $this->leaveLifecycleHook($hook);
+        }
+    }
+
+    private function enterLifecycleHook(string $hook): bool
+    {
+        if (Arr::hasKey($this->_activeLifecycleHooks, $hook)) {
+            return false;
+        }
+
+        $this->_activeLifecycleHooks[$hook] = 1;
+
+        return true;
+    }
+
+    private function leaveLifecycleHook(string $hook): void
+    {
+        $remaining = (int)Num::make($this->_activeLifecycleHooks[$hook] ?? 1)
+            ->decrement()
+            ->val();
+
+        if ($remaining <= 0) {
+            unset($this->_activeLifecycleHooks[$hook]);
+        } else {
+            $this->_activeLifecycleHooks[$hook] = $remaining;
+        }
+    }
+}

--- a/src/BlueCore/Registration/RegistrationEntry.php
+++ b/src/BlueCore/Registration/RegistrationEntry.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BlueFission\BlueCore\Registration;
+
+use BlueFission\Arr;
+use BlueFission\Obj;
+use BlueFission\Str;
+
+final class RegistrationEntry extends Obj
+{
+    public function __construct(string $section, string $name, mixed $definition)
+    {
+        parent::__construct();
+
+        $this->_data = Arr::make([
+            'section' => Str::make($section)->trim()->val(),
+            'name' => Str::make($name)->trim()->val(),
+            'definition' => $definition,
+        ]);
+    }
+
+    public function section(): string
+    {
+        return $this->_data['section'];
+    }
+
+    public function name(): string
+    {
+        return $this->_data['name'];
+    }
+
+    public function definition(): mixed
+    {
+        return $this->_data['definition'];
+    }
+}

--- a/src/BlueCore/Registration/RegistrationPlan.php
+++ b/src/BlueCore/Registration/RegistrationPlan.php
@@ -3,11 +3,22 @@
 namespace BlueFission\BlueCore\Registration;
 
 use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\DispatchesLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\Collections\Collection;
+use BlueFission\Str;
 use BlueFission\Val;
+use Throwable;
+use UnexpectedValueException;
 
 class RegistrationPlan
 {
+    use DispatchesLifecycleHooks;
+
+    public const FILTER_ENTRY = 'bluecore.registration.plan.entry';
+    public const HOOK_ENTRY_ADDED = 'bluecore.registration.plan.entry.added';
+    public const HOOK_ENTRY_FAILED = 'bluecore.registration.plan.entry.failed';
+
     private array $services = [];
     private array $delegates = [];
     private array $bindings = [];
@@ -58,11 +69,42 @@ class RegistrationPlan
 
     private function put(string $section, string $name, mixed $definition): self
     {
-        if (Val::isEmpty($name)) {
-            throw new \InvalidArgumentException('Registration names cannot be empty.');
-        }
+        try {
+            $entry = $this->applyLifecycleFilter(
+                self::FILTER_ENTRY,
+                new RegistrationEntry($section, $name, $definition)
+            );
 
-        $this->{$section}[$name] = $definition;
+            if (!$entry instanceof RegistrationEntry) {
+                throw new UnexpectedValueException(
+                    'Registration entry filters must return a RegistrationEntry.'
+                );
+            }
+
+            if (Val::isEmpty($entry->name())) {
+                throw new \InvalidArgumentException('Registration names cannot be empty.');
+            }
+
+            if (!Str::match($entry->section(), $section)) {
+                throw new UnexpectedValueException(
+                    'Registration entry filters cannot move entries between sections.'
+                );
+            }
+
+            $this->{$entry->section()}[$entry->name()] = $entry->definition();
+            $this->dispatchLifecycleAction(self::HOOK_ENTRY_ADDED, [$entry, $this]);
+        } catch (Throwable $exception) {
+            $this->dispatchLifecycleAction(self::HOOK_ENTRY_FAILED, [
+                new LifecycleFailure(
+                    self::HOOK_ENTRY_FAILED,
+                    'compose',
+                    self::class,
+                    $exception
+                ),
+            ]);
+
+            throw $exception;
+        }
 
         return $this;
     }

--- a/tests/BlueCore/Business/Managers/AddOnManagerTest.php
+++ b/tests/BlueCore/Business/Managers/AddOnManagerTest.php
@@ -2,12 +2,15 @@
 
 namespace BlueFission\Tests\BlueCore\Business\Managers;
 
+use BlueFission\Arr;
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
 use BlueFission\BlueCore\Domain\AddOn\AddOn;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\BlueCore\Registration\RegistrationPlan;
 use BlueFission\Collections\Collection;
 use BlueFission\Collections\Group;
 use BlueFission\Services\Application;
+use BlueFission\DevElation as Dev;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -36,6 +39,7 @@ class AddOnManagerTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->resetDevElation();
         unset(
             $GLOBALS['bluecore_registration_factory_calls'],
             $GLOBALS['bluecore_inactive_primary_loads']
@@ -50,6 +54,7 @@ class AddOnManagerTest extends TestCase
 
     protected function tearDown(): void
     {
+        $this->resetDevElation();
         if (self::$ownsRoot) {
             $this->removeDir(self::$root);
         }
@@ -687,6 +692,144 @@ PHP,
         }
     }
 
+    public function testRegistrationPlanFilterAndActionsWrapFactoryExecution(): void
+    {
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'hookedfactory';
+        File::ensureFile(
+            $path . DIRECTORY_SEPARATOR . 'main.php',
+            '<?php return static function ($application, $plan): void { $plan->service("factory", "executed"); };',
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel([[
+            'addon_id' => 25,
+            'name' => 'hookedfactory',
+            'path' => $path,
+            'primary_file' => 'main.php',
+            'is_active' => 1,
+        ]]));
+        $events = [];
+        Dev::up();
+        Dev::filter(
+            AddOnManager::FILTER_REGISTRATION_PLAN,
+            function (RegistrationPlan $plan) use (&$events): RegistrationPlan {
+                $events[] = 'filter';
+
+                return $plan->service('filtered', 'ready');
+            }
+        );
+        Dev::action(AddOnManager::HOOK_REGISTRATION_BEFORE, function () use (&$events): void {
+            $events[] = 'before';
+        });
+        Dev::action(AddOnManager::HOOK_REGISTRATION_AFTER, function () use (&$events): void {
+            $events[] = 'after';
+        });
+        $plan = new RegistrationPlan();
+
+        $result = $manager->loadActivatedAddOns(
+            new Application(['name' => 'registration-hook-test']),
+            $plan
+        );
+
+        $this->assertTrue($result[0]['ok']);
+        $this->assertSame(['filter', 'before', 'after'], $events);
+        $this->assertSame('ready', $plan->entries('services')['filtered']);
+        $this->assertSame('executed', $plan->entries('services')['factory']);
+    }
+
+    public function testRegistrationFailureActionReceivesSanitizedContext(): void
+    {
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'failedhookfactory';
+        File::ensureFile(
+            $path . DIRECTORY_SEPARATOR . 'main.php',
+            '<?php return static function (): void { throw new RuntimeException("private detail"); };',
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel([[
+            'addon_id' => 26,
+            'name' => 'failedhookfactory',
+            'path' => $path,
+            'primary_file' => 'main.php',
+            'is_active' => 1,
+        ]]));
+        $failure = null;
+        Dev::up();
+        Dev::action(
+            AddOnManager::HOOK_REGISTRATION_FAILED,
+            function (LifecycleFailure $context) use (&$failure): void {
+                $failure = $context;
+            }
+        );
+
+        $result = $manager->loadActivatedAddOns(
+            new Application(['name' => 'registration-failure-hook-test']),
+            new RegistrationPlan()
+        );
+
+        $this->assertFalse($result[0]['ok']);
+        $this->assertInstanceOf(LifecycleFailure::class, $failure);
+        $this->assertSame('failedhookfactory', $failure->dispatcher());
+        $this->assertSame(\RuntimeException::class, $failure->exceptionType());
+        $this->assertArrayNotHasKey('message', $failure->data());
+    }
+
+    public function testRegistrationActionReentryDoesNotExecuteFactoryTwice(): void
+    {
+        $path = self::$root . DIRECTORY_SEPARATOR . 'addons' . DIRECTORY_SEPARATOR . 'reentrantfactory';
+        File::ensureFile(
+            $path . DIRECTORY_SEPARATOR . 'main.php',
+            '<?php return static function (): void { $GLOBALS["bluecore_registration_factory_calls"] = ($GLOBALS["bluecore_registration_factory_calls"] ?? 0) + 1; };',
+            true
+        );
+        $manager = new TestableAddOnManager(new FakeAddOnModel([[
+            'addon_id' => 27,
+            'name' => 'reentrantfactory',
+            'path' => $path,
+            'primary_file' => 'main.php',
+            'is_active' => 1,
+        ]]));
+        $application = new Application(['name' => 'registration-reentry-test']);
+        $plan = new RegistrationPlan();
+        $nested = null;
+        Dev::up();
+        Dev::action(
+            AddOnManager::HOOK_REGISTRATION_BEFORE,
+            function () use ($manager, $application, $plan, &$nested): void {
+                $nested = $manager->loadActivatedAddOns($application, $plan);
+            }
+        );
+
+        $result = $manager->loadActivatedAddOns($application, $plan);
+
+        $this->assertSame('registered', $result[0]['registration']['status']);
+        $this->assertSame('registration_in_progress', $nested[0]['registration']['status']);
+        $this->assertSame(1, $GLOBALS['bluecore_registration_factory_calls']);
+    }
+
+    public function testContributionSummaryFilterRequiresAndReturnsArr(): void
+    {
+        $manager = new TestableAddOnManager(new FakeAddOnModel());
+        Dev::up();
+        Dev::filter(
+            AddOnManager::FILTER_CONTRIBUTIONS,
+            function (Arr $summary): Arr {
+                $summary->set('source', 'filtered');
+
+                return $summary;
+            }
+        );
+
+        $result = $manager->loadActivatedContributions('capabilities');
+
+        $this->assertSame('filtered', $result['source']);
+
+        $this->resetDevElation();
+        Dev::up();
+        Dev::filter(AddOnManager::FILTER_CONTRIBUTIONS, fn(): array => []);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $manager->loadActivatedContributions('capabilities');
+    }
+
     public function testActivateAndActivateAllReturnStructuredStatuses(): void
     {
         $model = new FakeAddOnModel([
@@ -1001,6 +1144,17 @@ PHP,
                 '<?php',
                 true
             );
+        }
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
         }
     }
 

--- a/tests/BlueCore/Contracts/RegistrationPlanTest.php
+++ b/tests/BlueCore/Contracts/RegistrationPlanTest.php
@@ -5,11 +5,26 @@ namespace BlueFission\Tests\BlueCore\Contracts;
 use BlueFission\BlueCore\Contracts\IAddOnLifecycleManager;
 use BlueFission\BlueCore\Contracts\IApplicationRegistrar;
 use BlueFission\BlueCore\Contracts\IThemeRegistry;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
+use BlueFission\BlueCore\Registration\RegistrationEntry;
 use BlueFission\BlueCore\Registration\RegistrationPlan;
+use BlueFission\DevElation as Dev;
 use PHPUnit\Framework\TestCase;
 
 class RegistrationPlanTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetDevElation();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDevElation();
+        parent::tearDown();
+    }
+
     public function testRegistrationPlanCollectsFrameworkContributions(): void
     {
         $plan = (new RegistrationPlan())
@@ -39,5 +54,97 @@ class RegistrationPlanTest extends TestCase
         $this->assertTrue(interface_exists(IApplicationRegistrar::class));
         $this->assertTrue(interface_exists(IAddOnLifecycleManager::class));
         $this->assertTrue(interface_exists(IThemeRegistry::class));
+    }
+
+    public function testRegistrationEntriesCanBeFilteredAndObservedInPriorityOrder(): void
+    {
+        $events = [];
+        Dev::up();
+        Dev::filter(
+            RegistrationPlan::FILTER_ENTRY,
+            function (RegistrationEntry $entry) use (&$events): RegistrationEntry {
+                $events[] = 'filter';
+
+                return new RegistrationEntry(
+                    $entry->section(),
+                    $entry->name(),
+                    $entry->definition() . '-filtered'
+                );
+            },
+            5
+        );
+        Dev::action(
+            RegistrationPlan::HOOK_ENTRY_ADDED,
+            function (RegistrationEntry $entry) use (&$events): void {
+                $events[] = 'added:' . $entry->name();
+            },
+            10
+        );
+
+        $plan = (new RegistrationPlan())->service('cache', 'service');
+
+        $this->assertSame('service-filtered', $plan->entries('services')['cache']);
+        $this->assertSame(['filter', 'added:cache'], $events);
+    }
+
+    public function testInvalidRegistrationFilterResultDispatchesSanitizedFailure(): void
+    {
+        $failure = null;
+        Dev::up();
+        Dev::filter(RegistrationPlan::FILTER_ENTRY, fn(): array => []);
+        Dev::action(
+            RegistrationPlan::HOOK_ENTRY_FAILED,
+            function (LifecycleFailure $context) use (&$failure): void {
+                $failure = $context;
+            }
+        );
+
+        try {
+            (new RegistrationPlan())->service('cache', 'service');
+            $this->fail('Invalid filter result was accepted.');
+        } catch (\UnexpectedValueException $exception) {
+            $this->assertStringContainsString('RegistrationEntry', $exception->getMessage());
+        }
+
+        $this->assertInstanceOf(LifecycleFailure::class, $failure);
+        $this->assertSame(RegistrationPlan::HOOK_ENTRY_FAILED, $failure->hook());
+        $this->assertSame('compose', $failure->operation());
+        $this->assertSame(RegistrationPlan::class, $failure->dispatcher());
+        $this->assertSame(\UnexpectedValueException::class, $failure->exceptionType());
+    }
+
+    public function testRegistrationEntryFilterReentryIsSuppressed(): void
+    {
+        $invocations = 0;
+        $plan = new RegistrationPlan();
+        Dev::up();
+        Dev::filter(
+            RegistrationPlan::FILTER_ENTRY,
+            function (RegistrationEntry $entry) use (&$invocations, $plan): RegistrationEntry {
+                $invocations++;
+
+                if ($invocations === 1) {
+                    $plan->service('nested', 'ready');
+                }
+
+                return $entry;
+            }
+        );
+
+        $plan->service('root', 'ready');
+
+        $this->assertSame(1, $invocations);
+        $this->assertSame(['nested', 'root'], array_keys($plan->entries('services')));
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
     }
 }


### PR DESCRIPTION
## Intent

Expose stable DevElation integration points around registration plan composition, active add-on registration, and passive contribution summaries without prescribing application installation structure.

## User stories and acceptance criteria

- Framework extensions can transform typed registration entries before they are stored.
- Applications can observe successful and failed registration composition through stable action names.
- Active add-on factories receive before, after, and sanitized failure actions.
- Registration plan and contribution filters reject incompatible return types before framework state crosses the boundary.
- Re-entry into a hook is suppressed, and an in-flight add-on factory cannot execute twice.
- Existing add-on loading and structured result behavior remains compatible when DevElation hooks are disabled.

This is the registration and add-on composition slice of #90. Remaining lifecycle areas stay tracked by that issue.

## Key files

- `src/BlueCore/Hooks/DispatchesLifecycleHooks.php`
- `src/BlueCore/Registration/RegistrationEntry.php`
- `src/BlueCore/Registration/RegistrationPlan.php`
- `src/BlueCore/Business/Managers/AddOnManager.php`
- `docs/develation-hooks.md`

## How to test

```bash
composer validate --no-check-publish --strict
composer lint
vendor/bin/phpunit --do-not-cache-result
composer audit --locked
```

Result: 151 tests, 612 assertions; validation, lint, and audit pass.

## QA checklist

- [x] Public hook names are constants.
- [x] Filters use DevElation first-class `Obj`/`Arr` values and validate return types.
- [x] Failure actions receive `LifecycleFailure` without exception messages or traces.
- [x] Registration re-entry does not duplicate factory execution.
- [x] Security and path-containment checks remain authoritative.
- [x] Hook contracts and examples are documented.

## Approval conditions

- Confirm the registration entry replacement contract is appropriately framework-level.
- Confirm add-on callbacks remain observational except for the documented plan and summary filters.
- Confirm issue #90 remains open for the later datasource, installation, response, template, and error slices.
