### PR TITLE
add datasource and installation lifecycle hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.2",
-        "bluefission/develation": "^1.3.41",
+        "bluefission/develation": "^1.3.44",
         "composer/installers": "^1.11",
         "composer-plugin-api": "^2.0",
         "vlucas/phpdotenv": "^5.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4985f677a975d6caca1d7582966070cf",
+    "content-hash": "ac2f5ed79df53ac71cc173440b1abb2b",
     "packages": [
         {
             "name": "bluefission/develation",
-            "version": "v1.3.41",
+            "version": "v1.3.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "25bdd65152ef39a83524b30eb47cba2c061ded91"
+                "reference": "096a10250164227662134f996f6ddd083605a5c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/25bdd65152ef39a83524b30eb47cba2c061ded91",
-                "reference": "25bdd65152ef39a83524b30eb47cba2c061ded91",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/096a10250164227662134f996f6ddd083605a5c7",
+                "reference": "096a10250164227662134f996f6ddd083605a5c7",
                 "shasum": ""
             },
             "require": {
@@ -33,7 +33,11 @@
                 "phpunit/phpunit": "^11.5"
             },
             "suggest": {
-                "cboden/ratchet": "Install to use the optional BlueFission\\Async\\Sock Ratchet websocket transport."
+                "cboden/ratchet": "Install to use the optional BlueFission\\Async\\Sock Ratchet websocket transport.",
+                "ext-memcached": "Install to use Memcached storage and MemQueue.",
+                "ext-mongodb": "Install with mongodb/mongodb to use the MongoLink database adapter.",
+                "ext-redis": "Install to use Redis connections, storage, and reliable queues.",
+                "mongodb/mongodb": "Install with ext-mongodb to use the MongoLink database adapter."
             },
             "type": "library",
             "autoload": {
@@ -76,7 +80,7 @@
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-08-07T19:31:33+00:00"
+            "time": "2026-08-31T20:50:17+00:00"
         },
         {
             "name": "composer/installers",

--- a/docs/develation-hooks.md
+++ b/docs/develation-hooks.md
@@ -74,6 +74,37 @@ Owner: `AddOnManager`.
 
 Registration is guarded per add-on runtime key. A callback that re-enters active add-on loading receives a `registration_in_progress` status for the in-flight add-on, and its factory is not executed twice. Contribution filters run only after path containment and passive-data validation have completed; filters cannot make unsafe files eligible for loading.
 
+## Datasource lifecycle hooks
+
+Owner: `DatasourceManager`. Planning filters receive DevElation `Arr` values and may only reorder or remove entries discovered by BlueCore. They cannot add migration or population files, change the batch, change the iteration, or change automatic-population intent.
+
+| Constant and hook | Type | Payload or value | Contract |
+| --- | --- | --- | --- |
+| `DatasourceManager::FILTER_MIGRATION_PLAN`<br>`bluecore.datasource.migration.plan` | Filter | `Arr` with `operation`, `batch`, `iteration`, and `deltas` | Must return `Arr`. `deltas` may contain a unique reordered subset of discovered files. |
+| `DatasourceManager::HOOK_MIGRATION_BEFORE`<br>`bluecore.datasource.migration.before` | Action | `Arr $plan, DatasourceManager $manager` | Runs after plan validation and before migration execution. |
+| `DatasourceManager::HOOK_MIGRATION_AFTER`<br>`bluecore.datasource.migration.after` | Action | `Arr $result, DatasourceManager $manager` | Runs after successful execution, including a successful no-op. |
+| `DatasourceManager::HOOK_MIGRATION_FAILED`<br>`bluecore.datasource.migration.failed` | Action | `LifecycleFailure $failure` | Observes sanitized planning or execution failure metadata. |
+| `DatasourceManager::FILTER_POPULATION_PLAN`<br>`bluecore.datasource.population.plan` | Filter | `Arr` with `operation`, `auto`, and `generators` | Must return `Arr`. `generators` may contain a unique reordered subset of discovered files. |
+| `DatasourceManager::HOOK_POPULATION_BEFORE`<br>`bluecore.datasource.population.before` | Action | `Arr $plan, DatasourceManager $manager` | Runs after plan validation and before population execution. |
+| `DatasourceManager::HOOK_POPULATION_AFTER`<br>`bluecore.datasource.population.after` | Action | `Arr $result, DatasourceManager $manager` | Runs after successful execution, including a successful no-op. |
+| `DatasourceManager::HOOK_POPULATION_FAILED`<br>`bluecore.datasource.population.failed` | Action | `LifecycleFailure $failure` | Observes sanitized planning or execution failure metadata. |
+
+## Installation lifecycle hooks
+
+Owner: `InstallationExecutor`. Installation actions expose summaries only. Host context, approval evidence, stage evidence, exception messages, and checkpoint storage handles are not published through the global action surface.
+
+| Constant and hook | Phase | Payload | Contract |
+| --- | --- | --- | --- |
+| `InstallationExecutor::HOOK_PREPARE_AFTER`<br>`bluecore.installation.prepare.after` | Plan prepared | `Arr $summary, InstallationExecutor $executor` | Reports plan id, status, diagnostic count, and checkpoint count after persistence. |
+| `InstallationExecutor::HOOK_RESUME_AFTER`<br>`bluecore.installation.resume.after` | Plan resumed | `Arr $summary, InstallationExecutor $executor` | Runs only when a checkpoint resolves to a plan. |
+| `InstallationExecutor::HOOK_EXECUTE_BEFORE`<br>`bluecore.installation.execute.before` | Before execution | `Arr $summary, InstallationExecutor $executor` | Runs after approval and readiness checks succeed. |
+| `InstallationExecutor::HOOK_STAGE_BEFORE`<br>`bluecore.installation.stage.before` | Before stage | `Arr $summary, InstallationExecutor $executor` | Reports only plan id, status, and stage name. |
+| `InstallationExecutor::HOOK_STAGE_AFTER`<br>`bluecore.installation.stage.after` | Stage success | `Arr $summary, InstallationExecutor $executor` | Reports sanitized outcome flags without stage evidence. |
+| `InstallationExecutor::HOOK_STAGE_FAILED`<br>`bluecore.installation.stage.failed` | Stage failure | `LifecycleFailure $failure` | Observes sanitized stage failure metadata. |
+| `InstallationExecutor::HOOK_CHECKPOINTED`<br>`bluecore.installation.checkpoint.after` | Checkpoint recorded | `Arr $summary, InstallationExecutor $executor` | Runs after the in-memory checkpoint is recorded and before durable plan save. |
+| `InstallationExecutor::HOOK_EXECUTE_AFTER`<br>`bluecore.installation.execute.after` | Execution success | `Arr $summary, InstallationExecutor $executor` | Runs after completion is persisted. |
+| `InstallationExecutor::HOOK_EXECUTE_FAILED`<br>`bluecore.installation.execute.failed` | Execution failure | `LifecycleFailure $failure` | Observes sanitized readiness or stage failure metadata. |
+
 ```php
 use BlueFission\Arr;
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
@@ -87,7 +118,12 @@ DevElation::up();
 
 DevElation::filter(
     DynamicGateway::FILTER_ARGUMENTS,
-    fn(array $arguments): Arr => Arr::make($arguments)->set('trace_enabled', true)
+    function (array $arguments): Arr {
+        $filtered = Arr::make($arguments);
+        $filtered->set('trace_enabled', true);
+
+        return $filtered;
+    }
 );
 
 DevElation::action(

--- a/docs/releases/v0.1.4-alpha.md
+++ b/docs/releases/v0.1.4-alpha.md
@@ -5,7 +5,7 @@ This alpha release establishes the first framework-wide DevElation hook and filt
 ## Compatibility
 
 - PHP 8.2 and 8.3 remain supported.
-- DevElation `^1.3.41` remains the minimum supported dependency line.
+- DevElation `^1.3.44` is the minimum supported dependency line.
 - Composer projects should use `bluefission/bluecore:^0.1.4@alpha` when adopting this release.
 
 ## Framework Changes
@@ -15,6 +15,8 @@ This alpha release establishes the first framework-wide DevElation hook and filt
 - Registration plans expose typed entry composition filters plus added and sanitized failure actions.
 - Active add-on registration exposes plan, before, after, and sanitized failure integration points without prescribing host installation policy.
 - Passive contribution summaries can be transformed as DevElation `Arr` values after containment and passive-data validation.
+- Datasource migration and population plans expose constrained `Arr` filters plus typed lifecycle actions.
+- Installation preparation, execution, stage, checkpoint, resume, and failure boundaries expose sanitized observational actions.
 - Hook re-entry is bounded, and an in-flight add-on registration factory cannot execute twice.
 
 ## Upgrade Guidance

--- a/src/BlueCore/Business/Managers/DatasourceManager.php
+++ b/src/BlueCore/Business/Managers/DatasourceManager.php
@@ -2,6 +2,8 @@
 namespace BlueFission\BlueCore\Business\Managers;
 
 use BlueFission\Services\Service;
+use BlueFission\BlueCore\Hooks\DispatchesLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\Collections\Collection;
 use BlueFission\Connections\Database\MySQLLink;
 use BlueFission\Data\Storage\Storage;
@@ -14,6 +16,16 @@ use BlueFission\Str;
 use BlueFission\Val;
 
 class DatasourceManager extends Service {
+	use DispatchesLifecycleHooks;
+
+	public const FILTER_MIGRATION_PLAN = 'bluecore.datasource.migration.plan';
+	public const HOOK_MIGRATION_BEFORE = 'bluecore.datasource.migration.before';
+	public const HOOK_MIGRATION_AFTER = 'bluecore.datasource.migration.after';
+	public const HOOK_MIGRATION_FAILED = 'bluecore.datasource.migration.failed';
+	public const FILTER_POPULATION_PLAN = 'bluecore.datasource.population.plan';
+	public const HOOK_POPULATION_BEFORE = 'bluecore.datasource.population.before';
+	public const HOOK_POPULATION_AFTER = 'bluecore.datasource.population.after';
+	public const HOOK_POPULATION_FAILED = 'bluecore.datasource.population.failed';
 
 	protected $_deltaDir = '';
 	protected $_generatorDir = '';
@@ -59,7 +71,12 @@ class DatasourceManager extends Service {
 		if (Flag::isFalse($this->deltaDirectoryExists())) {
 			$result->set('stage', 'complete');
 
-			return $result->toArray();
+			return $this->finalizeDatasourceResult(
+				$result,
+				'migration',
+				self::HOOK_MIGRATION_AFTER,
+				self::HOOK_MIGRATION_FAILED
+			);
 		}
 
 		$deltas = $this->loadDeltas();
@@ -72,11 +89,43 @@ class DatasourceManager extends Service {
 			->filter(fn ($delta) => Str::pos((string)$delta, '.') !== 0)
 			->values()
 			->toArray();
+		$plan = Arr::make([
+			'operation' => 'migration',
+			'batch' => $batch,
+			'iteration' => $iteration,
+			'deltas' => $deltas,
+		]);
+
+		try {
+			$plan = $this->filteredDatasourcePlan(
+				self::FILTER_MIGRATION_PLAN,
+				$plan,
+				'deltas'
+			);
+		} catch (\Throwable $exception) {
+			$result->set('ok', false);
+			$result->set('stage', 'planning');
+			$result->set('failed', 1);
+			$result->set('nextAction', 'review_migration_plan');
+			$result->set('error', $exception->getMessage());
+
+			return $this->finalizeDatasourceResult(
+				$result,
+				'migration',
+				self::HOOK_MIGRATION_AFTER,
+				self::HOOK_MIGRATION_FAILED,
+				$exception
+			);
+		}
+
+		$deltas = Arr::make($plan->get('deltas'))->toArray();
+		$this->dispatchLifecycleAction(self::HOOK_MIGRATION_BEFORE, [$plan, $this]);
 
 		$result->set('total', Arr::size($deltas));
 		$result->set('stage', 'migration');
 		$dbActive = $this->migrationTableExists();
 		$migrations = Arr::make([]);
+		$failureException = null;
 
 		foreach ($deltas as $delta) {
 			$migration = Arr::make([
@@ -91,8 +140,9 @@ class DatasourceManager extends Service {
 			$classname = $this->findClassName($this->_deltaDir . $delta);
 
 			if (Val::isEmpty($classname)) {
+				$failureException = new \RuntimeException('Migration class could not be resolved.');
 				$migration->set('status', 'missing_class');
-				$migration->set('error', 'Migration class could not be resolved.');
+				$migration->set('error', $failureException->getMessage());
 				$migrations->push($migration->toArray());
 				break;
 			}
@@ -114,6 +164,7 @@ class DatasourceManager extends Service {
 				$migration->set('ok', true);
 				$migration->set('status', 'applied');
 			} catch (\Throwable $exception) {
+				$failureException = $exception;
 				$status = 3;
 				$migration->set('status', 'failed');
 				$migration->set('error', $exception->getMessage());
@@ -157,7 +208,13 @@ class DatasourceManager extends Service {
 			$result->set('error', Arr::getPath($failure, 'error', 'Migration failed.'));
 		}
 
-		return $result->toArray();
+		return $this->finalizeDatasourceResult(
+			$result,
+			'migration',
+			self::HOOK_MIGRATION_AFTER,
+			self::HOOK_MIGRATION_FAILED,
+			$failureException
+		);
 	}
 
 	public function revertMigrations()
@@ -250,18 +307,61 @@ class DatasourceManager extends Service {
 		if (Flag::isFalse($this->generatorDirectoryExists())) {
 			$result->set('stage', 'complete');
 
-			return $result->toArray();
+			return $this->finalizeDatasourceResult(
+				$result,
+				'population',
+				self::HOOK_POPULATION_AFTER,
+				self::HOOK_POPULATION_FAILED
+			);
 		}
 
 		try {
 			$generators = $this->orderedGenerators($this->loadGenerators());
 		} catch (\Throwable $exception) {
-			return $this->failedPopulationResult($result, 'RootSeeder.php', $exception);
+			return $this->finalizeDatasourceResult(
+				Arr::make($this->failedPopulationResult($result, 'RootSeeder.php', $exception)),
+				'population',
+				self::HOOK_POPULATION_AFTER,
+				self::HOOK_POPULATION_FAILED,
+				$exception
+			);
 		}
+		$plan = Arr::make([
+			'operation' => 'population',
+			'auto' => Flag::parseBool($auto),
+			'generators' => $generators,
+		]);
+
+		try {
+			$plan = $this->filteredDatasourcePlan(
+				self::FILTER_POPULATION_PLAN,
+				$plan,
+				'generators'
+			);
+		} catch (\Throwable $exception) {
+			$result->set('ok', false);
+			$result->set('stage', 'planning');
+			$result->set('failed', 1);
+			$result->set('nextAction', 'review_population_plan');
+			$result->set('error', $exception->getMessage());
+			$result->set('results', []);
+
+			return $this->finalizeDatasourceResult(
+				$result,
+				'population',
+				self::HOOK_POPULATION_AFTER,
+				self::HOOK_POPULATION_FAILED,
+				$exception
+			);
+		}
+
+		$generators = Arr::make($plan->get('generators'))->toArray();
+		$this->dispatchLifecycleAction(self::HOOK_POPULATION_BEFORE, [$plan, $this]);
 
 		$result->set('total', Arr::size($generators));
 		$result->set('stage', 'population');
 		$outcomes = Arr::make([]);
+		$failureException = null;
 
 		foreach ($generators as $generator) {
 			$outcome = Arr::make([
@@ -288,6 +388,7 @@ class DatasourceManager extends Service {
 				$outcome->set('ok', true);
 				$outcome->set('status', 'populated');
 			} catch (\Throwable $exception) {
+				$failureException = $exception;
 				$outcome->set('status', 'failed');
 				$outcome->set('error', $exception->getMessage());
 				$outcome->set('exception', $exception::class);
@@ -318,7 +419,13 @@ class DatasourceManager extends Service {
 			$result->set('error', Arr::getPath($failure, 'error', 'Datasource population failed.'));
 		}
 
-		return $result->toArray();
+		return $this->finalizeDatasourceResult(
+			$result,
+			'population',
+			self::HOOK_POPULATION_AFTER,
+			self::HOOK_POPULATION_FAILED,
+			$failureException
+		);
 	}
 
 	protected function orderedGenerators(array $generators): array
@@ -348,6 +455,69 @@ class DatasourceManager extends Service {
 			->map(fn ($generator) => Str::endsWith((string)$generator, '.php') ? $generator : $generator . '.php')
 			->values()
 			->toArray();
+	}
+
+	private function filteredDatasourcePlan(string $hook, Arr $plan, string $itemsKey): Arr
+	{
+		$original = $plan->toArray();
+		$filtered = $this->applyLifecycleFilter($hook, $plan);
+
+		if (!$filtered instanceof Arr) {
+			throw new \UnexpectedValueException("{$hook} must return a DevElation Arr.");
+		}
+
+		foreach ($original as $key => $value) {
+			if ($key !== $itemsKey && $filtered->get($key) !== $value) {
+				throw new \UnexpectedValueException("{$hook} cannot change {$key}.");
+			}
+		}
+
+		$items = $filtered->get($itemsKey);
+		if (!Arr::is($items)) {
+			throw new \UnexpectedValueException("{$hook} must preserve {$itemsKey} as an array.");
+		}
+
+		$items = Arr::make($items)->values()->toArray();
+		if (Arr::make($items)->unique()->values()->toArray() !== $items) {
+			throw new \UnexpectedValueException("{$hook} cannot duplicate planned entries.");
+		}
+
+		$available = Arr::make(Arr::getPath($original, $itemsKey, []))->values()->toArray();
+		foreach ($items as $item) {
+			if (Flag::isFalse(Str::is($item)) || Flag::isFalse(Arr::has($available, $item, true))) {
+				throw new \UnexpectedValueException(
+					"{$hook} can only reorder or remove discovered entries."
+				);
+			}
+		}
+
+		$normalized = Arr::make($filtered->toArray());
+		$normalized->set($itemsKey, $items);
+
+		return $normalized;
+	}
+
+	private function finalizeDatasourceResult(
+		Arr $result,
+		string $operation,
+		string $afterHook,
+		string $failedHook,
+		?\Throwable $exception = null
+	): array {
+		if (Flag::parseBool($result->get('ok'))) {
+			$this->dispatchLifecycleAction($afterHook, [Arr::make($result->toArray()), $this]);
+		} else {
+			$exception ??= new \RuntimeException(
+				(string)(Val::isEmpty($result->get('error'))
+					? 'Datasource operation failed.'
+					: $result->get('error'))
+			);
+			$this->dispatchLifecycleAction($failedHook, [
+				new LifecycleFailure($failedHook, $operation, static::class, $exception),
+			]);
+		}
+
+		return $result->toArray();
 	}
 
 	private function failedPopulationResult(Arr $result, string $generator, \Throwable $exception): array

--- a/src/BlueCore/Engine.php
+++ b/src/BlueCore/Engine.php
@@ -104,9 +104,21 @@ class Engine extends Application {
 	/**
 	 * Return the active instance for the concrete Engine class.
 	 */
-	public static function instance()
+	public static function instance($name = null)
 	{
 		$calledClass = static::class;
+
+		if (Val::isNotNull($name)) {
+			$instance = parent::getInstance($name);
+			if (!$instance instanceof $calledClass) {
+				throw new \LogicException(
+					"Application instance '{$name}' is not compatible with the active Engine class."
+				);
+			}
+
+			return $instance;
+		}
+
 		$instances = Arr::make(self::$_activeInstances);
 
 		if ($instances->hasKey($calledClass)) {
@@ -126,9 +138,20 @@ class Engine extends Application {
 	/**
 	 * Resolve a dependency from the active concrete Engine instance.
 	 */
-	public static function makeInstance(string $class)
+	public static function makeInstance(
+		string $class,
+		Application|string|null $application = null
+	)
 	{
-		return static::instance()->resolveForPhase($class, 'static');
+		if ($application instanceof Application && !$application instanceof static) {
+			return parent::makeInstance($class, $application);
+		}
+
+		$engine = $application instanceof static
+			? $application
+			: static::instance($application);
+
+		return $engine->resolveForPhase($class, 'static');
 	}
 
 	public function resolve(string $class)

--- a/src/BlueCore/Installation/InstallationExecutor.php
+++ b/src/BlueCore/Installation/InstallationExecutor.php
@@ -4,6 +4,8 @@ namespace BlueFission\BlueCore\Installation;
 
 use BlueFission\Arr;
 use BlueFission\BlueCore\Contracts\IInstallationCheckpointStore;
+use BlueFission\BlueCore\Hooks\DispatchesLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\Collections\Collection;
 use BlueFission\Flag;
 use BlueFission\Func;
@@ -12,6 +14,18 @@ use BlueFission\Val;
 
 class InstallationExecutor
 {
+    use DispatchesLifecycleHooks;
+
+    public const HOOK_PREPARE_AFTER = 'bluecore.installation.prepare.after';
+    public const HOOK_RESUME_AFTER = 'bluecore.installation.resume.after';
+    public const HOOK_EXECUTE_BEFORE = 'bluecore.installation.execute.before';
+    public const HOOK_EXECUTE_AFTER = 'bluecore.installation.execute.after';
+    public const HOOK_EXECUTE_FAILED = 'bluecore.installation.execute.failed';
+    public const HOOK_STAGE_BEFORE = 'bluecore.installation.stage.before';
+    public const HOOK_STAGE_AFTER = 'bluecore.installation.stage.after';
+    public const HOOK_STAGE_FAILED = 'bluecore.installation.stage.failed';
+    public const HOOK_CHECKPOINTED = 'bluecore.installation.checkpoint.after';
+
     private Collection $stages;
     private ?Func $validator = null;
     private bool $approvalRequired = false;
@@ -72,6 +86,10 @@ class InstallationExecutor
             $plan->applyDiagnostics($this->validate($context));
         }
         $this->save($plan);
+        $this->dispatchLifecycleAction(self::HOOK_PREPARE_AFTER, [
+            $this->planSummary($plan),
+            $this,
+        ]);
 
         return $plan;
     }
@@ -83,14 +101,38 @@ class InstallationExecutor
         }
 
         $checkpoint = $this->checkpoints->load($planId);
+        $plan = Val::isNull($checkpoint) ? null : InstallationPlan::restore($checkpoint);
 
-        return Val::isNull($checkpoint) ? null : InstallationPlan::restore($checkpoint);
+        if (Val::isNotNull($plan)) {
+            $this->dispatchLifecycleAction(self::HOOK_RESUME_AFTER, [
+                $this->planSummary($plan),
+                $this,
+            ]);
+        }
+
+        return $plan;
     }
 
     public function execute(InstallationPlan $plan): array
     {
-        $plan->start($this->approvalRequired);
+        try {
+            $plan->start($this->approvalRequired);
+        } catch (\Throwable $exception) {
+            $this->dispatchInstallationFailure(
+                self::HOOK_EXECUTE_FAILED,
+                'execute',
+                self::class,
+                $exception
+            );
+
+            throw $exception;
+        }
+
         $this->save($plan);
+        $this->dispatchLifecycleAction(self::HOOK_EXECUTE_BEFORE, [
+            $this->planSummary($plan),
+            $this,
+        ]);
 
         foreach ($this->stages as $stage) {
             $stage = Arr::make($stage);
@@ -100,10 +142,17 @@ class InstallationExecutor
             }
 
             $operation = $stage->get('operation');
+            $stageFailure = null;
+            $this->dispatchLifecycleAction(self::HOOK_STAGE_BEFORE, [
+                $this->stageSummary($plan, $name),
+                $this,
+            ]);
+
             try {
                 $raw = $operation instanceof Func ? $operation->call($plan) : null;
                 $outcome = $this->outcome($name, $raw);
             } catch (\Throwable $exception) {
+                $stageFailure = $exception;
                 $outcome = $this->outcome($name, [
                     'ok' => false,
                     'changed' => false,
@@ -113,12 +162,40 @@ class InstallationExecutor
                 ]);
             }
 
+            if (Flag::make(Arr::getPath($outcome, 'ok', false))->isFalse()) {
+                $stageFailure ??= new \RuntimeException(
+                    (string)Arr::getPath($outcome, 'error', 'Installation stage failed.')
+                );
+                $this->dispatchInstallationFailure(
+                    self::HOOK_STAGE_FAILED,
+                    'stage',
+                    $name,
+                    $stageFailure
+                );
+            } else {
+                $this->dispatchLifecycleAction(self::HOOK_STAGE_AFTER, [
+                    $this->outcomeSummary($plan, $outcome),
+                    $this,
+                ]);
+            }
+
             $plan->checkpoint($name, $outcome);
+            $this->dispatchLifecycleAction(self::HOOK_CHECKPOINTED, [
+                $this->outcomeSummary($plan, $outcome),
+                $this,
+            ]);
             if (Flag::make(Arr::getPath($outcome, 'ok', false))->isFalse()) {
                 $plan->fail($name, $outcome);
                 $this->save($plan);
+                $result = $this->result($plan, false);
+                $this->dispatchInstallationFailure(
+                    self::HOOK_EXECUTE_FAILED,
+                    'execute',
+                    self::class,
+                    $stageFailure ?? new \RuntimeException('Installation execution failed.')
+                );
 
-                return $this->result($plan, false);
+                return $result;
             }
 
             $this->save($plan);
@@ -126,8 +203,59 @@ class InstallationExecutor
 
         $plan->complete();
         $this->save($plan);
+        $result = $this->result($plan, true);
+        $this->dispatchLifecycleAction(self::HOOK_EXECUTE_AFTER, [
+            $this->planSummary($plan),
+            $this,
+        ]);
 
-        return $this->result($plan, true);
+        return $result;
+    }
+
+    private function planSummary(InstallationPlan $plan): Arr
+    {
+        $data = $plan->toArray();
+
+        return Arr::make([
+            'plan_id' => $plan->id(),
+            'status' => $plan->status(),
+            'diagnostic_count' => Arr::size($plan->diagnostics()),
+            'checkpoint_count' => Arr::size(Arr::getPath($data, 'checkpoints', [])),
+        ]);
+    }
+
+    private function stageSummary(InstallationPlan $plan, string $stage): Arr
+    {
+        return Arr::make([
+            'plan_id' => $plan->id(),
+            'status' => $plan->status(),
+            'stage' => $stage,
+        ]);
+    }
+
+    private function outcomeSummary(InstallationPlan $plan, array $outcome): Arr
+    {
+        return Arr::make([
+            'plan_id' => $plan->id(),
+            'status' => $plan->status(),
+            'stage' => Arr::getPath($outcome, 'stage'),
+            'ok' => Flag::parseBool(Arr::getPath($outcome, 'ok', false)),
+            'changed' => Flag::parseBool(Arr::getPath($outcome, 'changed', false)),
+            'skipped' => Flag::parseBool(Arr::getPath($outcome, 'skipped', false)),
+            'next_action' => Arr::getPath($outcome, 'nextAction'),
+            'exception_type' => Arr::getPath($outcome, 'exception'),
+        ]);
+    }
+
+    private function dispatchInstallationFailure(
+        string $hook,
+        string $operation,
+        string $dispatcher,
+        \Throwable $exception
+    ): void {
+        $this->dispatchLifecycleAction($hook, [
+            new LifecycleFailure($hook, $operation, $dispatcher, $exception),
+        ]);
     }
 
     private function validate(array $context): array

--- a/src/Helpers/global.php
+++ b/src/Helpers/global.php
@@ -6,7 +6,7 @@ use BlueFission\Flag;
 use BlueFission\Utils\Util;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
-use BlueFission\Services\Application as App;
+use BlueFission\BlueCore\Engine as App;
 use BlueFission\Str;
 use BlueFission\Val;
 

--- a/tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php
@@ -73,10 +73,10 @@ class DatasourceManagerMigrationRunTest extends TestCase
             DatasourceManager::FILTER_MIGRATION_PLAN,
             function (Arr $plan) use (&$events): Arr {
                 $events[] = 'filter';
-				$filtered = Arr::make($plan->toArray());
-				$filtered->set('deltas', ['002_later.php']);
+                $filtered = Arr::make($plan->toArray());
+                $filtered->set('deltas', ['002_later.php']);
 
-				return $filtered;
+                return $filtered;
             }
         );
         Dev::action(

--- a/tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerMigrationRunTest.php
@@ -4,10 +4,22 @@ namespace BlueFission\Tests\BlueCore\Business\Managers;
 
 use BlueFission\Arr;
 use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
+use BlueFission\DevElation as Dev;
 use PHPUnit\Framework\TestCase;
 
 class DatasourceManagerMigrationRunTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->resetDevElation();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDevElation();
+    }
+
     public function testPendingMigrationsAreScopedByBatchAndRepeatAsNoOp(): void
     {
         $manager = new ExecutableDatasourceManager(['001_initial.php', '002_later.php']);
@@ -50,6 +62,80 @@ class DatasourceManagerMigrationRunTest extends TestCase
             ['001_initial.php', '002_retry.php', '003_after.php'],
             $manager->historyFor('retry-addon')
         );
+    }
+
+    public function testMigrationPlanFilterAndActionsUseTypedLifecyclePayloads(): void
+    {
+        $events = [];
+        $manager = new ExecutableDatasourceManager(['001_initial.php', '002_later.php']);
+        Dev::up();
+        Dev::filter(
+            DatasourceManager::FILTER_MIGRATION_PLAN,
+            function (Arr $plan) use (&$events): Arr {
+                $events[] = 'filter';
+				$filtered = Arr::make($plan->toArray());
+				$filtered->set('deltas', ['002_later.php']);
+
+				return $filtered;
+            }
+        );
+        Dev::action(
+            DatasourceManager::HOOK_MIGRATION_BEFORE,
+            function (Arr $plan) use (&$events): void {
+                $events[] = 'before';
+                $this->assertSame(['002_later.php'], $plan->get('deltas'));
+            }
+        );
+        Dev::action(
+            DatasourceManager::HOOK_MIGRATION_AFTER,
+            function (Arr $result) use (&$events): void {
+                $events[] = 'after';
+                $this->assertSame(1, $result->get('applied'));
+            }
+        );
+
+        $result = $manager->runMigrations('filtered');
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(['002_later.php'], $manager->historyFor('filtered'));
+        $this->assertSame(['filter', 'before', 'after'], $events);
+    }
+
+    public function testInvalidMigrationPlanFilterReturnsStructuredFailure(): void
+    {
+        $failure = null;
+        $manager = new ExecutableDatasourceManager(['001_initial.php']);
+        Dev::up();
+        Dev::filter(DatasourceManager::FILTER_MIGRATION_PLAN, fn (): array => []);
+        Dev::action(
+            DatasourceManager::HOOK_MIGRATION_FAILED,
+            function (LifecycleFailure $context) use (&$failure): void {
+                $failure = $context;
+            }
+        );
+
+        $result = $manager->runMigrations('invalid-filter');
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('planning', $result['stage']);
+        $this->assertSame('review_migration_plan', $result['nextAction']);
+        $this->assertInstanceOf(LifecycleFailure::class, $failure);
+        $this->assertSame(
+            DatasourceManager::HOOK_MIGRATION_FAILED,
+            $failure->hook()
+        );
+        $this->assertSame([], $manager->historyFor('invalid-filter'));
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
     }
 }
 

--- a/tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php
@@ -83,10 +83,10 @@ class DatasourceManagerPopulationTest extends TestCase
             DatasourceManager::FILTER_POPULATION_PLAN,
             function (Arr $plan) use (&$events): Arr {
                 $events[] = 'filter';
-				$filtered = Arr::make($plan->toArray());
-				$filtered->set('generators', ['SecondSeeder.php']);
+                $filtered = Arr::make($plan->toArray());
+                $filtered->set('generators', ['SecondSeeder.php']);
 
-				return $filtered;
+                return $filtered;
             }
         );
         Dev::action(

--- a/tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php
+++ b/tests/BlueCore/Business/Managers/DatasourceManagerPopulationTest.php
@@ -4,10 +4,21 @@ namespace BlueFission\Tests\BlueCore\Business\Managers;
 
 use BlueFission\Arr;
 use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use BlueFission\DevElation as Dev;
 use PHPUnit\Framework\TestCase;
 
 class DatasourceManagerPopulationTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->resetDevElation();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDevElation();
+    }
+
     public function testMissingGeneratorDirectoryReturnsStructuredNoOp(): void
     {
         $result = (new ExecutablePopulationManager([], directoryExists: false))->populate();
@@ -58,6 +69,57 @@ class DatasourceManagerPopulationTest extends TestCase
         $this->assertSame(['FirstSeeder.php', 'FailingSeeder.php'], $manager->populated());
         $this->assertSame('failed', $result['results'][1]['status']);
         $this->assertSame(\RuntimeException::class, $result['results'][1]['exception']);
+    }
+
+    public function testPopulationPlanFilterAndActionsUseTypedLifecyclePayloads(): void
+    {
+        $events = [];
+        $manager = new ExecutablePopulationManager([
+            'FirstSeeder.php',
+            'SecondSeeder.php',
+        ]);
+        Dev::up();
+        Dev::filter(
+            DatasourceManager::FILTER_POPULATION_PLAN,
+            function (Arr $plan) use (&$events): Arr {
+                $events[] = 'filter';
+				$filtered = Arr::make($plan->toArray());
+				$filtered->set('generators', ['SecondSeeder.php']);
+
+				return $filtered;
+            }
+        );
+        Dev::action(
+            DatasourceManager::HOOK_POPULATION_BEFORE,
+            function (Arr $plan) use (&$events): void {
+                $events[] = 'before';
+                $this->assertSame(['SecondSeeder.php'], $plan->get('generators'));
+            }
+        );
+        Dev::action(
+            DatasourceManager::HOOK_POPULATION_AFTER,
+            function (Arr $result) use (&$events): void {
+                $events[] = 'after';
+                $this->assertSame(1, $result->get('populated'));
+            }
+        );
+
+        $result = $manager->populate(true);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(['SecondSeeder.php'], $manager->populated());
+        $this->assertSame(['filter', 'before', 'after'], $events);
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
     }
 }
 

--- a/tests/BlueCore/EngineBindingResolutionTest.php
+++ b/tests/BlueCore/EngineBindingResolutionTest.php
@@ -5,6 +5,7 @@ namespace BlueFission\Tests\BlueCore;
 use BlueFission\BlueCore\Engine;
 use BlueFission\BlueCore\Registration\RegistrationResolutionException;
 use BlueFission\Services\Application;
+use BlueFission\Exceptions\DependencyResolutionException;
 use PHPUnit\Framework\TestCase;
 
 interface EngineBindingContract
@@ -86,6 +87,26 @@ final class EngineBindingResolutionTest extends TestCase
         $this->assertInstanceOf(EngineBindingImplementation::class, $resolved);
     }
 
+    public function testNamedInstanceUsesTheDevElationSelectionContract(): void
+    {
+        $first = new Engine(['name' => 'first-named-engine']);
+        $second = new Engine(['name' => 'second-named-engine']);
+		$first->bind(EngineBindingContract::class, EngineBindingImplementation::class);
+		$second->bind(EngineBindingContract::class, AlternateEngineBindingImplementation::class);
+
+        $this->assertSame($first, Engine::instance('first-named-engine'));
+        $this->assertSame($second, Engine::instance('second-named-engine'));
+        $this->assertSame($second, Engine::instance());
+		$this->assertInstanceOf(
+			EngineBindingImplementation::class,
+			Engine::makeInstance(EngineBindingContract::class, 'first-named-engine')
+		);
+		$this->assertInstanceOf(
+			AlternateEngineBindingImplementation::class,
+			Engine::makeInstance(EngineBindingContract::class, $second)
+		);
+    }
+
     public function testResolutionFailureNamesTheContractAndLifecyclePhase(): void
     {
         $engine = new Engine(['name' => 'diagnostic-engine']);
@@ -97,7 +118,10 @@ final class EngineBindingResolutionTest extends TestCase
             $this->assertSame(EngineBindingContract::class, $exception->diagnostic()['contract']);
             $this->assertSame('boot', $exception->diagnostic()['phase']);
             $this->assertSame(EngineBindingContract::class, $exception->diagnostic()['implementation']);
-            $this->assertSame(\Error::class, $exception->diagnostic()['exception_class']);
+            $this->assertSame(
+                DependencyResolutionException::class,
+                $exception->diagnostic()['exception_class']
+            );
             $this->assertStringContainsString(EngineBindingContract::class, $exception->getMessage());
             $this->assertStringContainsString('boot', $exception->getMessage());
         }

--- a/tests/BlueCore/EngineBindingResolutionTest.php
+++ b/tests/BlueCore/EngineBindingResolutionTest.php
@@ -91,20 +91,20 @@ final class EngineBindingResolutionTest extends TestCase
     {
         $first = new Engine(['name' => 'first-named-engine']);
         $second = new Engine(['name' => 'second-named-engine']);
-		$first->bind(EngineBindingContract::class, EngineBindingImplementation::class);
-		$second->bind(EngineBindingContract::class, AlternateEngineBindingImplementation::class);
+        $first->bind(EngineBindingContract::class, EngineBindingImplementation::class);
+        $second->bind(EngineBindingContract::class, AlternateEngineBindingImplementation::class);
 
         $this->assertSame($first, Engine::instance('first-named-engine'));
         $this->assertSame($second, Engine::instance('second-named-engine'));
         $this->assertSame($second, Engine::instance());
-		$this->assertInstanceOf(
-			EngineBindingImplementation::class,
-			Engine::makeInstance(EngineBindingContract::class, 'first-named-engine')
-		);
-		$this->assertInstanceOf(
-			AlternateEngineBindingImplementation::class,
-			Engine::makeInstance(EngineBindingContract::class, $second)
-		);
+        $this->assertInstanceOf(
+            EngineBindingImplementation::class,
+            Engine::makeInstance(EngineBindingContract::class, 'first-named-engine')
+        );
+        $this->assertInstanceOf(
+            AlternateEngineBindingImplementation::class,
+            Engine::makeInstance(EngineBindingContract::class, $second)
+        );
     }
 
     public function testResolutionFailureNamesTheContractAndLifecyclePhase(): void

--- a/tests/BlueCore/Installation/InstallationExecutorTest.php
+++ b/tests/BlueCore/Installation/InstallationExecutorTest.php
@@ -3,10 +3,12 @@
 namespace BlueFission\Tests\BlueCore\Installation;
 
 use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\BlueCore\Installation\InstallationExecutor;
 use BlueFission\BlueCore\Installation\InstallationPlan;
 use BlueFission\BlueCore\Installation\JsonInstallationCheckpointStore;
 use BlueFission\Data\FileSystem;
+use BlueFission\DevElation as Dev;
 use BlueFission\Str;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
@@ -18,6 +20,7 @@ class InstallationExecutorTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->resetDevElation();
         $this->checkpointDirectory = Path::ensureDir(
             Path::normalize(
                 sys_get_temp_dir().DIRECTORY_SEPARATOR.'bluecore-installation-'.Str::rand('', 10)
@@ -27,6 +30,7 @@ class InstallationExecutorTest extends TestCase
 
     protected function tearDown(): void
     {
+        $this->resetDevElation();
         if (!FileSystem::directoryExists($this->checkpointDirectory)) {
             return;
         }
@@ -184,10 +188,93 @@ class InstallationExecutorTest extends TestCase
         (new InstallationExecutor())->resume('missing');
     }
 
+    public function testInstallationActionsExposeSanitizedLifecycleSummaries(): void
+    {
+        $events = [];
+        Dev::up();
+        Dev::action(
+            InstallationExecutor::HOOK_PREPARE_AFTER,
+            function (Arr $summary) use (&$events): void {
+                $events[] = 'prepared';
+                $this->assertFalse($summary->hasKey('context'));
+            }
+        );
+        Dev::action(InstallationExecutor::HOOK_EXECUTE_BEFORE, function () use (&$events): void {
+            $events[] = 'execute-before';
+        });
+        Dev::action(InstallationExecutor::HOOK_STAGE_BEFORE, function () use (&$events): void {
+            $events[] = 'stage-before';
+        });
+        Dev::action(InstallationExecutor::HOOK_STAGE_AFTER, function () use (&$events): void {
+            $events[] = 'stage-after';
+        });
+        Dev::action(InstallationExecutor::HOOK_CHECKPOINTED, function (Arr $summary) use (&$events): void {
+            $events[] = 'checkpointed';
+            $this->assertFalse($summary->hasKey('evidence'));
+        });
+        Dev::action(InstallationExecutor::HOOK_EXECUTE_AFTER, function () use (&$events): void {
+            $events[] = 'execute-after';
+        });
+        $executor = (new InstallationExecutor())->stage('configured', fn (): bool => true);
+
+        $result = $executor->execute($executor->prepare(['secret' => 'not-published'], 'hooks'));
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame([
+            'prepared',
+            'execute-before',
+            'stage-before',
+            'stage-after',
+            'checkpointed',
+            'execute-after',
+        ], $events);
+    }
+
+    public function testInstallationFailureActionsUseSanitizedFailureContext(): void
+    {
+        $failures = [];
+        Dev::up();
+        Dev::action(
+            InstallationExecutor::HOOK_STAGE_FAILED,
+            function (LifecycleFailure $failure) use (&$failures): void {
+                $failures[] = $failure;
+            }
+        );
+        Dev::action(
+            InstallationExecutor::HOOK_EXECUTE_FAILED,
+            function (LifecycleFailure $failure) use (&$failures): void {
+                $failures[] = $failure;
+            }
+        );
+        $executor = (new InstallationExecutor())->stage(
+            'failing',
+            fn () => throw new \RuntimeException('sensitive failure detail')
+        );
+
+        $result = $executor->execute($executor->prepare());
+
+        $this->assertFalse($result['ok']);
+        $this->assertCount(2, $failures);
+        $this->assertSame('failing', $failures[0]->dispatcher());
+        $this->assertSame(InstallationExecutor::class, $failures[1]->dispatcher());
+        $this->assertArrayNotHasKey('message', $failures[0]->data());
+    }
+
     private function executor(): InstallationExecutor
     {
         return new InstallationExecutor(
             new JsonInstallationCheckpointStore($this->checkpointDirectory)
         );
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+        $reflection = new \ReflectionClass(Dev::class);
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setValue(null, []);
+        }
     }
 }

--- a/tests/ComposerMetadataTest.php
+++ b/tests/ComposerMetadataTest.php
@@ -52,7 +52,7 @@ final class ComposerMetadataTest extends TestCase
     {
         $composer = $this->composer();
 
-        $this->assertSame('^1.3.41', $composer['require']['bluefission/develation']);
+        $this->assertSame('^1.3.44', $composer['require']['bluefission/develation']);
     }
 
     public function testPackageArchiveExcludesDevelopmentFiles(): void
@@ -103,7 +103,7 @@ final class ComposerMetadataTest extends TestCase
             $readme->has('composer require bluefission/bluecore:^0.1.4@alpha')
         );
         $this->assertTrue($release->has('bluefission/bluecore:^0.1.4@alpha'));
-        $this->assertTrue($release->has('DevElation `^1.3.41`'));
+        $this->assertTrue($release->has('DevElation `^1.3.44`'));
         $this->assertTrue($release->has('Packagist resolves the tag to the same commit'));
     }
 

--- a/tests/Helpers/TemplateRenderingHelperTest.php
+++ b/tests/Helpers/TemplateRenderingHelperTest.php
@@ -141,7 +141,7 @@ class TemplateRenderingHelperTest extends TestCase
     {
         $instances = new \ReflectionProperty(Application::class, '_instances');
         $instances->setValue(null, []);
-		$active = new \ReflectionProperty(Engine::class, '_activeInstances');
-		$active->setValue(null, []);
+        $active = new \ReflectionProperty(Engine::class, '_activeInstances');
+        $active->setValue(null, []);
     }
 }

--- a/tests/Helpers/TemplateRenderingHelperTest.php
+++ b/tests/Helpers/TemplateRenderingHelperTest.php
@@ -141,5 +141,7 @@ class TemplateRenderingHelperTest extends TestCase
     {
         $instances = new \ReflectionProperty(Application::class, '_instances');
         $instances->setValue(null, []);
+		$active = new \ReflectionProperty(Engine::class, '_activeInstances');
+		$active->setValue(null, []);
     }
 }


### PR DESCRIPTION
## Intent

Advance #90 with a focused datasource and installation lifecycle slice while preserving BlueCore's framework-neutral policy boundaries.

## User stories and acceptance criteria

- Add-on and application integrations can reorder or remove discovered migration and population work through typed DevElation `Arr` filters.
- Datasource filters cannot add undiscovered files, duplicate entries, or change immutable batch, iteration, or population intent.
- Migration and population before, after, and failure actions expose documented typed payloads.
- Installation preparation, resume, execution, stage, checkpoint, and failure actions publish sanitized summaries without host context, approval evidence, stage evidence, exception messages, or storage handles.
- DevElation `^1.3.44` named-instance and dependency-resolution contracts are supported without changing the default active Engine behavior.
- The global BlueCore `instance()` helper resolves the active Engine under DevElation's class-owned application lifecycle.

## Key files changed

- `src/BlueCore/Business/Managers/DatasourceManager.php`
- `src/BlueCore/Installation/InstallationExecutor.php`
- `src/BlueCore/Engine.php`
- `src/Helpers/global.php`
- `docs/develation-hooks.md`
- `composer.json` and `composer.lock`

## How to test

```bash
composer ci
composer test:installer
composer audit --locked
```

Local results: Composer validation, lint, and PHPUnit pass with 157 tests and 642 assertions. Project installer source/dist parity passes. The live security advisory audit remains blocked by DNS timeouts resolving Packagist's advisory endpoint; the lockfile was resolved to DevElation `v1.3.44` from Packagist cache and dist metadata.

## QA checklist

- [x] Hook names follow `bluecore.<area>.<operation>.<phase>`.
- [x] Filters require DevElation `Arr` and fail with structured datasource diagnostics.
- [x] Filtered plans remain subsets of framework-discovered work.
- [x] Installation action payloads exclude opaque host and evidence data.
- [x] Failure actions use sanitized `LifecycleFailure` metadata.
- [x] DevElation `v1.3.44` compatibility regressions have focused coverage.
- [x] Release notes and metadata tests use the updated dependency floor.

## Approval conditions

- Review confirms datasource filters cannot bypass discovery or path-containment ownership.
- Review confirms installation actions remain observational and do not prescribe host policy.
- CI passes on PHP 8.2 and 8.3.
- Run the live dependency audit when Packagist DNS is available before publishing `v0.1.4-alpha`.
