### PR TITLE
add response template and error lifecycle hooks

### DIFF
--- a/docs/develation-hooks.md
+++ b/docs/develation-hooks.md
@@ -105,11 +105,34 @@ Owner: `InstallationExecutor`. Installation actions expose summaries only. Host 
 | `InstallationExecutor::HOOK_EXECUTE_AFTER`<br>`bluecore.installation.execute.after` | Execution success | `Arr $summary, InstallationExecutor $executor` | Runs after completion is persisted. |
 | `InstallationExecutor::HOOK_EXECUTE_FAILED`<br>`bluecore.installation.execute.failed` | Execution failure | `LifecycleFailure $failure` | Observes sanitized readiness or stage failure metadata. |
 
+## Response, template, and error hooks
+
+Owner: `HelperLifecycleHooks`. These constants cover Composer-loaded global helpers that do not have a class owner. Re-entry into the same helper hook is suppressed.
+
+| Constant and hook | Type | Payload or value | Contract |
+| --- | --- | --- | --- |
+| `HelperLifecycleHooks::FILTER_RESPONSE`<br>`bluecore.response.prepare` | Filter | `Arr` with `data` and integer `status` | Must return `Arr`. The status must remain between 100 and 599. |
+| `HelperLifecycleHooks::HOOK_RESPONSE_BEFORE`<br>`bluecore.response.before` | Action | Sanitized `Arr` with `status` and `content_type` | Runs before the DevElation `Response` is filled and headers are prepared. Response data is not exposed. |
+| `HelperLifecycleHooks::HOOK_RESPONSE_AFTER`<br>`bluecore.response.after` | Action | Sanitized `Arr` with `status` and `content_type` | Runs after response preparation and immediately before `Response::send()`. DevElation delivery exits on its complete event, so this is not a post-delivery callback. |
+| `HelperLifecycleHooks::HOOK_RESPONSE_FAILED`<br>`bluecore.response.failed` | Action | `LifecycleFailure $failure` | Observes sanitized preparation or extension failure metadata before the original exception is rethrown. |
+| `HelperLifecycleHooks::EVENT_RESPONSE_PREPARED`<br>`bluecore.response.prepared` | Event | Sanitized response summary `Arr` | A genuine prepared-response event triggered immediately before delivery. Register it with `listen()`, then attach callables with `subscribe()`. |
+| `HelperLifecycleHooks::FILTER_TEMPLATE_DATA`<br>`bluecore.template.data` | Filter | Template data `Arr` | Must return `Arr`. Theme selection and the relative template file remain framework-owned and cannot be changed through this filter. |
+| `HelperLifecycleHooks::HOOK_TEMPLATE_BEFORE`<br>`bluecore.template.before` | Action | Sanitized `Arr` with `theme`, `file`, and `data_count` | Runs after data filtering and before renderer selection. Data values are not exposed. |
+| `HelperLifecycleHooks::FILTER_TEMPLATE_OUTPUT`<br>`bluecore.template.output` | Filter | Rendered `Str` | Must return `Str`. Runs only after a renderer returns a native string. |
+| `HelperLifecycleHooks::HOOK_TEMPLATE_AFTER`<br>`bluecore.template.after` | Action | Sanitized template summary `Arr` | Runs after output filtering and adds `output_length` without exposing rendered content. |
+| `HelperLifecycleHooks::HOOK_TEMPLATE_FAILED`<br>`bluecore.template.failed` | Action | `LifecycleFailure $failure` | Observes sanitized rendering or extension failure metadata before the original exception is rethrown. |
+| `HelperLifecycleHooks::HOOK_ERROR_REPORTED`<br>`bluecore.error.reported` | Action | Sanitized error summary `Arr` | Runs after logging a handled PHP error. Message, file, line, and trace are omitted. |
+| `HelperLifecycleHooks::HOOK_EXCEPTION_REPORTED`<br>`bluecore.exception.reported` | Action | Sanitized exception summary `Arr` | Adds only exception class and numeric code to the shared error summary fields. |
+| `HelperLifecycleHooks::HOOK_FATAL_REPORTED`<br>`bluecore.fatal.reported` | Action | Sanitized fatal summary `Arr` | Runs after fatal-error logging. Hook failures are contained so they cannot replace error reporting. |
+
+Response and template filter failures remain fail-closed. Error-report actions are observational and cannot replace the original logging, status, debug-output, or exit behavior.
+
 ```php
 use BlueFission\Arr;
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
 use BlueFission\BlueCore\Engine;
 use BlueFission\BlueCore\Gateway\DynamicGateway;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
 use BlueFission\BlueCore\Registration\RegistrationEntry;
 use BlueFission\BlueCore\Registration\RegistrationPlan;
 use BlueFission\DevElation;
@@ -145,6 +168,14 @@ DevElation::filter(
     function (Arr $summary): Arr {
         return $summary;
     }
+);
+
+DevElation::listen(HelperLifecycleHooks::EVENT_RESPONSE_PREPARED);
+DevElation::subscribe(
+    function (Arr $summary): void {
+        // React to a prepared response without inspecting its body.
+    },
+    HelperLifecycleHooks::EVENT_RESPONSE_PREPARED
 );
 ```
 

