### PR TITLE
prepare v0.1.4 alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ BlueCore provides core functionality and architecture for modular, scalable web 
 BlueCore requires PHP 8.2 or newer. Install the current alpha release through Composer:
 
 ```bash
-composer require bluefission/bluecore:^0.1.3@alpha
+composer require bluefission/bluecore:^0.1.4@alpha
 ```
 
 The alpha line is intended for integration testing while the public API is finalized. Pin an explicit alpha constraint in reproducible environments.

--- a/docs/releases/v0.1.4-alpha.md
+++ b/docs/releases/v0.1.4-alpha.md
@@ -1,0 +1,30 @@
+# BlueCore v0.1.4-alpha
+
+This alpha release establishes the first framework-wide DevElation hook and filter contracts introduced after `v0.1.3-alpha`.
+
+## Compatibility
+
+- PHP 8.2 and 8.3 remain supported.
+- DevElation `^1.3.41` remains the minimum supported dependency line.
+- Composer projects should use `bluefission/bluecore:^0.1.4@alpha` when adopting this release.
+
+## Framework Changes
+
+- Engine bootstrap, process, run, denial, and failure boundaries expose stable BlueCore-owned DevElation actions.
+- Dynamic gateway arguments expose a typed neutral filter while retaining the previous alpha hook as a compatibility path.
+- Registration plans expose typed entry composition filters plus added and sanitized failure actions.
+- Active add-on registration exposes plan, before, after, and sanitized failure integration points without prescribing host installation policy.
+- Passive contribution summaries can be transformed as DevElation `Arr` values after containment and passive-data validation.
+- Hook re-entry is bounded, and an in-flight add-on registration factory cannot execute twice.
+
+## Upgrade Guidance
+
+- Call `DevElation::up()` before expecting global filters or actions to execute; inactive hooks preserve existing behavior.
+- Register integrations through the public hook constants documented in `docs/develation-hooks.md`.
+- Filters must return their documented DevElation or framework type. Invalid filter results fail at the owning boundary.
+- Treat actions as observational. Authorization, path containment, registration validation, and other fail-closed checks remain authoritative.
+- New gateway integrations should use the neutral BlueCore hook; the previous alpha hook is retained only for the documented compatibility window.
+
+## Release Gate
+
+The tag must be created from reviewed `main` only after the lifecycle-hook pull requests included by this release are merged. Before tagging, run strict Composer validation, lint, PHPUnit, installer parity where the environment permits, and a dependency audit. After publishing the prerelease, verify that Packagist resolves the tag to the same commit before announcing the constraint as consumable.

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -96,13 +96,13 @@ final class ComposerMetadataTest extends TestCase
     {
         $readme = Str::make(File::readContents($this->rootFile('README.md')));
         $release = Str::make(
-            File::readContents($this->rootFile('docs/releases/v0.1.3-alpha.md'))
+            File::readContents($this->rootFile('docs/releases/v0.1.4-alpha.md'))
         );
 
         $this->assertTrue(
-            $readme->has('composer require bluefission/bluecore:^0.1.3@alpha')
+            $readme->has('composer require bluefission/bluecore:^0.1.4@alpha')
         );
-        $this->assertTrue($release->has('bluefission/bluecore:^0.1.3@alpha'));
+        $this->assertTrue($release->has('bluefission/bluecore:^0.1.4@alpha'));
         $this->assertTrue($release->has('DevElation `^1.3.41`'));
         $this->assertTrue($release->has('Packagist resolves the tag to the same commit'));
     }


### PR DESCRIPTION
## Intent

Stage the `v0.1.4-alpha` release metadata and verification contract from `main` while keeping tag publication gated on reviewed lifecycle-hook work.

Closes #93 after the release is merged, tagged, published as a prerelease, and verified on Packagist.

## User stories and acceptance criteria

- The README advertises the next explicit alpha constraint.
- Release notes describe the framework-owned DevElation lifecycle surface and compatibility rules.
- The metadata test prevents the README and release constraint from drifting.
- Tagging remains restricted to reviewed `main` after included implementation PRs merge.
- Packagist must resolve the tag to the same commit before availability is announced.

## Key files

- `README.md`
- `docs/releases/v0.1.4-alpha.md`
- `tests/ComposerMetadataTest.php`

## How to test

```bash
composer ci
composer test:installer
vendor/bin/phpunit --do-not-cache-result --no-progress
composer audit --locked
```

Local result: installer parity passes; PHPUnit passes 144 tests and 588 assertions. The dependency audit passed immediately before this branch was created with the same lockfile; a release-branch retry reached a DNS timeout at the advisory endpoint.

## QA checklist

- [x] Version advances from `v0.1.3-alpha` to `v0.1.4-alpha`.
- [x] PHP and DevElation compatibility are explicit.
- [x] Release notes remain framework-neutral.
- [x] Publication is gated on reviewed `main`.
- [x] Packagist commit verification is required.

## Approval conditions

- Merge PR #92 first and rerun CI on the resulting `main`.
- Reconcile the release notes against the final `v0.1.3-alpha..main` diff.
- Rerun the live dependency audit when DNS is available.
- Obtain human approval before creating the tag and GitHub prerelease.