--- a/docs/releases/v0.1.4-alpha.md
+++ b/docs/releases/v0.1.4-alpha.md
@@ -17,6 +17,8 @@ This alpha release establishes the first framework-wide DevElation hook and filt
 - Passive contribution summaries can be transformed as DevElation `Arr` values after containment and passive-data validation.
 - Datasource migration and population plans expose constrained `Arr` filters plus typed lifecycle actions.
 - Installation preparation, execution, stage, checkpoint, resume, and failure boundaries expose sanitized observational actions.
+- Response preparation, template rendering, and production error reporting expose typed and sanitized helper lifecycle hooks.
+- Prepared responses publish a DevElation listener/subscriber event before the upstream response delivery contract exits.
 - Hook re-entry is bounded, and an in-flight add-on registration factory cannot execute twice.
 
 ## Upgrade Guidance

--- a/examples/lifecycle-hooks.php
+++ b/examples/lifecycle-hooks.php
@@ -1,0 +1,39 @@
+<?php
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
+use BlueFission\DevElation;
+
+require dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+DevElation::up();
+
+DevElation::filter(
+    HelperLifecycleHooks::FILTER_RESPONSE,
+    function (Arr $context): Arr {
+        $data = Arr::make($context['data']);
+        $data->set('meta', ['framework' => 'bluecore']);
+        $context->set('data', $data->val());
+
+        return $context;
+    }
+);
+
+DevElation::action(
+    HelperLifecycleHooks::HOOK_RESPONSE_BEFORE,
+    function (Arr $summary): void {
+        store('last_response_status', $summary['status']);
+    }
+);
+
+DevElation::listen(HelperLifecycleHooks::EVENT_RESPONSE_PREPARED);
+DevElation::subscribe(
+    function (Arr $summary): void {
+        store('response_prepared', $summary->val());
+    },
+    HelperLifecycleHooks::EVENT_RESPONSE_PREPARED
+);
+
+response([
+    'status' => 'ready',
+]);

--- a/src/BlueCore/Hooks/HelperLifecycleHooks.php
+++ b/src/BlueCore/Hooks/HelperLifecycleHooks.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BlueFission\BlueCore\Hooks;
+
+use BlueFission\Arr;
+use BlueFission\DevElation as Dev;
+use Throwable;
+
+final class HelperLifecycleHooks
+{
+    public const FILTER_RESPONSE = 'bluecore.response.prepare';
+    public const HOOK_RESPONSE_BEFORE = 'bluecore.response.before';
+    public const HOOK_RESPONSE_AFTER = 'bluecore.response.after';
+    public const HOOK_RESPONSE_FAILED = 'bluecore.response.failed';
+    public const EVENT_RESPONSE_PREPARED = 'bluecore.response.prepared';
+
+    public const FILTER_TEMPLATE_DATA = 'bluecore.template.data';
+    public const FILTER_TEMPLATE_OUTPUT = 'bluecore.template.output';
+    public const HOOK_TEMPLATE_BEFORE = 'bluecore.template.before';
+    public const HOOK_TEMPLATE_AFTER = 'bluecore.template.after';
+    public const HOOK_TEMPLATE_FAILED = 'bluecore.template.failed';
+
+    public const HOOK_ERROR_REPORTED = 'bluecore.error.reported';
+    public const HOOK_EXCEPTION_REPORTED = 'bluecore.exception.reported';
+    public const HOOK_FATAL_REPORTED = 'bluecore.fatal.reported';
+
+    private static array $activeHooks = [];
+
+    public static function apply(string $hook, mixed $value): mixed
+    {
+        if (!self::enter($hook)) {
+            return $value;
+        }
+
+        try {
+            return Dev::apply($hook, $value);
+        } finally {
+            self::leave($hook);
+        }
+    }
+
+    public static function action(string $hook, array $arguments = []): void
+    {
+        if (!self::enter($hook)) {
+            return;
+        }
+
+        try {
+            Dev::do($hook, $arguments);
+        } finally {
+            self::leave($hook);
+        }
+    }
+
+    public static function event(string $event, array $arguments = []): void
+    {
+        if (!self::enter($event)) {
+            return;
+        }
+
+        try {
+            Dev::trigger($event, $arguments);
+        } finally {
+            self::leave($event);
+        }
+    }
+
+    public static function failure(string $hook, LifecycleFailure $failure): void
+    {
+        try {
+            self::action($hook, [$failure]);
+        } catch (Throwable) {
+            error_log("BlueCore failure hook '{$hook}' raised an exception.");
+        }
+    }
+
+    private static function enter(string $hook): bool
+    {
+        if (Arr::hasKey(self::$activeHooks, $hook)) {
+            return false;
+        }
+
+        self::$activeHooks[$hook] = true;
+
+        return true;
+    }
+
+    private static function leave(string $hook): void
+    {
+        unset(self::$activeHooks[$hook]);
+    }
+}

--- a/src/Helpers/errors.php
+++ b/src/Helpers/errors.php
@@ -1,6 +1,7 @@
 <?php
 
 use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
 use BlueFission\Flag;
 use BlueFission\Net\HTTP;
 use BlueFission\Num;
@@ -36,6 +37,15 @@ if (!function_exists('customErrorHandler')) {
         }
 
         error_log("Error: [{$errno}] {$errstr} in {$errfile} on line {$errline}");
+        blueCoreReportLifecycleError(
+            HelperLifecycleHooks::HOOK_ERROR_REPORTED,
+            Arr::make([
+                'kind' => 'error',
+                'code' => Num::int($errno),
+                'debug' => blueCoreDebugMode(),
+                'sapi' => PHP_SAPI,
+            ])
+        );
 
         if (!blueCoreDebugMode()) {
             return true;
@@ -70,6 +80,16 @@ if (!function_exists('customExceptionHandler')) {
             'Exception: ' . $exception->getMessage()
             . ' in ' . $exception->getFile()
             . ' on line ' . $exception->getLine()
+        );
+        blueCoreReportLifecycleError(
+            HelperLifecycleHooks::HOOK_EXCEPTION_REPORTED,
+            Arr::make([
+                'kind' => 'exception',
+                'code' => Num::int($exception->getCode()),
+                'exception_type' => $exception::class,
+                'debug' => blueCoreDebugMode(),
+                'sapi' => PHP_SAPI,
+            ])
         );
         blueCoreSetErrorStatus();
 
@@ -113,6 +133,15 @@ if (!function_exists('shutdownHandler')) {
             . ' in ' . $error['file']
             . ' on line ' . $error['line']
         );
+        blueCoreReportLifecycleError(
+            HelperLifecycleHooks::HOOK_FATAL_REPORTED,
+            Arr::make([
+                'kind' => 'fatal',
+                'code' => Num::int($error['type']),
+                'debug' => blueCoreDebugMode(),
+                'sapi' => PHP_SAPI,
+            ])
+        );
         blueCoreSetErrorStatus();
 
         if (!blueCoreDebugMode()) {
@@ -138,6 +167,17 @@ if (!function_exists('shutdownHandler')) {
     }
 
     register_shutdown_function('shutdownHandler');
+}
+
+if (!function_exists('blueCoreReportLifecycleError')) {
+    function blueCoreReportLifecycleError(string $hook, Arr $summary): void
+    {
+        try {
+            HelperLifecycleHooks::action($hook, [$summary]);
+        } catch (Throwable) {
+            error_log("BlueCore lifecycle hook '{$hook}' failed during error reporting.");
+        }
+    }
 }
 
 if (!function_exists('sourceCodeWindow')) {

--- a/src/Helpers/response.php
+++ b/src/Helpers/response.php
@@ -6,7 +6,11 @@ use BlueFission\HTML\Template;
 use BlueFission\Services\Response;
 use BlueFission\Net\HTTP;
 use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
+use BlueFission\Flag;
 use BlueFission\Func;
+use BlueFission\Num;
 use BlueFission\Str;
 use BlueFission\Val;
 use BlueFission\Utils\File;
@@ -24,19 +28,81 @@ if (!function_exists( 'template' )) {
 	function template(string $themeName, string $file, array $data = []) {
 		static $delegating = false;
 
-		if (Val::isFalsy($delegating)) {
-			$renderer = template_renderer_service();
-			if (Val::isNotNull($renderer) && Func::isCallable([$renderer, 'render'])) {
-				$delegating = true;
-				try {
-					return $renderer->render($themeName, $file, $data);
-				} finally {
-					$delegating = false;
+		try {
+			$filteredData = HelperLifecycleHooks::apply(
+				HelperLifecycleHooks::FILTER_TEMPLATE_DATA,
+				Arr::make($data)
+			);
+			if (!$filteredData instanceof Arr) {
+				throw new UnexpectedValueException('Template data filters must return Arr.');
+			}
+
+			$data = $filteredData->val();
+			HelperLifecycleHooks::action(
+				HelperLifecycleHooks::HOOK_TEMPLATE_BEFORE,
+				[template_lifecycle_summary($themeName, $file, $data)]
+			);
+
+			$output = null;
+			$rendered = Flag::make(false);
+			if (Val::isFalsy($delegating)) {
+				$renderer = template_renderer_service();
+				if (Val::isNotNull($renderer) && Func::isCallable([$renderer, 'render'])) {
+					$delegating = true;
+					try {
+						$output = $renderer->render($themeName, $file, $data);
+						$rendered->val(true);
+					} finally {
+						$delegating = false;
+					}
 				}
 			}
-		}
 
-		return template_legacy_render($themeName, $file, $data);
+			if ($rendered->isFalse()) {
+				$output = template_legacy_render($themeName, $file, $data);
+			}
+			if (!Str::is($output)) {
+				throw new UnexpectedValueException('Template renderers must return a string.');
+			}
+
+			$filteredOutput = HelperLifecycleHooks::apply(
+				HelperLifecycleHooks::FILTER_TEMPLATE_OUTPUT,
+				Str::make($output)
+			);
+			if (!$filteredOutput instanceof Str) {
+				throw new UnexpectedValueException('Template output filters must return Str.');
+			}
+
+			$output = $filteredOutput->val();
+			$summary = template_lifecycle_summary($themeName, $file, $data);
+			$summary->set('output_length', Str::len($output));
+			HelperLifecycleHooks::action(HelperLifecycleHooks::HOOK_TEMPLATE_AFTER, [$summary]);
+
+			return $output;
+		} catch (Throwable $exception) {
+			HelperLifecycleHooks::failure(
+				HelperLifecycleHooks::HOOK_TEMPLATE_FAILED,
+				new LifecycleFailure(
+					HelperLifecycleHooks::HOOK_TEMPLATE_FAILED,
+					'render',
+					'template',
+					$exception
+				)
+			);
+
+			throw $exception;
+		}
+	}
+}
+
+if (!function_exists('template_lifecycle_summary')) {
+	function template_lifecycle_summary(string $themeName, string $file, array $data): Arr
+	{
+		return Arr::make([
+			'theme' => $themeName,
+			'file' => $file,
+			'data_count' => Arr::size($data),
+		]);
 	}
 }
 
@@ -222,16 +288,73 @@ if (!function_exists( 'get_template_url' )) {
  * @return string The JSON representation of the response data
  */
 function response($data, $status = 200) {
-	$response = new Response();
+	try {
+		$context = HelperLifecycleHooks::apply(
+			HelperLifecycleHooks::FILTER_RESPONSE,
+			Arr::make([
+				'data' => $data,
+				'status' => Num::int($status),
+			])
+		);
+		if (!$context instanceof Arr) {
+			throw new UnexpectedValueException('Response filters must return Arr.');
+		}
+		if (!$context->hasKey('data') || !$context->hasKey('status')) {
+			throw new UnexpectedValueException('Response filters must preserve data and status fields.');
+		}
 
-	$response->fill($data);
-	$statusLine = HTTP::statusLine((int)$status);
-	if (Val::isNotEmpty($statusLine)) {
-		header($statusLine, true, (int)$status);
+		$status = $context['status'] ?? null;
+		if (!Num::isInt($status) || $status < 100 || $status > 599) {
+			throw new UnexpectedValueException('Response status must be an integer between 100 and 599.');
+		}
+
+		$data = $context['data'];
+		HelperLifecycleHooks::action(
+			HelperLifecycleHooks::HOOK_RESPONSE_BEFORE,
+			[response_lifecycle_summary($status)]
+		);
+
+		$response = new Response();
+		$response->fill($data);
+		$statusLine = HTTP::statusLine($status);
+		if (Val::isNotEmpty($statusLine)) {
+			header($statusLine, true, $status);
+		}
+
+		header(HTTP::headerLine('Content-Type', 'application/json'));
+		HelperLifecycleHooks::action(
+			HelperLifecycleHooks::HOOK_RESPONSE_AFTER,
+			[response_lifecycle_summary($status)]
+		);
+		HelperLifecycleHooks::event(
+			HelperLifecycleHooks::EVENT_RESPONSE_PREPARED,
+			[response_lifecycle_summary($status)]
+		);
+
+		return $response->send();
+	} catch (Throwable $exception) {
+		HelperLifecycleHooks::failure(
+			HelperLifecycleHooks::HOOK_RESPONSE_FAILED,
+			new LifecycleFailure(
+				HelperLifecycleHooks::HOOK_RESPONSE_FAILED,
+				'prepare',
+				'response',
+				$exception
+			)
+		);
+
+		throw $exception;
 	}
+}
 
-	header(HTTP::headerLine('Content-Type', 'application/json'));
-	return $response->send();
+if (!function_exists('response_lifecycle_summary')) {
+	function response_lifecycle_summary(int $status): Arr
+	{
+		return Arr::make([
+			'status' => $status,
+			'content_type' => 'application/json',
+		]);
+	}
 }
 
 /**

--- a/tests/Fixtures/response-lifecycle-hooks.php
+++ b/tests/Fixtures/response-lifecycle-hooks.php
@@ -1,0 +1,59 @@
+<?php
+
+use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
+use BlueFission\DevElation as Dev;
+
+require dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+$mode = $argv[1] ?? 'success';
+
+if ($mode === 'inactive') {
+    Dev::filter(HelperLifecycleHooks::FILTER_RESPONSE, function (Arr $context): Arr {
+        echo 'filter|';
+
+        return $context;
+    });
+    response(['status' => 'inactive']);
+}
+
+Dev::up();
+
+if ($mode === 'invalid') {
+    Dev::filter(HelperLifecycleHooks::FILTER_RESPONSE, fn(Arr $context): array => $context->val());
+    Dev::action(
+        HelperLifecycleHooks::HOOK_RESPONSE_FAILED,
+        function (LifecycleFailure $failure): void {
+            echo 'failed:' . $failure->exceptionType() . '|';
+        }
+    );
+
+    try {
+        response(['status' => 'invalid']);
+    } catch (UnexpectedValueException) {
+        echo 'caught';
+    }
+
+    exit(0);
+}
+
+Dev::listen(HelperLifecycleHooks::EVENT_RESPONSE_PREPARED);
+Dev::subscribe(function (Arr $summary): void {
+    echo 'prepared:' . $summary['status'] . '|';
+}, HelperLifecycleHooks::EVENT_RESPONSE_PREPARED);
+Dev::filter(HelperLifecycleHooks::FILTER_RESPONSE, function (Arr $context): Arr {
+    echo 'filter|';
+    $context->set('data', ['status' => 'filtered']);
+    $context->set('status', 202);
+
+    return $context;
+});
+Dev::action(HelperLifecycleHooks::HOOK_RESPONSE_BEFORE, function (Arr $context): void {
+    echo 'before:' . $context['status'] . '|';
+});
+Dev::action(HelperLifecycleHooks::HOOK_RESPONSE_AFTER, function (Arr $summary): void {
+    echo 'after:' . $summary['status'] . '|';
+});
+
+response(['status' => 'original']);

--- a/tests/Helpers/ProductionErrorHandlerTest.php
+++ b/tests/Helpers/ProductionErrorHandlerTest.php
@@ -2,6 +2,9 @@
 
 namespace BlueFission\Tests\Helpers;
 
+use BlueFission\Arr;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
+use BlueFission\DevElation as Dev;
 use BlueFission\Str;
 use BlueFission\System\Process;
 use BlueFission\Utils\File;
@@ -10,6 +13,18 @@ use PHPUnit\Framework\TestCase;
 
 class ProductionErrorHandlerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resetDevElation();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDevElation();
+        parent::tearDown();
+    }
+
     public function testProductionWarningIsLoggedWithoutResponseOutput(): void
     {
         $debugMode = getenv('DEBUG_MODE');
@@ -61,5 +76,45 @@ class ProductionErrorHandlerTest extends TestCase
         $this->assertStringContainsString('private exception', File::readContents($errorLog));
 
         unlink($errorLog);
+    }
+
+    public function testProductionWarningDispatchesSanitizedErrorSummary(): void
+    {
+        $debugMode = getenv('DEBUG_MODE');
+        $errorLog = ini_get('error_log');
+        $testLog = Path::normalize(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bluecore-hook-warning-' . Str::rand('', 10) . '.log');
+        $summary = null;
+        putenv('DEBUG_MODE=false');
+        ini_set('error_log', $testLog);
+        Dev::up();
+        Dev::action(HelperLifecycleHooks::HOOK_ERROR_REPORTED, function (Arr $context) use (&$summary): void {
+            $summary = $context;
+        });
+
+        try {
+            customErrorHandler(E_WARNING, 'private warning', __FILE__, __LINE__);
+
+            $this->assertInstanceOf(Arr::class, $summary);
+            $this->assertSame('error', $summary['kind']);
+            $this->assertSame(E_WARNING, $summary['code']);
+            $this->assertFalse($summary->hasKey('message'));
+            $this->assertFalse($summary->hasKey('file'));
+        } finally {
+            ini_set('error_log', (string)$errorLog);
+            $debugMode === false ? putenv('DEBUG_MODE') : putenv("DEBUG_MODE={$debugMode}");
+            if ((new File())->exists($testLog)) {
+                unlink($testLog);
+            }
+        }
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = new \ReflectionProperty(Dev::class, $propertyName);
+            $property->setValue(null, []);
+        }
     }
 }

--- a/tests/Helpers/ResponseLifecycleHookTest.php
+++ b/tests/Helpers/ResponseLifecycleHookTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BlueFission\Tests\Helpers;
+
+use BlueFission\Str;
+use BlueFission\System\Process;
+use BlueFission\Utils\Path;
+use PHPUnit\Framework\TestCase;
+
+class ResponseLifecycleHookTest extends TestCase
+{
+    public function testResponseFilterActionsAndPreparedEventUseTypedSanitizedContexts(): void
+    {
+        [$output, $exitCode] = $this->runFixture('success');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringStartsWith('filter|before:202|after:202|prepared:202|', $output);
+        $this->assertStringContainsString('"status":"filtered"', $output);
+    }
+
+    public function testResponseFilterRejectsInvalidTypesAndDispatchesSanitizedFailure(): void
+    {
+        [$output, $exitCode] = $this->runFixture('invalid');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('failed:UnexpectedValueException|caught', $output);
+    }
+
+    public function testResponseHooksRemainInactiveUntilDevElationIsEnabled(): void
+    {
+        [$output, $exitCode] = $this->runFixture('inactive');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringStartsNotWith('filter|', $output);
+        $this->assertStringContainsString('"status":"inactive"', $output);
+    }
+
+    private function runFixture(string $mode): array
+    {
+        $root = Path::normalize(dirname(__DIR__, 2));
+        $fixture = Path::normalize(
+            $root
+            . DIRECTORY_SEPARATOR
+            . 'tests'
+            . DIRECTORY_SEPARATOR
+            . 'Fixtures'
+            . DIRECTORY_SEPARATOR
+            . 'response-lifecycle-hooks.php'
+        );
+        $command = Str::make(escapeshellarg(PHP_BINARY))
+            ->append(' ')
+            ->append(escapeshellarg($fixture))
+            ->append(' ')
+            ->append(escapeshellarg($mode))
+            ->val();
+        $process = new Process($command, $root);
+
+        $process->start();
+        while ($process->status() === true) {
+            usleep(10000);
+        }
+
+        return [$process->output(), $process->close()];
+    }
+}

--- a/tests/Helpers/TemplateRenderingHelperTest.php
+++ b/tests/Helpers/TemplateRenderingHelperTest.php
@@ -2,12 +2,18 @@
 
 namespace BlueFission\Tests\Helpers;
 
+use BlueFission\Arr;
 use BlueFission\BlueCore\Engine;
+use BlueFission\BlueCore\Hooks\HelperLifecycleHooks;
+use BlueFission\BlueCore\Hooks\LifecycleFailure;
 use BlueFission\BlueCore\Theme;
+use BlueFission\DevElation as Dev;
 use BlueFission\Services\Application;
+use BlueFission\Str;
 use BlueFission\Utils\File;
 use BlueFission\Utils\Path;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 class TemplateRenderingHelperTest extends TestCase
 {
@@ -35,12 +41,71 @@ class TemplateRenderingHelperTest extends TestCase
     protected function setUp(): void
     {
         $this->resetApplications();
+        $this->resetDevElation();
         Path::ensureDir($this->themePath());
     }
 
     protected function tearDown(): void
     {
+        $this->resetDevElation();
         $this->resetApplications();
+    }
+
+    public function testTemplateFiltersDataAndOutputAroundRenderingActions(): void
+    {
+        $events = [];
+        $this->writeTemplate('hooked.tpl', 'Hello, {$name}');
+        $this->engineWithTheme();
+        Dev::up();
+        Dev::filter(HelperLifecycleHooks::FILTER_TEMPLATE_DATA, function (Arr $data) use (&$events): Arr {
+            $events[] = 'data';
+            $data->set('name', 'Grace');
+
+            return $data;
+        });
+        Dev::action(HelperLifecycleHooks::HOOK_TEMPLATE_BEFORE, function (Arr $summary) use (&$events): void {
+            $events[] = 'before';
+            $this->assertSame(1, $summary['data_count']);
+            $this->assertFalse($summary->hasKey('data'));
+        });
+        Dev::filter(HelperLifecycleHooks::FILTER_TEMPLATE_OUTPUT, function (Str $output) use (&$events): Str {
+            $events[] = 'output';
+
+            return $output->append('!');
+        });
+        Dev::action(HelperLifecycleHooks::HOOK_TEMPLATE_AFTER, function (Arr $summary) use (&$events): void {
+            $events[] = 'after';
+            $this->assertSame(13, $summary['output_length']);
+        });
+
+        $this->assertSame('Hello, Grace!', template('test', 'hooked.tpl', ['name' => 'Ada']));
+        $this->assertSame(['data', 'before', 'output', 'after'], $events);
+    }
+
+    public function testTemplateOutputFilterRejectsInvalidTypesAndDispatchesFailure(): void
+    {
+        $failure = null;
+        $this->writeTemplate('invalid-hook.tpl', 'Invalid');
+        $this->engineWithTheme();
+        Dev::up();
+        Dev::filter(HelperLifecycleHooks::FILTER_TEMPLATE_OUTPUT, fn(Str $output): string => $output->val());
+        Dev::action(
+            HelperLifecycleHooks::HOOK_TEMPLATE_FAILED,
+            function (LifecycleFailure $context) use (&$failure): void {
+                $failure = $context;
+            }
+        );
+
+        try {
+            template('test', 'invalid-hook.tpl');
+            $this->fail('The invalid template output filter did not fail.');
+        } catch (UnexpectedValueException $exception) {
+            $this->assertSame('Template output filters must return Str.', $exception->getMessage());
+        }
+
+        $this->assertInstanceOf(LifecycleFailure::class, $failure);
+        $this->assertSame(HelperLifecycleHooks::HOOK_TEMPLATE_FAILED, $failure->hook());
+        $this->assertSame(UnexpectedValueException::class, $failure->exceptionType());
     }
 
     public function testTemplateDelegatesToRegisteredRenderingService(): void
@@ -143,5 +208,15 @@ class TemplateRenderingHelperTest extends TestCase
         $instances->setValue(null, []);
         $active = new \ReflectionProperty(Engine::class, '_activeInstances');
         $active->setValue(null, []);
+    }
+
+    private function resetDevElation(): void
+    {
+        Dev::down();
+
+        foreach (['_filters', '_actions', '_listeners', '_config'] as $propertyName) {
+            $property = new \ReflectionProperty(Dev::class, $propertyName);
+            $property->setValue(null, []);
+        }
     }
 }


### PR DESCRIPTION
## Intent

Complete the remaining helper lifecycle slice of #90 with framework-owned response preparation, template rendering, and production error-reporting extension points.

## User stories and acceptance criteria

- Integrations can transform response data and status through a typed DevElation `Arr` filter before delivery.
- Response actions and the prepared-response event receive fresh sanitized summaries without body data.
- Template integrations can transform data through `Arr` and rendered output through `Str` without changing framework-owned theme or file selection.
- Template and response filter failures remain fail-closed and preserve the original exception when failure observers fail.
- Production error, exception, and fatal actions omit message, file, line, trace, and mutable runtime state.
- Hook re-entry is suppressed and inactive DevElation state preserves existing behavior.
- A runnable example demonstrates a filter, an action, and a `listen`/`subscribe` event flow.

## Key files changed

- `src/BlueCore/Hooks/HelperLifecycleHooks.php`
- `src/Helpers/response.php`
- `src/Helpers/errors.php`
- `docs/develation-hooks.md`
- `examples/lifecycle-hooks.php`
- Focused helper and fixture tests under `tests/Helpers` and `tests/Fixtures`

## How to test

```bash
composer validate --no-check-publish --strict
composer lint
vendor/bin/phpunit --do-not-cache-result --no-progress
composer test:installer
php examples/lifecycle-hooks.php
composer audit --locked
```

Local results: Composer validation and lint pass; PHPUnit passes 163 tests and 664 assertions; project-installer source/dist parity passes; the lifecycle example produces the filtered JSON response. The live Composer advisory request remains unavailable because DNS resolution for Packagist times out, so release publication remains gated on a successful live audit.

## QA checklist

- [x] Public names follow `bluecore.<area>.<operation>.<phase>`.
- [x] Filters enforce DevElation `Arr` or `Str` return types.
- [x] Response actions and events exclude response data.
- [x] Template actions exclude template data and rendered output.
- [x] Error actions exclude sensitive error details.
- [x] Failure observers cannot replace the original response or template exception.
- [x] The upstream exiting `Response::send()` contract remains unchanged.
- [x] Documentation distinguishes response preparation from post-delivery execution.

## Approval conditions

- Review confirms response and template filters cannot bypass framework-owned path or delivery boundaries.
- Review confirms action/event summaries are sufficiently stable and sanitized.
- CI passes on supported PHP versions.
- Run a successful live dependency audit before publishing `v0.1.4-alpha`.

This completes the implementation scope currently defined by #90. Issue closure should follow human review and successful release-gate verification.
